### PR TITLE
refactor(BookingAddress): add schema validation for CustomerAddressId…

### DIFF
--- a/src/Helpers/PageHelpers/IPageHelper.cs
+++ b/src/Helpers/PageHelpers/IPageHelper.cs
@@ -51,5 +51,7 @@ namespace form_builder.Helpers.PageHelpers
         List<Answers> SaveFormFileAnswers(List<Answers> answers, IEnumerable<CustomFormFile> files, bool isMultipleFileUploadElementType, PageAnswers currentAnswersForFileUpload);
 
         void CheckConditionalElementsAreValid(List<Page> pages, string formName);
+
+        void CheckQuestionIdExistsForBookingCustomerAddressId(List<Page> pages, string formName);
     }
 }

--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -247,6 +247,32 @@ namespace form_builder.Helpers.PageHelpers
             });
         }
 
+        public void CheckQuestionIdExistsForBookingCustomerAddressId(List<Page> pages, string formName)
+        {
+            var bookingElements = pages.SelectMany(_ => _.Elements)
+                .Where(_ => _.Type.Equals(EElementType.Booking)).ToList();
+
+            if (bookingElements.Count > 0)
+            {
+                foreach (var bookingElement in bookingElements)
+                {
+                    if (!string.IsNullOrEmpty(bookingElement.Properties.CustomerAddressId))
+                    {
+                        var matchingElement = pages.SelectMany(_ => _.Elements)
+                            .FirstOrDefault(_ =>
+                                _.Properties.QuestionId != null &&
+                                _.Properties.QuestionId.Contains(bookingElement.Properties.CustomerAddressId));
+
+                        if (matchingElement == null)
+                            throw new ApplicationException($"The provided json '{formName}' does not contain an element with questionId of " +
+                                                           $"'{bookingElement.Properties.CustomerAddressId}' for booking element " +
+                                                           $"'{bookingElement.Properties.QuestionId}'");
+                    }
+                }
+                
+            }
+        }
+
         public void CheckForCurrentEnvironmentSubmitSlugs(List<Page> pages, string formName)
         {
             var behaviours = pages.Where(page => page.Behaviours != null).SelectMany(page => page.Behaviours).ToList();

--- a/src/Models/FormSchema.cs
+++ b/src/Models/FormSchema.cs
@@ -91,6 +91,7 @@ namespace form_builder.Models
             pageHelper.CheckForAnyConditionType(Pages);
             pageHelper.CheckUploadedFilesSummaryQuestionsIsSet(Pages);
             pageHelper.CheckForBookingElement(Pages);
+            pageHelper.CheckQuestionIdExistsForBookingCustomerAddressId(Pages, form);
         }
 
         public bool IsAvailable(string environment)

--- a/src/Services/BookingService/BookingService.cs
+++ b/src/Services/BookingService/BookingService.cs
@@ -228,7 +228,9 @@ namespace form_builder.Services.BookingService
             var currentlySelectedBookingStartTime = bookingElement.StartTimeQuestionId;
             var currentlySelectedBookingEndTime = bookingElement.EndTimeQuestionId;
 
-            
+            var bookingRequest = await _mappingService.MapBookingRequest(guid, bookingElement, viewModel, form);
+            var location = await GetReservedBookingLocation(bookingElement, bookingRequest);
+            viewModel.Add(bookingElement.AppointmentLocation, location);
 
             if (viewModel.ContainsKey(reservedBookingId) && !string.IsNullOrEmpty((string)viewModel[reservedBookingId]))
             {
@@ -248,12 +250,9 @@ namespace form_builder.Services.BookingService
             viewModel.Remove(reservedBookingStartTime);
             viewModel.Remove(reservedBookingEndTime);
 
-            var bookingRequest = await _mappingService.MapBookingRequest(guid, bookingElement, viewModel, form);
             var result = await _bookingProviders.Get(bookingElement.Properties.BookingProvider)
                 .Reserve(bookingRequest);
 
-            var location = await GetReservedBookingLocation(bookingElement, bookingRequest);
-            viewModel.Add(bookingElement.AppointmentLocation, location);
             viewModel.Add(reservedBookingDate, viewModel[currentlySelectedBookingDate]);
             viewModel.Add(reservedBookingStartTime, viewModel[currentlySelectedBookingStartTime]);
             viewModel.Add(reservedBookingEndTime, viewModel[currentlySelectedBookingEndTime]);

--- a/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
@@ -1000,6 +1000,84 @@ namespace form_builder_tests.UnitTests.Helpers
         }
 
         [Fact]
+        public void CheckQuestionIdExistsForBookingCustomerAddressId_ShouldThrowException_WhenQuestionIdDoesNotExist()
+        {
+            // Arrange
+            var pages = new List<Page>();
+
+            var element = new ElementBuilder()
+                .WithQuestionId("address")
+                .WithType(EElementType.Textarea)
+                .Build();
+
+            var bookingElement = new ElementBuilder()
+                .WithQuestionId("booking")
+                .WithType(EElementType.Booking)
+                .WithCustomerAddressId("address")
+                .Build();
+
+            var additionalBookingElement = new ElementBuilder()
+                .WithQuestionId("additionalBooking")
+                .WithType(EElementType.Booking)
+                .WithCustomerAddressId("additionalAddress")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            pages.Add(page);
+            page = new PageBuilder()
+                .WithElement(bookingElement)
+                .Build();
+
+            pages.Add(page);
+            page = new PageBuilder()
+                .WithElement(additionalBookingElement)
+                .Build();
+
+            pages.Add(page);
+
+            // Act
+            var result = Assert.Throws<ApplicationException>(() => _pageHelper.CheckQuestionIdExistsForBookingCustomerAddressId(pages, "formName"));
+
+            // Assert
+            Assert.StartsWith("The provided json 'formName' does not contain an element with questionId of ", result.Message);
+        }
+
+        [Fact]
+        public void CheckQuestionIdExistsForBookingCustomerAddressId_ShouldNotThrowException_WhenQuestionIdExists()
+        {
+            // Arrange
+            var pages = new List<Page>();
+
+            var addressElement = new ElementBuilder()
+                .WithQuestionId("address")
+                .WithType(EElementType.Textarea)
+                .Build();
+
+            var bookingElement = new ElementBuilder()
+                .WithQuestionId("booking")
+                .WithType(EElementType.Booking)
+                .WithCustomerAddressId("address")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(addressElement)
+                .Build();
+
+            pages.Add(page);
+            page = new PageBuilder()
+                .WithElement(bookingElement)
+                .Build();
+
+            pages.Add(page);
+
+            // Act & Assert
+            _pageHelper.CheckForInvalidQuestionOrTargetMappingValue(pages, "formName");
+        }
+
+        [Fact]
         public async Task CheckForPaymentConfiguration_ShouldThrowException_WhenNoConfigFound_ForForm()
         {
             // Arrange

--- a/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
@@ -578,7 +578,7 @@ namespace form_builder_tests.UnitTests.Services
             await _service.ProcessBooking(model, page, formSchema, "guid", "path");
 
             _bookingProvider.Verify(_ => _.Reserve(It.IsAny<BookingRequest>()), Times.Never);
-            _mockMappingService.Verify(_ => _.MapBookingRequest(It.IsAny<string>(), It.IsAny<IElement>(), It.IsAny<Dictionary<string, dynamic>>(), It.IsAny<string>()), Times.Never);
+            _mockMappingService.Verify(_ => _.MapBookingRequest(It.IsAny<string>(), It.IsAny<IElement>(), It.IsAny<Dictionary<string, dynamic>>(), It.IsAny<string>()), Times.Once);
             _mockPageHelper.Verify(_ => _.SaveAnswers(It.IsAny<Dictionary<string, object>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<CustomFormFile>>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
         }
 


### PR DESCRIPTION
…, move call for create BookingRequest obj and GetBookingLocation

### Description
- add Validation method to PageHelpers to validate schema with CustomerAddressId's
- add unit tests
- move the calls to map the BookingRequest and get the BookingLocation to above the currentReservedDate checks

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary