### PR TITLE
fix(fileupload): changed file size check to use binary bytes value

### DIFF
--- a/src/Constants/SystemConstants.cs
+++ b/src/Constants/SystemConstants.cs
@@ -10,6 +10,8 @@ namespace form_builder.Constants
 
         public static readonly int DefaultMaxCombinedFileSize = 24117248;
 
+        public static readonly int OneMBInBinaryBytes = 1048576;
+
         public static readonly string CaseReferenceQueryString = "?caseReference=";
     }
 }

--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using form_builder.Constants;
 
 namespace form_builder.Extensions
 {
@@ -43,7 +44,7 @@ namespace form_builder.Extensions
 
         public static int ToReadableMaxFileSize(this int value)
         {
-            var megaByteValue = (value / 1024f) / 1024f;
+            var megaByteValue = value / SystemConstants.OneMBInBinaryBytes;
             return Convert.ToInt32(megaByteValue);
         }
 

--- a/src/Models/Elements/FileUpload.cs
+++ b/src/Models/Elements/FileUpload.cs
@@ -20,7 +20,7 @@ namespace form_builder.Models.Elements
         public override Dictionary<string, dynamic> GenerateElementProperties(string type = "")
         {
             var allowedFileType = Properties.AllowedFileTypes ?? SystemConstants.AcceptedMimeTypes;
-            var convertedMaxFileSize = Properties.MaxFileSize * 1024000;
+            var convertedMaxFileSize = Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes;
             var appliedMaxFileSize = convertedMaxFileSize > 0 && convertedMaxFileSize < SystemConstants.DefaultMaxFileSize 
                                 ? convertedMaxFileSize 
                                 : SystemConstants.DefaultMaxFileSize;

--- a/src/Models/Elements/MultipleFileUpload.cs
+++ b/src/Models/Elements/MultipleFileUpload.cs
@@ -20,11 +20,11 @@ namespace form_builder.Models.Elements
         }
 
         public string AllowFileTypeText { get { return Properties.AllowedFileTypes?.ToReadableFileType() ?? SystemConstants.AcceptedMimeTypes.ToReadableFileType();} }
-        public string MaxFileSizeText { get { return $"{(Properties.MaxFileSize * 1024000 == 0 ? SystemConstants.DefaultMaxFileSize.ToReadableMaxFileSize() : Properties.MaxFileSize)}MB"; } }
+        public string MaxFileSizeText { get { return $"{(Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes == 0 ? SystemConstants.DefaultMaxFileSize.ToReadableMaxFileSize() : Properties.MaxFileSize)}MB"; } }
         public string MaxCombinedFileSizeText { get { return $"{(Properties.MaxCombinedFileSize == 0 ? SystemConstants.DefaultMaxCombinedFileSize.ToReadableMaxFileSize() : Properties.MaxCombinedFileSize)}MB"; } }
         public override string QuestionId => $"{base.QuestionId}{FileUploadConstants.SUFFIX}";
         public List<string> CurrentFilesUploaded { get; set; } = new List<string>();
-        public int MaxFileSize => Properties.MaxFileSize * 1024000 > 0 && Properties.MaxFileSize * 1024000 < SystemConstants.DefaultMaxFileSize ? Properties.MaxFileSize * 1024000 : SystemConstants.DefaultMaxFileSize;
+        public int MaxFileSize => Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes > 0 && Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes < SystemConstants.DefaultMaxFileSize ? Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes : SystemConstants.DefaultMaxFileSize;
 
         public override Dictionary<string, dynamic> GenerateElementProperties(string type = "")
         {

--- a/src/Validators/MultipleFileUploadElementValidator.cs
+++ b/src/Validators/MultipleFileUploadElementValidator.cs
@@ -55,7 +55,6 @@ namespace form_builder.Validators
                 {
                     response = JsonConvert.DeserializeObject<List<FileUploadModel>>(pageAnswersString.Response.ToString());
 
-                    // Sets a different message if on the subpage and no files selected
                     if (response.Any())
                         isValid = true;
                 }

--- a/src/Validators/RestrictCombinedFileSizeValidator.cs
+++ b/src/Validators/RestrictCombinedFileSizeValidator.cs
@@ -37,7 +37,7 @@ namespace form_builder.Validators
             if (documentModel == null)
                 return new ValidationResult { IsValid = true };
 
-            var maxCombinedFileSize = element.Properties.MaxCombinedFileSize > 0 ? element.Properties.MaxCombinedFileSize * 1048576 : SystemConstants.DefaultMaxCombinedFileSize;
+            var maxCombinedFileSize = element.Properties.MaxCombinedFileSize > 0 ? element.Properties.MaxCombinedFileSize * SystemConstants.OneMBInBinaryBytes : SystemConstants.DefaultMaxCombinedFileSize;
 
             var sessionGuid = _sessionHelper.GetSessionGuid();
             var cachedAnswers = _distributedCache.GetString(sessionGuid);

--- a/src/Validators/RestrictFileSizeValidator.cs
+++ b/src/Validators/RestrictFileSizeValidator.cs
@@ -31,7 +31,7 @@ namespace form_builder.Validators
 
         private ValidationResult MultiFileUpload(Element element, List<DocumentModel> documentModel)
         {
-            var maxFileSize = element.Properties.MaxFileSize > 0 ? element.Properties.MaxFileSize * 1048576 : SystemConstants.DefaultMaxFileSize;
+            var maxFileSize = element.Properties.MaxFileSize > 0 ? element.Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes : SystemConstants.DefaultMaxFileSize;
 
             var invalidFileSizes = documentModel.Where(_ => _.FileSize >= maxFileSize).ToList();
 
@@ -39,8 +39,8 @@ namespace form_builder.Validators
                 return new ValidationResult { IsValid = true };
 
             var validationMessage = invalidFileSizes.Count == 1 
-                ? $"The selected file must be smaller than {maxFileSize / 1048576}MB"
-                : invalidFileSizes.Select(_ => $"{_.FileName} must be smaller than {maxFileSize / 1048576}MB").Aggregate((curr, acc) => $"{acc} <br/> {curr}");
+                ? $"The selected file must be smaller than {maxFileSize / SystemConstants.OneMBInBinaryBytes}MB"
+                : invalidFileSizes.Select(_ => $"{_.FileName} must be smaller than {maxFileSize / SystemConstants.OneMBInBinaryBytes}MB").Aggregate((curr, acc) => $"{acc} <br/> {curr}");
 
             return new ValidationResult
             { 
@@ -51,7 +51,7 @@ namespace form_builder.Validators
 
         private ValidationResult SingleFileUpload(Element element, List<DocumentModel> documentModel)
         {
-            var maxFileSize = element.Properties.MaxFileSize > 0 ? element.Properties.MaxFileSize * 1048576 : SystemConstants.DefaultMaxFileSize;
+            var maxFileSize = element.Properties.MaxFileSize > 0 ? element.Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes : SystemConstants.DefaultMaxFileSize;
 
             if (documentModel.All(_ => _.FileSize <= maxFileSize))
                 return new ValidationResult { IsValid = true };
@@ -59,7 +59,7 @@ namespace form_builder.Validators
             return new ValidationResult
             {
                 IsValid = false,
-                Message = $"The selected file must be smaller than {maxFileSize / 1048576}MB"
+                Message = $"The selected file must be smaller than {maxFileSize / SystemConstants.OneMBInBinaryBytes}MB"
             };
         }
     }

--- a/tests/UnitTests/Models/Elements/MultipleFileUploadTests.cs
+++ b/tests/UnitTests/Models/Elements/MultipleFileUploadTests.cs
@@ -136,7 +136,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
             Assert.True(result.ContainsValue("file"));
             Assert.True(result.ContainsValue(true));
             Assert.True(result.ContainsValue("smbc-multiple-file-upload"));
-            Assert.True(result.ContainsValue(value * 1024000));
+            Assert.True(result.ContainsValue(value * SystemConstants.OneMBInBinaryBytes));
         }
     }
 }


### PR DESCRIPTION
### Description
Changed how file size is determine by using 1MB in binary bytes value.

1 MB = 1,048,576 Bytes

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary