### PR TITLE
fix: amend email Regex

### DIFF
--- a/src/Validators/EmailElementValidator.cs
+++ b/src/Validators/EmailElementValidator.cs
@@ -34,7 +34,7 @@ namespace form_builder.Validators
 
             var value = viewModel[element.Properties.QuestionId];
             var isValid = true;
-            var regex = new Regex(@"^([\w\.\-]+)@([\w\-]+)((\.(\w){2,3})+)$");
+            var regex = new Regex(@"^([\w\.\-]+)@([\w\-]+)((\.(\w)+)+)$");
             Match match = regex.Match(value);
 
             if (!match.Success)


### PR DESCRIPTION
### Description
Amend email Regex to allow emails with multiple .'s after the ~ with an many characters as needed.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary