### PR TITLE
fix(spellcheck): spellcheck on textbox

### DIFF
--- a/src/Models/Elements/Textbox.cs
+++ b/src/Models/Elements/Textbox.cs
@@ -39,7 +39,7 @@ namespace form_builder.Models.Elements
                 { "id", Properties.QuestionId },
                 { "maxlength", Properties.MaxLength },
                 { "value", Properties.Value},
-                { "spellcheck", Properties.Spellcheck.ToString() }
+                { "spellcheck", Properties.Spellcheck.ToString().ToLower() }
             };
             
             if (Properties.Numeric)


### PR DESCRIPTION
### Description
Fixed spellecheck on TextBox not working due to missing lowercase on bool value

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary