### PR TITLE
fix(fileupload): optional fileupload now save answers

### DIFF
--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -107,10 +107,11 @@ namespace form_builder.Helpers.PageHelpers
                     answers.Add(new Answers { QuestionId = item.Key, Response = item.Value });
             }
 
+            if((files == null || !files.Any()) && currentPageAnswers.Answers != null && currentPageAnswers.Answers.Any() && isPageValid && appendMultipleFileUploadParts)
+                answers = currentPageAnswers.Answers;
+
             if (files != null && files.Any() && isPageValid)
-            {
                 answers = SaveFormFileAnswers(answers, files, appendMultipleFileUploadParts, currentPageAnswers);
-            }
 
             convertedAnswers.Pages?.Add(new PageAnswers
             {

--- a/src/Services/FileUploadService/FileUploadService.cs
+++ b/src/Services/FileUploadService/FileUploadService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using form_builder.Constants;
 using form_builder.ContentFactory;
+using form_builder.Enum;
 using form_builder.Helpers.PageHelpers;
 using form_builder.Models;
 using form_builder.Providers.StorageProvider;
@@ -117,6 +118,9 @@ namespace form_builder.Services.FileUploadService
 
             if(currentPage.IsValid && viewModel.ContainsKey(ButtonConstants.SUBMIT) && (files == null || !files.Any()) && modelStateIsValid)
             {
+                if(currentPage.Elements.Where(_ => _.Type.Equals(EElementType.MultipleFileUpload)).Any(_ => _.Properties.Optional))
+                    _pageHelper.SaveAnswers(viewModel, guid, baseForm.BaseURL, files, currentPage.IsValid, true);
+                    
                 return new ProcessRequestEntity
                 {
                     Page = currentPage

--- a/tests/UnitTests/Services/FileUploadServiceTests.cs
+++ b/tests/UnitTests/Services/FileUploadServiceTests.cs
@@ -411,5 +411,51 @@ namespace form_builder_tests.UnitTests.Services
             Assert.Equal(JsonConvert.SerializeObject(expectedRouteValues), JsonConvert.SerializeObject(result.RouteValues));
             Assert.Null(result.Page);
         }
+
+        [Fact]
+        public async Task ProcessFile_ProcessSelectedFiles_ShouldSave_WhenMUltipleFileUpload_IsOptional_WithNoFiles_OnSubmit()
+        {
+
+            var _element = new ElementBuilder()
+                .WithType(EElementType.MultipleFileUpload)
+                .WithQuestionId("fileUpload")
+                .WithOptional(true)
+                .Build();
+
+            var _page = new PageBuilder()
+                .WithElement(_element)
+                .WithValidatedModel(true)
+                .WithPageSlug("page-one")
+                .Build();
+
+            var _schema = new FormSchemaBuilder()
+                .WithPage(_page)
+                .WithBaseUrl("baseUrl")
+                .Build();
+
+
+            // Arrange
+            var expectedRouteValues = new
+            {
+                form = "baseUrl",
+                path = "path"
+            };
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {
+                    "Submit", "Submit"
+                }
+            };
+
+            // Act
+            var result = await _service.ProcessFile(viewModel, _page, _schema, new Guid().ToString(),
+                "path", null, true);
+
+            // Assert
+            Assert.IsType<ProcessRequestEntity>(result);
+            Assert.False(result.RedirectToAction);
+            _mockPageHelper.Verify(_ => _.SaveAnswers(It.IsAny<Dictionary<string, dynamic>>(), It.IsAny<string>(), It.IsAny<string>(), null, true, true), Times.Once);
+        }
     }
 }


### PR DESCRIPTION
### Description
Fixed issue with optional fileupload when on last page of form and no files uploaded routing would fail due to using previous page for routing logic as no data has been saved.

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary