### PR TITLE
patch: enable optional date equality flag for datebefore and dateafte…

### DIFF
--- a/src/Builders/ElementBuilder.cs
+++ b/src/Builders/ElementBuilder.cs
@@ -430,5 +430,12 @@ namespace form_builder.Builders
 
             return this;
         }
+
+        public ElementBuilder WithIsDateEqualityAllowed(bool allowed)
+        {
+            _property.IsDateEqualityAllowed = allowed;
+
+            return this;
+        }
     }
 }

--- a/src/Models/Properties/ElementProperties/DateValidatorProperty.cs
+++ b/src/Models/Properties/ElementProperties/DateValidatorProperty.cs
@@ -12,6 +12,8 @@
         
         public string IsDateAfterAbsolute { get; set; }  = string.Empty;
 
-        public string IsDateAfterValidationMessage { get; set; } = string.Empty;      
+        public string IsDateAfterValidationMessage { get; set; } = string.Empty;  
+
+        public bool IsDateEqualityAllowed { get; set; } = false;  
     }
 }

--- a/src/Validators/IsDateAfterValidator.cs
+++ b/src/Validators/IsDateAfterValidator.cs
@@ -39,7 +39,7 @@ namespace form_builder.Validators
             if (currentElementValue > comparisonElementValue) 
                 return new ValidationResult { IsValid = true };
 
-            if(currentElement.Properties.IsDateEqualityAllowed && currentElementValue == comparisonElementValue)
+            if (currentElement.Properties.IsDateEqualityAllowed && currentElementValue == comparisonElementValue)
                 return new ValidationResult { IsValid = true };
 
             return new ValidationResult {

--- a/src/Validators/IsDateAfterValidator.cs
+++ b/src/Validators/IsDateAfterValidator.cs
@@ -39,6 +39,9 @@ namespace form_builder.Validators
             if (currentElementValue > comparisonElementValue) 
                 return new ValidationResult { IsValid = true };
 
+            if(currentElement.Properties.IsDateEqualityAllowed && currentElementValue == comparisonElementValue)
+                return new ValidationResult { IsValid = true };
+
             return new ValidationResult {
                 IsValid = false,
                 Message = !string.IsNullOrEmpty(currentElement.Properties.IsDateAfterValidationMessage) 

--- a/src/Validators/IsDateBeforeValidator.cs
+++ b/src/Validators/IsDateBeforeValidator.cs
@@ -39,6 +39,9 @@ namespace form_builder.Validators
             if (currentElementValue < comparisonElementValue) 
                 return new ValidationResult { IsValid = true };
 
+            if(currentElement.Properties.IsDateEqualityAllowed && currentElementValue == comparisonElementValue)
+                return new ValidationResult { IsValid = true };
+
             return new ValidationResult {
                 IsValid = false,
                 Message = !string.IsNullOrEmpty(currentElement.Properties.IsDateBeforeValidationMessage) 
@@ -46,7 +49,7 @@ namespace form_builder.Validators
                     : string.Format(ValidationConstants.IS_DATE_AFTER_VALIDATOR_DEFAULT, currentElement.Properties.IsDateBefore)
             };
         }
-        
+
         private bool IsValidatorRelevant(IElement element, IElement comparisonElement)
         {
             if (element.Type != EElementType.DatePicker && element.Type != EElementType.DateInput)

--- a/src/Validators/IsDateBeforeValidator.cs
+++ b/src/Validators/IsDateBeforeValidator.cs
@@ -39,7 +39,7 @@ namespace form_builder.Validators
             if (currentElementValue < comparisonElementValue) 
                 return new ValidationResult { IsValid = true };
 
-            if(currentElement.Properties.IsDateEqualityAllowed && currentElementValue == comparisonElementValue)
+            if (currentElement.Properties.IsDateEqualityAllowed && currentElementValue == comparisonElementValue)
                 return new ValidationResult { IsValid = true };
 
             return new ValidationResult {


### PR DESCRIPTION
…r validators

### Description
Added the flag _IsDateEqualityAllowed_ to enable this behaviour of IsDateBefore and IsDateAfter validators. Added test, docs updated.

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary