### PR TITLE
tests(email_content): test email

### DIFF
--- a/src/Providers/EmailProvider/FakeEmailProvider.cs
+++ b/src/Providers/EmailProvider/FakeEmailProvider.cs
@@ -8,10 +8,7 @@ namespace form_builder.Providers.EmailProvider
     public class FakeEmailProvider : IEmailProvider
     {
         private readonly ILogger<FakeEmailProvider> _logger;
-        public FakeEmailProvider(ILogger<FakeEmailProvider> logger)
-        {
-            _logger = logger;
-        }
+        public FakeEmailProvider(ILogger<FakeEmailProvider> logger) => _logger = logger;
 
         public async Task<HttpStatusCode> SendEmail(EmailMessage emailMessage)
         {

--- a/tests/unit-tests/UnitTests/TagParsers/TagParserTests.cs
+++ b/tests/unit-tests/UnitTests/TagParsers/TagParserTests.cs
@@ -13,9 +13,7 @@ namespace form_builder_tests.UnitTests.Services
         private Regex _regex => new Regex("(?<={{)TEST:.*?(?=}})");
         private TagParser _tagParser;
 
-        public TagParserTests(){
-            _tagParser = new TagParser(_mockFormatters.Object);
-        }
+        public TagParserTests() =>_tagParser = new TagParser(_mockFormatters.Object);
 
         [Fact]
         public void Parse_ShouldThrowException_WhenQuestionValue_IsNotWithinAnswers()


### PR DESCRIPTION
Calls Email Content Method && Email Content Parses Variable or removes Variable from content string

### Description
Added Tests for Method I created to parse variables passed into an Email Body from the properties.content field in the JSON form.

1) EmailServiceTests : Check it calls the GetEmailContent method.

2) ActionHelpertests : Check it finds the response from the form by a valid QuestionId, or removes the variable from the properties.content field which makes up the body of the email, if the {{variable}} name is invalid/type/etc.

3) And some small changes for constructors that I come across with a single argument, moved to arrow style initialisation.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary