### PR TITLE
chore(GetReducedAnswers): added support for multiple pages with same pageslug

### DIFF
--- a/src/Extensions/FormAnswersExtensions.cs
+++ b/src/Extensions/FormAnswersExtensions.cs
@@ -22,17 +22,25 @@ namespace form_builder.Extensions
             string currentPageSlug,
             List<PageAnswers> reducedAnswers)
         {
+            var page = new Page();
             var currentAnswer = answers.Find(_ => _.PageSlug.Equals(currentPageSlug));
             if (currentAnswer == null)
                 return reducedAnswers;
 
-            var currentSchema = schema.Find(_ => _.PageSlug.Equals(currentPageSlug));
+            var currentSchema = schema.FindAll(_ => _.PageSlug.Equals(currentPageSlug));
             if (currentSchema == null)
                 return reducedAnswers;
 
+            page = currentSchema.Count > 1 
+                ? currentSchema.FirstOrDefault(page => page.CheckPageMeetsConditions(answersDictionary))
+                : currentSchema.FirstOrDefault();
+
+            if(page == null)
+               return reducedAnswers;
+
             reducedAnswers.Add(currentAnswer);
 
-            var behaviour = currentSchema.GetNextPage(answersDictionary);
+            var behaviour = page.GetNextPage(answersDictionary);
             if (behaviour.BehaviourType != EBehaviourType.GoToPage)
                 return reducedAnswers;
 

--- a/tests/UnitTests/Extensions/FormAnswersExtensionsTests.cs
+++ b/tests/UnitTests/Extensions/FormAnswersExtensionsTests.cs
@@ -4,6 +4,7 @@ using form_builder.Models;
 using System.Collections.Generic;
 using form_builder_tests.Builders;
 using Xunit;
+using form_builder.Builders;
 
 namespace form_builder_tests.UnitTests.Extensions
 {
@@ -280,6 +281,254 @@ namespace form_builder_tests.UnitTests.Extensions
 
             // Assert
             Assert.Equal(2, result.Count);
+        }
+
+        [Theory]
+        [InlineData("question2", "yes", "yes-routing-answer")]
+        [InlineData("question3", "no", "no-routing-answer")]
+        public void GetReducedAnswers_ShouldReturnCorrectAnswers_WhenScheamContains_TwoOfSamePageSlug_WithRenderConditions(string questionId, string answer, string value)
+        {
+            // Arrange
+            var formAnswers = new FormAnswers
+            {
+                FormName = "test",
+                Pages = new List<PageAnswers>
+                {
+                    new PageAnswers
+                    {
+                        PageSlug = "page-1",
+                        Answers = new List<Answers>
+                        {
+                            new Answers
+                            {
+                                QuestionId = "test",
+                                Response = answer
+                            }
+                        }
+                    },
+                    new PageAnswers
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new Answers
+                            {
+                                QuestionId = questionId,
+                                Response = value
+                            }
+                        },
+                        PageSlug = "page-2"
+                    },
+                    new PageAnswers
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new Answers
+                            {
+                                QuestionId = "routingquestion",
+                                Response = "data"
+                            }
+                        },
+                        PageSlug = "page-4"
+                    }
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("test")
+                .Build();
+
+            var element2 = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("question2")
+                .Build();
+
+            var element3 = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("question3")
+                .Build();
+
+            var behaviour = new BehaviourBuilder()
+                .WithPageSlug("page-2")
+                .WithBehaviourType(EBehaviourType.GoToPage)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithPageSlug("page-1")
+                .WithElement(element)
+                .WithBehaviour(behaviour)
+                .Build();
+
+            var behaviour2 = new BehaviourBuilder()
+                .WithBehaviourType(EBehaviourType.SubmitForm)
+                .Build();
+
+            var page2 = new PageBuilder()
+                .WithPageSlug("page-2")
+                .WithBehaviour(behaviour2)
+                .WithElement(element2)
+                .WithRenderConditions(new Condition
+                {
+                    QuestionId = "test",
+                    ConditionType = ECondition.EqualTo,
+                    ComparisonValue = "yes"
+                })
+                .Build();
+
+            var page3 = new PageBuilder()
+                .WithPageSlug("page-2")
+                .WithBehaviour(behaviour2)
+                .WithElement(element3)
+                .WithRenderConditions(new Condition
+                {
+                    QuestionId = "test",
+                    ConditionType = ECondition.EqualTo,
+                    ComparisonValue = "no"
+                })
+                .Build();
+
+            var formSchema = new FormSchemaBuilder()
+                .WithPage(page)
+                .WithPage(page2)
+                .WithPage(page3)
+                .WithFirstPageSlug("page-1")
+                .Build();
+
+            // Act
+            var result = formAnswers.GetReducedAnswers(formSchema);
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Equal(questionId, result[1].Answers[0].QuestionId);
+            Assert.Equal(value, result[1].Answers[0].Response);
+        }
+
+        [Fact]
+        public void GetReducedAnswers_ShouldReturnCorrectAnswers_WhenScheamContains_TwoOfSamePageSlug_WithRenderConditions_AndOptionalPage()
+        {
+            // Arrange
+            var formAnswers = new FormAnswers
+            {
+                FormName = "test",
+                Pages = new List<PageAnswers>
+                {
+                    new PageAnswers
+                    {
+                        PageSlug = "page-1",
+                        Answers = new List<Answers>
+                        {
+                            new Answers
+                            {
+                                QuestionId = "test",
+                                Response = "no"
+                            }
+                        }
+                    },
+                    new PageAnswers
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new Answers
+                            {
+                                QuestionId = "question2",
+                                Response = "answer"
+                            }
+                        },
+                        PageSlug = "page-2"
+                    },
+                    new PageAnswers
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new Answers
+                            {
+                                QuestionId = "routingquestion",
+                                Response = "data"
+                            }
+                        },
+                        PageSlug = "page-4"
+                    }
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("test")
+                .Build();
+
+            var element2 = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("question2")
+                .Build();
+
+            var element3 = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("routingquestion")
+                .Build();
+
+            var behaviour = new BehaviourBuilder()
+                .WithPageSlug("page-2")
+                .WithBehaviourType(EBehaviourType.GoToPage)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithPageSlug("page-1")
+                .WithElement(element)
+                .WithBehaviour(behaviour)
+                .Build();
+
+            var behaviour2 = new BehaviourBuilder()
+                .WithBehaviourType(EBehaviourType.SubmitForm)
+                .Build();
+
+            var page2 = new PageBuilder()
+                .WithPageSlug("page-2")
+                .WithBehaviour(behaviour2)
+                .WithRenderConditions(new Condition
+                {
+                    QuestionId = "test",
+                    ConditionType = ECondition.EqualTo,
+                    ComparisonValue = "yes"
+                })
+                .Build();
+
+            var behaviour3 = new BehaviourBuilder()
+                .WithPageSlug("page-4")
+                .WithBehaviourType(EBehaviourType.GoToPage)
+                .Build();
+
+            var page3 = new PageBuilder()
+                .WithPageSlug("page-2")
+                .WithBehaviour(behaviour3)
+                .WithRenderConditions(new Condition
+                {
+                    QuestionId = "test",
+                    ConditionType = ECondition.EqualTo,
+                    ComparisonValue = "no"
+                })
+                .Build();
+
+            var page4 = new PageBuilder()
+                .WithPageSlug("page-4")
+                .WithBehaviour(behaviour2)
+                .WithElement(element3)
+                .Build();
+
+            var formSchema = new FormSchemaBuilder()
+                .WithPage(page)
+                .WithPage(page2)
+                .WithPage(page3)
+                .WithPage(page4)
+                .WithFirstPageSlug("page-1")
+                .Build();
+
+            // Act
+            var result = formAnswers.GetReducedAnswers(formSchema);
+
+            // Assert
+            Assert.Equal(3, result.Count);
+            Assert.Equal("routingquestion", result[2].Answers[0].QuestionId);
+            Assert.Equal("data", result[2].Answers[0].Response);
         }
     }
 }


### PR DESCRIPTION


### Description
Updated GetReducedAnswers method to FindAll on pages to fix issue with not correctly creating answers when formSchema contains multiple pages with the same pageslug.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary