### PR TITLE
fix(Document): fixed expired view for document download

### DIFF
--- a/src/Controllers/Document/DocumentController.cs
+++ b/src/Controllers/Document/DocumentController.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using form_builder.Enum;
 using form_builder.Exceptions;
 using form_builder.Extensions;
+using form_builder.ViewModels;
 using form_builder.Workflows.DocumentWorkflow;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/src/Controllers/Document/DocumentController.cs
+++ b/src/Controllers/Document/DocumentController.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using form_builder.Enum;
 using form_builder.Exceptions;
 using form_builder.Extensions;
-using form_builder.ViewModels;
 using form_builder.Workflows.DocumentWorkflow;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/src/Views/Document/Expired.cshtml
+++ b/src/Views/Document/Expired.cshtml
@@ -1,6 +1,10 @@
 @{
     ViewData["Title"] = "Error";
+    ViewData["IsError"] = true;
+    Layout = "_ErrorLayout";
 }
 
-<h1>Document download has expired</h1>
-<a href="https://www.stockport.gov.uk" class="button-primary">Return to stockport.gov.uk</a>
+<h1 class="govuk-heading-l">Document download has expired</h1>
+<p class="smbc-body">
+    <a class="govuk-link" href="https://www.stockport.gov.uk">Go back to the homepage</a>
+</p>


### PR DESCRIPTION
### Description
Document download expired view has been missed when updating to DS.
View has been updated and fixed due to missing ViewModel values causing expired view to not be displayed.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary