### PR TITLE
fix(Action): Added jsonconvert attribute to EActionType for JsonSubTypes

### DIFF
--- a/src/Models/Actions/IAction.cs
+++ b/src/Models/Actions/IAction.cs
@@ -5,16 +5,18 @@ using form_builder.Models.Properties.ActionProperties;
 using form_builder.Providers.EmailProvider;
 using JsonSubTypes;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace form_builder.Models.Actions
 {
     [JsonConverter(typeof(JsonSubtypes), "Type")]
     public interface IAction
     {
+        [JsonConverter(typeof(StringEnumConverter))]
         EActionType Type { get; set; }
 
         BaseActionProperty Properties { get; set; }
-
+        
         Task Process(IActionHelper actionHelper, IEmailProvider emailProvider, FormAnswers formAnswers);
     }
 }


### PR DESCRIPTION
### Description

Fixed serialisation issue with IAction type due to JsonSubTypes needing string name not enum. Added string enum converter to convert enum to string version to allow deserialisation once stored in cache.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary