### PR TITLE
fix(H3): Use cssClass varible for classname

### DIFF
--- a/src/Views/Shared/H3.cshtml
+++ b/src/Views/Shared/H3.cshtml
@@ -15,4 +15,4 @@
             break;
     }
 }
-<h3 class="govuk-heading-m">@Model.Properties.Text</h3>
+<h3 class="@cssClass">@Model.Properties.Text</h3>


### PR DESCRIPTION
Fixed h3 view not using cssclass variable 