### PR TITLE
chore(MappingService): limit filename to 100 characters

### DIFF
--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace form_builder.Extensions
 {
@@ -44,6 +45,16 @@ namespace form_builder.Extensions
         {
             var megaByteValue = (value / 1024f) / 1024f;
             return Convert.ToInt32(megaByteValue);
+        }
+
+        public static string ToMaxSpecifiedStringLengthForFileName(this string value, int length)
+        {
+            if(value.Length <= length)
+                return value;
+
+            var extension = Path.GetExtension(value);
+
+            return $"{value.Substring(0, length - extension.Length)}{extension}";
         }
     }
 }

--- a/src/Mappers/ElementMapper.cs
+++ b/src/Mappers/ElementMapper.cs
@@ -8,6 +8,7 @@ using form_builder.Extensions;
 using form_builder.Models;
 using form_builder.Models.Elements;
 using form_builder.Providers.StorageProvider;
+using form_builder.Extensions;
 using Newtonsoft.Json;
 using StockportGovUK.NetStandard.Models.FileManagement;
 using Address = StockportGovUK.NetStandard.Models.Addresses.Address;
@@ -187,8 +188,8 @@ namespace form_builder.Mappers
 
                     var model = new File();
                     model.Content = fileData;
-                    model.TrustedOriginalFileName = file.TrustedOriginalFileName;
-                    model.UntrustedOriginalFileName = file.UntrustedOriginalFileName;
+                    model.TrustedOriginalFileName = file.TrustedOriginalFileName.ToMaxSpecifiedStringLengthForFileName(100);
+                    model.UntrustedOriginalFileName = file.UntrustedOriginalFileName.ToMaxSpecifiedStringLengthForFileName(100);
                     model.KeyName = key;
 
                     listOfFiles.Add(model);

--- a/tests/UnitTests/Extensions/StringExtensionsTests.cs
+++ b/tests/UnitTests/Extensions/StringExtensionsTests.cs
@@ -31,5 +31,30 @@ namespace form_builder_tests.UnitTests.Extensions
             // Act & Assert
             Assert.Throws<Exception>(() => testString.ToS3EnvPrefix());
         }
+
+        [Theory]
+        [InlineData("fileone.txt", "fileon.txt", 10)]
+        [InlineData("reallylongfilenameshouldbetrimmed.jpeg", "reall.jpeg", 10)]
+        [InlineData("reallylongfilenameshouldbetrimmed.docx", "reallylong.docx", 15)]
+        public void ToMaxSpecifiedStringLengthForFileName_ShouldLimitString_ToSuppliedLength(string value, string expected, int length)
+        {
+            // Act & Assert
+            var result = value.ToMaxSpecifiedStringLengthForFileName(length);
+            Assert.Equal(expected ,result);
+            Assert.Equal(length, result.Length);
+        }
+
+        [Theory]
+        [InlineData("fileon.txt")]
+        [InlineData("fileon.jpg")]
+        [InlineData("file.txt")]
+        [InlineData("f.doc")]
+        public void ToMaxSpecifiedStringLengthForFileName_ShouldReturn_OriginalString_IfLength_IsBelowLimit(string value)
+        {
+            // Act & Assert
+            var result = value.ToMaxSpecifiedStringLengthForFileName(10);
+            Assert.Equal(value, result);
+            Assert.True(result.Length <= 10);
+        }
     }
 }

--- a/tests/UnitTests/Mappers/ElementMapperTests.cs
+++ b/tests/UnitTests/Mappers/ElementMapperTests.cs
@@ -634,7 +634,7 @@ namespace form_builder_tests.UnitTests.Mappers
                             new Answers
                             {
                                 QuestionId = "fileUpload_fileUploadTestKey-fileupload",
-                                Response = JsonConvert.SerializeObject(new List<FileUploadModel>{ new FileUploadModel{ UntrustedOriginalFileName = key } })
+                                Response = JsonConvert.SerializeObject(new List<FileUploadModel>{ new FileUploadModel{ UntrustedOriginalFileName = key, TrustedOriginalFileName = key } })
                             }
                         }
                     }
@@ -677,8 +677,8 @@ namespace form_builder_tests.UnitTests.Mappers
                                 QuestionId = "fileUpload_fileUploadTestKey-fileupload",
                                 Response = JsonConvert.SerializeObject(new List<FileUploadModel>
                                 { 
-                                    new FileUploadModel{ TrustedOriginalFileName = "file1.txt", Key = "datakeyfile1" }, 
-                                    new FileUploadModel{ TrustedOriginalFileName = "file2.txt", Key = "datakeyfile2"  } 
+                                    new FileUploadModel{  UntrustedOriginalFileName ="file1.txt",  TrustedOriginalFileName = "file1.txt", Key = "datakeyfile1" }, 
+                                    new FileUploadModel{  UntrustedOriginalFileName ="file2.txt", TrustedOriginalFileName = "file2.txt", Key = "datakeyfile2"  } 
                                 })
                             }
                         }


### PR DESCRIPTION
### Description
Limit filename length in submit data to 100 characters.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary