### PR TITLE
feat: resuable elements multiple pages

### DIFF
--- a/tests/UnitTests/Factories/Transform/ReusableElementSchemaTransformFactoryTests.cs
+++ b/tests/UnitTests/Factories/Transform/ReusableElementSchemaTransformFactoryTests.cs
@@ -350,43 +350,19 @@ namespace form_builder_tests.UnitTests.Factories.Transform
             // Arrange
             _transformDataProvider
                 .Setup(_ => _.Get(It.Is<string>(_ => _ == "elementRef1")))
-                .ReturnsAsync(new Textbox
-                {
-                    Properties = new BaseProperty
-                    {
-                        QuestionId = "baseQuestionIdRef1",
-                    }
-                });
+                .ReturnsAsync(new ElementBuilder().WithType(EElementType.Textbox).WithQuestionId("baseQuestionIdRef1").Build());
 
             _transformDataProvider
                 .Setup(_ => _.Get(It.Is<string>(_ => _ == "elementRef2")))
-                .ReturnsAsync(new Textbox
-                {
-                    Properties = new BaseProperty
-                    {
-                        QuestionId = "baseQuestionIdRef2",
-                    }
-                });
+                .ReturnsAsync(new ElementBuilder().WithType(EElementType.Textbox).WithQuestionId("baseQuestionIdRef2").Build());
 
             _transformDataProvider
                 .Setup(_ => _.Get(It.Is<string>(_ => _ == "elementRef3")))
-                .ReturnsAsync(new Textbox
-                {
-                    Properties = new BaseProperty
-                    {
-                        QuestionId = "baseQuestionIdRef3"
-                    }
-                });
+                .ReturnsAsync(new ElementBuilder().WithType(EElementType.Textbox).WithQuestionId("baseQuestionIdRef3").Build());
 
             _transformDataProvider
                 .Setup(_ => _.Get(It.Is<string>(_ => _ == "elementRef4")))
-                .ReturnsAsync(new Textbox
-                {
-                    Properties = new BaseProperty
-                    {
-                        QuestionId = "baseQuestionIdRef4"
-                    }
-                });
+                .ReturnsAsync(new ElementBuilder().WithType(EElementType.Textbox).WithQuestionId("baseQuestionIdRef4").Build());
 
             var element = (Reusable)new ElementBuilder()
                 .WithType(EElementType.Reusable)


### PR DESCRIPTION
### Description
Updated reusable element factory to support pages with the same page-slug, the page index is now used rather then the page slug.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary