### PR TITLE
chore: Added maxlength override for reusable elements

### DIFF
--- a/src/Factories/Transform/ReusableElements/ReusableElementSchemaTransformFactory.cs
+++ b/src/Factories/Transform/ReusableElements/ReusableElementSchemaTransformFactory.cs
@@ -77,6 +77,9 @@ namespace form_builder.Factories.Transform.ReusableElements
             if (reusableElement.Properties.Optional)
                 substituteElement.Properties.Optional = true;
 
+            if (reusableElement.Properties.MaxLength != 200)
+                substituteElement.Properties.MaxLength = reusableElement.Properties.MaxLength;
+
             return substituteElement;
         }
 

--- a/tests/UnitTests/Factories/Transform/ReusableElementSchemaTransformFactoryTests.cs
+++ b/tests/UnitTests/Factories/Transform/ReusableElementSchemaTransformFactoryTests.cs
@@ -209,5 +209,49 @@ namespace form_builder_tests.UnitTests.Factories.Transform
             Assert.Equal("target.mapping", result.Pages.FirstOrDefault().Elements.FirstOrDefault().Properties.TargetMapping);
             Assert.True(result.Pages.FirstOrDefault().Elements.FirstOrDefault().Properties.Optional);
         }
+
+        
+        [Fact]
+        public async Task Transform_ShouldCall_TransformDataProvider_And_ShouldUpdate_MaxLength_WhenSupplied()
+        {
+            // Arrange
+            _transformDataProvider
+                .Setup(_ => _.Get(It.IsAny<string>()))
+                .ReturnsAsync(new Textbox
+                {
+                    Properties = new BaseProperty
+                    {
+                        QuestionId = "ReusableTest"
+                    }
+                });
+
+            ReusableElementSchemaTransformFactory = new ReusableElementSchemaTransformFactory(_transformDataProvider.Object);
+
+            var element = (Reusable)new ElementBuilder()
+                .WithType(EElementType.Reusable)
+                .WithQuestionId("ReusableTest")
+                .Build();
+
+            element.ElementRef = "test";
+            element.Properties.MaxLength = 30;
+
+            // Act
+            var result = await ReusableElementSchemaTransformFactory.Transform(new FormSchema()
+            {
+                Pages = new List<Page>{
+                    new Page()
+                    {
+                        Elements = new List<IElement>
+                        {
+                            element
+                        }
+                    }
+                }
+            });
+
+            // Assert
+            Assert.IsType<FormSchema>(result);
+            Assert.Equal(30, result.Pages.FirstOrDefault().Elements.FirstOrDefault().Properties.MaxLength);
+        }
     }
 }


### PR DESCRIPTION
### Description
Added ability to allow you to override default maxlength for reusable elements


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary