### PR TITLE
fix: email validation message

### DIFF
--- a/src/Constants/ValidationConstants.cs
+++ b/src/Constants/ValidationConstants.cs
@@ -3,9 +3,8 @@
     public class ValidationConstants
     {
         public const string DatePickerDefault = "Check the date and try again";
-
         public const string POSTCODE_INCORRECT_FORMAT = "Enter a postcode in the correct format";
-
         public const string POSTCODE_EMPTY = "Enter the postcode";
+        public const string EMAIL_INCORRECT_FORMAT = "Enter an email address in the correct format, like name@example.com";
     }
 }

--- a/src/Validators/EmailElementValidator.cs
+++ b/src/Validators/EmailElementValidator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using form_builder.Constants;
 using form_builder.Models.Elements;
 
 namespace form_builder.Validators
@@ -45,9 +46,7 @@ namespace form_builder.Validators
             return new ValidationResult
             {
                 IsValid = isValid,
-                Message = !string.IsNullOrEmpty(element.Properties.CustomValidationMessage)
-                    ? element.Properties.CustomValidationMessage
-                    : "Enter an email address in the correct format, like name@example.com"
+                Message = ValidationConstants.EMAIL_INCORRECT_FORMAT
             };
         }
     }


### PR DESCRIPTION
## Description
Changed Email validation message to not allow override and to be always the govuk error message.
"Enter an email address in the correct format, like name@example.com"

![image](https://user-images.githubusercontent.com/35955528/92936559-212f7a80-f442-11ea-986d-baa3d019b949.png)



### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary