### PR TITLE
refactor(customer address): handle address as Address component or text field

### DIFF
--- a/src/Builders/ElementBuilder.cs
+++ b/src/Builders/ElementBuilder.cs
@@ -399,5 +399,12 @@ namespace form_builder.Builders
 
             return this;
         }
+
+        public ElementBuilder WithCustomerAddressId(string value)
+        {
+            _property.CustomerAddressId = value;
+
+            return this;
+        }
     }
 }

--- a/src/Config/appsettings.local.json
+++ b/src/Config/appsettings.local.json
@@ -24,6 +24,6 @@
   "IAddressServiceGatewayConfig:baseUrl": "http://scninthub-int1.stockport.gov.uk/addressservice/",
   "IStreetServiceGatewayConfig:baseUrl": "http://scninthub-int1.stockport.gov.uk/streetservice/",
   "IOrganisationGatewayServiceConfig:baseUrl": "http://scninthub-int1.stockport.gov.uk/organisationservice/",
-  "IBookingServiceGatewayConfig:baseUrl": "https://localhost:44359",
+  "IBookingServiceGatewayConfig:baseUrl": "https://localhost:44377",
   "ErrorRoute": "/error"
 }

--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -667,10 +667,10 @@ namespace form_builder.Helpers.PageHelpers
                         booking.Properties.OptionalResources.ForEach(resource =>
                         {
                             if (resource.Quantity <= 0)
-                                throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element optional resouces are invalid, cannot have a quantity less than 0");
+                                throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element optional resources are invalid, cannot have a quantity less than 0");
 
                             if (resource.ResourceId.Equals(Guid.Empty))
-                                throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element optional resouces are invalid, ResourceId cannot be an empty Guid.");
+                                throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element optional resources are invalid, ResourceId cannot be an empty Guid.");
                         });
                     }
                 });
@@ -681,12 +681,11 @@ namespace form_builder.Helpers.PageHelpers
                 var additionalRequiredElements = pages.SelectMany(_ => _.ValidatableElements)
                     .Where(_ => _.Properties != null && _.Properties.TargetMapping != null)
                     .Where(_ => _.Properties.TargetMapping.ToLower().Equals("customer.firstname")
-                        || _.Properties.TargetMapping.ToLower().Equals("customer.lastname")
-                        || _.Properties.TargetMapping.ToLower().Equals("customer.email"))
+                        || _.Properties.TargetMapping.ToLower().Equals("customer.lastname"))
                     .ToList();
 
-                if (additionalRequiredElements.Count() != 3)
-                    throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element requires customer firstname/lastname/email elements for reservation");
+                if (additionalRequiredElements.Count != 2)
+                    throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element requires customer firstname/lastname elements for reservation");
             }
         }
     }

--- a/src/Models/Properties/ElementProperties/BookingProperty.cs
+++ b/src/Models/Properties/ElementProperties/BookingProperty.cs
@@ -14,5 +14,6 @@ namespace form_builder.Models.Properties.ElementProperties
         public string NextAvailableIAG { get; set; } = "This is the next available appointment.";
         public List<BookingResource> OptionalResources { get; set; } = new List<BookingResource>();
         public string NoAvailableTimeForBookingType { get; set; } = "appointments";
+        public string CustomerAddressId { get; set; }
     }
 }

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "booking-using-address-component",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "local"
       }

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -11,7 +11,6 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "booking-using-address-component",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "local"
       }

--- a/src/Services/BookingService/BookingService.cs
+++ b/src/Services/BookingService/BookingService.cs
@@ -228,8 +228,7 @@ namespace form_builder.Services.BookingService
             var currentlySelectedBookingStartTime = bookingElement.StartTimeQuestionId;
             var currentlySelectedBookingEndTime = bookingElement.EndTimeQuestionId;
 
-            var location = await GetReservedBookingLocation(bookingElement, form, guid);
-            viewModel.Add(bookingElement.AppointmentLocation, location);
+            
 
             if (viewModel.ContainsKey(reservedBookingId) && !string.IsNullOrEmpty((string)viewModel[reservedBookingId]))
             {
@@ -253,6 +252,8 @@ namespace form_builder.Services.BookingService
             var result = await _bookingProviders.Get(bookingElement.Properties.BookingProvider)
                 .Reserve(bookingRequest);
 
+            var location = await GetReservedBookingLocation(bookingElement, bookingRequest);
+            viewModel.Add(bookingElement.AppointmentLocation, location);
             viewModel.Add(reservedBookingDate, viewModel[currentlySelectedBookingDate]);
             viewModel.Add(reservedBookingStartTime, viewModel[currentlySelectedBookingStartTime]);
             viewModel.Add(reservedBookingEndTime, viewModel[currentlySelectedBookingEndTime]);
@@ -261,7 +262,7 @@ namespace form_builder.Services.BookingService
             return result;
         }
 
-        private async Task<string> GetReservedBookingLocation(Booking bookingElement, string form, string guid)
+        private async Task<string> GetReservedBookingLocation(Booking bookingElement, BookingRequest bookingRequest)
         {
             var bookingProvider = _bookingProviders.Get(bookingElement.Properties.BookingProvider);
             var location = await bookingProvider.GetLocation(new LocationRequest
@@ -272,13 +273,10 @@ namespace form_builder.Services.BookingService
 
             if (string.IsNullOrEmpty(location))
             {
-                var address = await _mappingService.MapAddress(guid, form);
-                return address.ConvertAddressToTitleCase();
+                return string.IsNullOrEmpty(bookingRequest.Customer.Address) ? string.Empty : bookingRequest.Customer.Address.ConvertAddressToTitleCase();
             }
-            else
-            {
-                return location.ConvertAddressToTitleCase();
-            }
+
+            return location.ConvertAddressToTitleCase();
         }
 
         public async Task ProcessMonthRequest(Dictionary<string, object> viewModel, FormSchema baseForm, Page currentPage, string guid)

--- a/src/Services/BookingService/BookingService.cs
+++ b/src/Services/BookingService/BookingService.cs
@@ -273,7 +273,7 @@ namespace form_builder.Services.BookingService
             if (string.IsNullOrEmpty(location))
             {
                 var address = await _mappingService.MapAddress(guid, form);
-                return address.ToStringWithoutPlaceRef().ConvertAddressToTitleCase();
+                return address.ConvertAddressToTitleCase();
             }
             else
             {

--- a/src/Services/MappingService/IMappingService.cs
+++ b/src/Services/MappingService/IMappingService.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using form_builder.Models.Elements;
 using form_builder.Services.MappingService.Entities;
 using StockportGovUK.NetStandard.Models.Booking.Request;
-using Address = StockportGovUK.NetStandard.Models.Addresses.Address;
 
 namespace form_builder.Services.MappingService
 {
@@ -11,6 +10,5 @@ namespace form_builder.Services.MappingService
     {
         Task<MappingEntity> Map(string sessionGuid, string form);
         Task<BookingRequest> MapBookingRequest(string sessionGuid, IElement bookingElement, Dictionary<string, dynamic> viewModel, string form);
-        Task<string> MapAddress(string sessionGuid, string form);
     }
 }

--- a/src/Services/MappingService/IMappingService.cs
+++ b/src/Services/MappingService/IMappingService.cs
@@ -11,6 +11,6 @@ namespace form_builder.Services.MappingService
     {
         Task<MappingEntity> Map(string sessionGuid, string form);
         Task<BookingRequest> MapBookingRequest(string sessionGuid, IElement bookingElement, Dictionary<string, dynamic> viewModel, string form);
-        Task<Address> MapAddress(string sessionGuid, string form);
+        Task<string> MapAddress(string sessionGuid, string form);
     }
 }

--- a/src/Services/MappingService/MappingService.cs
+++ b/src/Services/MappingService/MappingService.cs
@@ -55,16 +55,29 @@ namespace form_builder.Services.MappingService
         {
             var (convertedAnswers, baseForm) = await GetFormAnswers(form, sessionGuid);
 
+            var pageWithAddress = 
+                baseForm.Pages.FirstOrDefault(_ => _.Elements.Count(_ => _.Properties.QuestionId.Equals(bookingElement.Properties.CustomerAddressId)) > 0);
+            var addressElement = pageWithAddress.Elements.FirstOrDefault(_ =>
+                _.Properties.QuestionId.Equals(bookingElement.Properties.QuestionId));
+            var address = _elementMapper.GetAnswerStringValue(addressElement, convertedAnswers);
+            var customer = GetCustomerDetails(convertedAnswers, baseForm);
             return new BookingRequest
             {
                 AppointmentId = bookingElement.Properties.AppointmentType,
-                Customer = GetCustomerDetails(convertedAnswers, baseForm),
+                Customer = new Customer
+                {
+                    Firstname = customer.Firstname,
+                    Lastname = customer.Lastname,
+                    Address = address,
+                    Email = customer.Email,
+                    PhoneNumber = customer.PhoneNumber
+                },
                 StartDateTime = GetStartDateTime(bookingElement.Properties.QuestionId, viewModel, form),
                 OptionalResources = bookingElement.Properties.OptionalResources
             };
         }
 
-        public async Task<Address> MapAddress(string sessionGuid, string form)
+        public async Task<string> MapAddress(string sessionGuid, string form)
         {
             var (convertedAnswers, baseForm) = await GetFormAnswers(form, sessionGuid);
 

--- a/src/form-builder.csproj
+++ b/src/form-builder.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="StockportGovUK.AspNetCore.Attributes.TokenAuthentication" Version="1.0.0" />
     <PackageReference Include="StockportGovUK.AspNetCore.Middleware.ExceptionHandling" Version="2.0.2" />
-    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="6.0.0-prerelease-62" />
+    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="6.0.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.6" />

--- a/src/form-builder.csproj
+++ b/src/form-builder.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="StockportGovUK.AspNetCore.Attributes.TokenAuthentication" Version="1.0.0" />
     <PackageReference Include="StockportGovUK.AspNetCore.Middleware.ExceptionHandling" Version="2.0.2" />
-    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="5.5.2" />
+    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="6.0.0-prerelease-62" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.6" />

--- a/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
@@ -2578,7 +2578,7 @@ namespace form_builder_tests.UnitTests.Helpers
 
             // Act
             var result = Assert.Throws<ApplicationException>(() => _pageHelper.CheckForBookingElement(pages));
-            Assert.Equal("PageHelper:CheckForBookingElement, Booking element requires customer firstname/lastname/email elements for reservation", result.Message);
+            Assert.Equal("PageHelper:CheckForBookingElement, Booking element requires customer firstname/lastname elements for reservation", result.Message);
         }
 
         [Fact]
@@ -2673,7 +2673,7 @@ namespace form_builder_tests.UnitTests.Helpers
 
             // Act
             var result = Assert.Throws<ApplicationException>(() => _pageHelper.CheckForBookingElement(pages));
-            Assert.Equal("PageHelper:CheckForBookingElement, Booking element optional resouces are invalid, ResourceId cannot be an empty Guid.", result.Message);
+            Assert.Equal("PageHelper:CheckForBookingElement, Booking element optional resources are invalid, ResourceId cannot be an empty Guid.", result.Message);
         }
 
         [Fact]
@@ -2698,7 +2698,7 @@ namespace form_builder_tests.UnitTests.Helpers
 
             // Act
             var result = Assert.Throws<ApplicationException>(() => _pageHelper.CheckForBookingElement(pages));
-            Assert.Equal("PageHelper:CheckForBookingElement, Booking element optional resouces are invalid, cannot have a quantity less than 0", result.Message);
+            Assert.Equal("PageHelper:CheckForBookingElement, Booking element optional resources are invalid, cannot have a quantity less than 0", result.Message);
         }
     }
 }

--- a/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
@@ -44,19 +44,14 @@ namespace form_builder_tests.UnitTests.Services
         public BookingServiceTests()
         {
             _mockdistributedCacheExpirationConfiguration.Setup(_ => _.Value).Returns(_cacheConfig);
-
+            _mockMappingService
+                .Setup(_ => _.MapBookingRequest(It.IsAny<string>(), It.IsAny<IElement>(), It.IsAny<Dictionary<string, object>>(), It.IsAny<string>()))
+                .ReturnsAsync(new BookingRequest { Customer = new Customer() });
             _bookingProvider.Setup(_ => _.ProviderName).Returns("testBookingProvider");
             _bookingProviders = new List<IBookingProvider>
             {
                 _bookingProvider.Object
             };
-
-            _mockMappingService
-                .Setup(expression: _ => _.MapAddress(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(new Address
-                {
-                    SelectedAddress = "Address"
-                });
 
             _service = new BookingService(
               _mockDistributedCache.Object,
@@ -590,6 +585,7 @@ namespace form_builder_tests.UnitTests.Services
         [Fact]
         public async Task ProcessBooking_Should_Call_BookingProvider_When_SelectedDate_IsDifferent_To_ReservedDateAndTime()
         {
+            
             var appointmentTypeGuid = new Guid();
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
@@ -619,6 +615,8 @@ namespace form_builder_tests.UnitTests.Services
                 { $"{element.Properties.QuestionId}-{BookingConstants.RESERVED_BOOKING_START_TIME}", date.ToString() },
                 { $"{element.Properties.QuestionId}-{BookingConstants.RESERVED_BOOKING_END_TIME}", date.ToString() },
             };
+
+            
 
             await _service.ProcessBooking(model, page, formSchema, "guid", "path");
 

--- a/tests/unit-tests/form-builder-tests-unit.csproj
+++ b/tests/unit-tests/form-builder-tests-unit.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="84.0.4147.3001" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
-    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="6.0.0-prerelease-62" />
+    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/unit-tests/form-builder-tests-unit.csproj
+++ b/tests/unit-tests/form-builder-tests-unit.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="84.0.4147.3001" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
-    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="5.5.2" />
+    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="6.0.0-prerelease-62" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Description
- update Gateways to v6.0.0
- add CustomerAddressId property to Booking to refer to address questionId
- rename and refactor MappingService.GetCustomerBookingDetails to handle address as a string
- remove MappingService.MapAddress as no longer needed
- move GetReservedBookingLocation call in BookingService to after Reserve to enable use of the BookingRequest object
- refactor GetReservedBookingLocation to use BookingRequest object
- refactor schema validation as email not mandatory anymore
- add unit test to MappingServiceTests for address

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary