### PR TITLE
fix(DIGITAL-4496): summary list html structure

### DIFF
--- a/src/Models/Elements/Summary.cs
+++ b/src/Models/Elements/Summary.cs
@@ -41,7 +41,7 @@ namespace form_builder.Models.Elements
                     htmlContent.AppendHtmlLine($"<dd class=\"govuk-summary-list__value\">{answer.Value}</dd>");
 
                     if (Properties != null && Properties.AllowEditing)
-                        htmlContent.AppendHtmlLine($"<dd class=\"govuk-summary-list__actions\"><a class=\"govuk-link\" href=\"{pageSummary.PageSlug}\">Change</a><span class=\"govuk-visually-hidden\">{answer.Key}</span</dd>");
+                        htmlContent.AppendHtmlLine($"<dd class=\"govuk-summary-list__actions\"><a class=\"govuk-link\" href=\"{pageSummary.PageSlug}\">Change <span class=\"govuk-visually-hidden\">{answer.Key}</span></a></dd>");
 
                     htmlContent.AppendHtmlLine("</div>");
                 }


### PR DESCRIPTION
### Description

Fix siteimprove issue due to visually hidden span not within the Change acnhor, causing the site imrpove error due to repeated links with the same 'Change' text.

span has been moved within anchor to fix issue.
![image](https://user-images.githubusercontent.com/35955528/106013247-2cfba080-60b4-11eb-85ba-dbceb4d94ce7.png)


### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary