### PR TITLE
chore(booking):Add Email Content Method

### DIFF
--- a/src/Constants/BookingConstants.cs
+++ b/src/Constants/BookingConstants.cs
@@ -8,10 +8,10 @@ namespace form_builder.Constants
         public const string APPOINTMENT_TIME = "appointment-time";
         public const string APPOINTMENT_TIME_END = "appointment-time-end";
         public const string CHECK_YOUR_BOOKING = "check-your-booking";
-        public const string RESERVED_BOOKING_DATE = "ReservedDate";
-        public const string RESERVED_BOOKING_TIME = "ReservedTime";
-        public const string RESERVED_BOOKING_ID = "ReservedAppointmentId";
-        public const string BOOKING_MONTH_REQUEST = "BOOKING_MONTH_REQUEST";
+        public const string RESERVED_BOOKING_DATE = "reserved-date";
+        public const string RESERVED_BOOKING_TIME = "reserved-time";
+        public const string RESERVED_BOOKING_ID = "reserved-appointment-id";
+        public const string BOOKING_MONTH_REQUEST = "month-request";
         public const string NO_APPOINTMENT_AVAILABLE = "no-appointment-available";
     }
 }

--- a/src/Helpers/ActionsHelpers/ActionHelper.cs
+++ b/src/Helpers/ActionsHelpers/ActionHelper.cs
@@ -1,6 +1,9 @@
-﻿using form_builder.Models;
+﻿using form_builder.Extensions;
+using form_builder.Models;
 using form_builder.Models.Actions;
 using form_builder.Services.RetrieveExternalDataService.Entities;
+using form_builder.TagParser;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -9,13 +12,15 @@ namespace form_builder.Helpers.ActionsHelpers
     public interface IActionHelper
     {
         RequestEntity GenerateUrl(string baseUrl, FormAnswers formAnswers);
-
         string GetEmailToAddresses(IAction action, FormAnswers formAnswers);
+        string GetEmailContent(IAction action, FormAnswers formAnswers);
     }
 
     public class ActionHelper : IActionHelper
     {
+        private readonly IEnumerable<IFormatter> _formatters;
         private static Regex TagRegex => new Regex("(?<={{).*?(?=}})", RegexOptions.Compiled);
+        public ActionHelper(IEnumerable<IFormatter> formatters) => _formatters = formatters;
 
         public RequestEntity GenerateUrl(string baseUrl, FormAnswers formAnswers)
         {
@@ -27,6 +32,45 @@ namespace form_builder.Helpers.ActionsHelpers
                 Url = newUrl,
                 IsPost = !matches.Any()
             };
+        }
+
+        public string GetEmailContent(IAction action, FormAnswers formAnswers)
+        {
+            // Any {{variables}} to find
+            string content = action.Properties.Content;
+            if (!TagRegex.Matches(content).Any())
+                return content;
+
+            foreach (Match m in TagRegex.Matches(content))
+            {
+                if (m.Success)
+                {
+                    var splitMatch = m.Value.Split(":");
+                    var questionKey = splitMatch[0];
+                    var question = formAnswers.Pages
+                            .SelectMany(_ => _.Answers)
+                            .FirstOrDefault(_ => _.QuestionId.Equals(questionKey));
+
+                    if (question != null)
+                    {
+                        var answer = question.Response as string;
+
+                        // Format on ":" split of string
+                        if (splitMatch.Length > 1)
+                            answer = _formatters.Get(splitMatch[1]).Parse(answer);
+
+                        // Replace and return string...
+                        content = content.Replace($"{{{{{m.Groups[0].Value}}}}}", answer);
+                    }
+                    else
+                    {
+                        // Found no such key : At least remove the variable name
+                        content = content.Replace($"{{{{{m.Groups[0].Value}}}}}", string.Empty);
+                    }
+                }
+            }
+
+            return content;
         }
 
         public string GetEmailToAddresses(IAction action, FormAnswers formAnswers)
@@ -47,8 +91,8 @@ namespace form_builder.Helpers.ActionsHelpers
         private string Replace(Match match, string current, FormAnswers formAnswers)
         {
             var splitTargets = match.Value.Split(".");
-            var formAnswerDictionary= formAnswers.Pages.SelectMany(_ => _.Answers).Select(x => new Answers { QuestionId = x.QuestionId, Response = x.Response }).ToList();
-            formAnswerDictionary.AddRange(formAnswers.AdditionalFormData.Select(x => new Answers {QuestionId = x.Key, Response = x.Value}).ToList());
+            var formAnswerDictionary = formAnswers.Pages.SelectMany(_ => _.Answers).Select(x => new Answers { QuestionId = x.QuestionId, Response = x.Response }).ToList();
+            formAnswerDictionary.AddRange(formAnswers.AdditionalFormData.Select(x => new Answers { QuestionId = x.Key, Response = x.Value }).ToList());
 
             var answer = RecursiveGetAnswerValue(match.Value, formAnswerDictionary.First(a => a.QuestionId.Equals(splitTargets[0])));
 

--- a/src/Models/Actions/UserEmail.cs
+++ b/src/Models/Actions/UserEmail.cs
@@ -11,13 +11,13 @@ namespace form_builder.Models.Actions
 
         public override async Task Process(IActionHelper actionHelper, IEmailProvider emailProvider, FormAnswers formAnswers)
         {
-            var emailMessage = new EmailMessage(
-                              this.Properties.Subject,
-                              this.Properties.Content,
-                              this.Properties.From,
-                              actionHelper.GetEmailToAddresses(this, formAnswers));
-
-            await emailProvider.SendEmail(emailMessage);
+            await emailProvider
+                .SendEmail(
+                    new EmailMessage(
+                        Properties.Subject,
+                        actionHelper.GetEmailContent(this, formAnswers), 
+                        Properties.From, 
+                        actionHelper.GetEmailToAddresses(this, formAnswers)));
         }
     }
 }

--- a/src/TagParsers/FormAnswerTagParser.cs
+++ b/src/TagParsers/FormAnswerTagParser.cs
@@ -13,7 +13,7 @@ namespace form_builder.TagParser
 
         public Page Parse(Page page, FormAnswers formAnswers)
         {
-            var answersDictionary = formAnswers.Pages?.SelectMany(_ => _.Answers).ToDictionary(x => x.QuestionId, x => x.Response);
+            var answersDictionary = formAnswers.Pages?.SelectMany(x => x.Answers).ToDictionary(x => x.QuestionId, x => x.Response);
 
             page.Elements.Select((element) =>
             {

--- a/src/TagParsers/FormDataTagParser.cs
+++ b/src/TagParsers/FormDataTagParser.cs
@@ -7,9 +7,7 @@ namespace form_builder.TagParser
 {
     public class FormDataTagParser : TagParser, ITagParser
     {
-        public FormDataTagParser(IEnumerable<IFormatter> formatters) : base(formatters)
-        {
-        }
+        public FormDataTagParser(IEnumerable<IFormatter> formatters) : base(formatters) { }
 
         public Regex Regex => new Regex("(?<={{)FORMDATA:.*?(?=}})", RegexOptions.Compiled);
 

--- a/src/TagParsers/TagParser.cs
+++ b/src/TagParsers/TagParser.cs
@@ -10,10 +10,7 @@ namespace form_builder.TagParser
     public class TagParser
     {
         private readonly IEnumerable<IFormatter> _formatters;
-        public TagParser(IEnumerable<IFormatter> formatters)
-        {
-            _formatters = formatters;
-        }
+        public TagParser(IEnumerable<IFormatter> formatters) => _formatters = formatters;
 
         public string Parse(string value, Dictionary<string, object> answersDictionary, Regex regex)
         {

--- a/src/Views/Shared/Booking/CheckYourBooking.cshtml
+++ b/src/Views/Shared/Booking/CheckYourBooking.cshtml
@@ -5,6 +5,7 @@
 @Html.Hidden(@Model.GetCustomItemId(BookingConstants.RESERVED_BOOKING_DATE), Model.ReservedBookingDate)
 @Html.Hidden(@Model.GetCustomItemId(BookingConstants.RESERVED_BOOKING_TIME), Model.ReservedBookingTime)
 @Html.Hidden(@Model.GetCustomItemId(BookingConstants.RESERVED_BOOKING_ID), Model.ReservedBookingId)
+@Html.Hidden(@Model.GetCustomItemId(BookingConstants.APPOINTMENT_TIME_END), Model.AppointmentEndTime)
 
 <h1 class="govuk-heading-l">Check your booking</h1>
 <table class="govuk-table">


### PR DESCRIPTION
Select dynamic variables to use in the email body

### Description
Created a very similar method to TagParsers, to allow {{variables}} within the FormBuilders, PageActions of Type UserEmail, "Content" field. So that variables from he form can be used in the email body. These variables for the booking element are taken from BookingConstants, and created from searched and reserved dates / appointments.

This was brought to my attention by Stephen. That the end-date of the appointment would be needed in the confirmation email.

My concern is that this I totally have the wrong end of the stick, and this has already been done somewhere else. I couldn't find any other email functionality within the application, apart from this PageActions. So this is what I did...

Some clean up / standardisation in a few files...
src/Constants/BookingConstants.cs
src/Models\Actions/UserEmail.cs
src/TagParsers/FormAnswerTagParser.cs
src/TagParsers/FormDataTagParser.cs
src/TagParsers/TagParser.cs

Added "booking-appointment-time-end" as hidden input to "CheckYourBooking" view
src/Views/Shared/Booking/CheckYourBooking.cshtml

Added Method to parse {{variables}} into the string for the email body
src/Helpers/ActionsHelpers/ActionHelper.cs

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary