### PR TITLE
chore(service): throw exception when session data is null

### DIFF
--- a/src/Services/PageService/PageService.cs
+++ b/src/Services/PageService/PageService.cs
@@ -293,9 +293,13 @@ namespace form_builder.Services.PageService
             var sessionGuid = _sessionHelper.GetSessionGuid();
 
             if (string.IsNullOrEmpty(sessionGuid))
-                throw new Exception("PageService::FinalisePageJourney: Session has expired");
+                throw new ApplicationException("PageService::FinalisePageJourney: Session has expired");
 
             var formData = _distributedCache.GetString(sessionGuid);
+
+            if(formData == null)
+                throw new ApplicationException("PageService::FinalisePageJourney: Session data is null");
+
             var formAnswers = JsonConvert.DeserializeObject<FormAnswers>(formData);
 
             var formFileUploadElements = baseForm.Pages.SelectMany(_ => _.Elements)

--- a/tests/unit-tests/UnitTests/Services/PageServicesTests.cs
+++ b/tests/unit-tests/UnitTests/Services/PageServicesTests.cs
@@ -710,6 +710,52 @@ namespace form_builder_tests.UnitTests.Services
         }
 
         [Fact]
+        public async Task FinalisePageJourney_ShouldThrow_ApplicationException_WhenNoSessionGuid()
+        {
+            // Arrange
+            _sessionHelper.Setup(_ => _.GetSessionGuid()).Returns(string.Empty);
+
+            var page = new PageBuilder()
+                .WithPageSlug("page-one")
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithPage(page)
+                .Build();
+
+            // Act
+            var result = await Assert.ThrowsAsync<ApplicationException>(() => _service.FinalisePageJourney("form", EBehaviourType.SubmitAndPay, schema));
+
+            // Assert
+            Assert.Equal("PageService::FinalisePageJourney: Session has expired",result.Message);
+        }
+
+
+        [Fact]
+        public async Task FinalisePageJourney_ShouldThrow_ApplicationException_When_SessionData_IsNull()
+        {
+            // Arrange
+            var guid = Guid.NewGuid();
+            _sessionHelper.Setup(_ => _.GetSessionGuid()).Returns(guid.ToString());
+
+            _distributedCache.Setup(_ => _.GetString(It.IsAny<string>())).Returns((string)null);
+
+            var page = new PageBuilder()
+                .WithPageSlug("page-one")
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithPage(page)
+                .Build();
+
+            // Act
+            var result = await Assert.ThrowsAsync<ApplicationException>(() => _service.FinalisePageJourney("form", EBehaviourType.SubmitAndPay, schema));
+
+            // Assert
+            Assert.Equal("PageService::FinalisePageJourney: Session data is null",result.Message);
+        }
+
+        [Fact]
         public async Task FinalisePageJourney_ShouldDeleteFileUpload_CacheEntries()
         {
             // Arrange
@@ -879,7 +925,7 @@ namespace form_builder_tests.UnitTests.Services
         }
 
         [Fact]
-        public async Task FinalisePageJourney_ShouldNotError_WhenFileUPload_DataIsNull()
+        public async Task FinalisePageJourney_ShouldNotError_WhenFileUpload_DataIsNull()
         {
             // Arrange
             var guid = Guid.NewGuid();


### PR DESCRIPTION
### Description
Throw application exception when session data is null, rather then attempt to Deserialise null object.

Removes error log around attempting to Deserialise a null object.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary