### PR TITLE
fix(Recapcha): load recapha script only when required

### DIFF
--- a/src/Views/Shared/Recaptcha/Recaptcha.cshtml
+++ b/src/Views/Shared/Recaptcha/Recaptcha.cshtml
@@ -5,4 +5,6 @@
     var recaptchaClasses = Model ? "g-recaptcha smbc-recaptcha" : "g-recaptcha smbc-recaptcha govuk-input--error";
 }
 
-<div data-module="smbc-recaptcha" class="@recaptchaClasses" data-sitekey="@Config.Value.SiteKey"></div>
+@section Recaptcha {
+    <div data-module="smbc-recaptcha" class="@recaptchaClasses" data-sitekey="@Config.Value.SiteKey"></div>
+}

--- a/src/Views/Shared/Recaptcha/Recaptcha.cshtml
+++ b/src/Views/Shared/Recaptcha/Recaptcha.cshtml
@@ -5,6 +5,6 @@
     var recaptchaClasses = Model ? "g-recaptcha smbc-recaptcha" : "g-recaptcha smbc-recaptcha govuk-input--error";
 }
 
-@section Recaptcha {
-    <div data-module="smbc-recaptcha" class="@recaptchaClasses" data-sitekey="@Config.Value.SiteKey"></div>
-}
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
+
+<div data-module="smbc-recaptcha" class="@recaptchaClasses" data-sitekey="@Config.Value.SiteKey"></div>

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -16,10 +16,6 @@
     <link rel="shortcut icon" type="image/png" href="~/assets/images/favicon-sg.png" media="print" />
     <title>@ViewData["PageTitle"] - @ViewData["Title"] - Stockport Council</title>
     <link href="https://design-system.stockport.gov.uk/int/1/smbc-frontend.min.css" rel="stylesheet" />
-    @if (IsSectionDefined("Recaptcha"))
-    {
-        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-    }
     <partial name="TagManagerHead" />
 </head>
 

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -16,7 +16,10 @@
     <link rel="shortcut icon" type="image/png" href="~/assets/images/favicon-sg.png" media="print" />
     <title>@ViewData["PageTitle"] - @ViewData["Title"] - Stockport Council</title>
     <link href="https://design-system.stockport.gov.uk/int/1/smbc-frontend.min.css" rel="stylesheet" />
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    @if (IsSectionDefined("Recaptcha"))
+    {
+        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    }
     <partial name="TagManagerHead" />
 </head>
 


### PR DESCRIPTION
### Description
- Moved recapcha script to partial to only be loaded when required
- Fixed recapcha IE issue which was breaking other JS (Maps) when loaded first


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary