### PR TITLE
fix(Views): Handle AntiForgeryToken generation

### DIFF
--- a/src/Views/Home/Index.cshtml
+++ b/src/Views/Home/Index.cshtml
@@ -8,8 +8,9 @@
     ViewData["Breadcrumbs"] = Model.BreadCrumbs;
 }
 
-@using (Html.BeginForm("Index", "Home", FormMethod.Post, new { autocomplete = "on", novalidate = "novalidate", enctype = "multipart/form-data" }))
+@using (Html.BeginForm("Index", "Home", new {}, FormMethod.Post, false, new { autocomplete = "on", novalidate = "novalidate", enctype = "multipart/form-data" }) )
 {
+    @Html.AntiForgeryToken()
     @Html.Raw(Model.RawHTML)
     @Html.HiddenFor(_ => _.Path)
 }


### PR DESCRIPTION
 
### Description
When a user is using the Booking calendar on occassions the page may not have fully loaded and if the user clicks on the previous/next month button the request sent to the controller does not contains the AntiForgeryToken due to being at the bottom of the form. 

We now generate the AntiForgeryToken token at the top of the form before the elements html is rendered.
![image](https://user-images.githubusercontent.com/35955528/102798475-12455600-43a9-11eb-8888-39dd28d58e33.png)


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary