### PR TITLE
refactor(booking): support for different envs in appointment type

### DIFF
--- a/src/Builders/AppointmentTypeBuilder.cs
+++ b/src/Builders/AppointmentTypeBuilder.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using form_builder.Models;
+using StockportGovUK.NetStandard.Models.Booking.Request;
+
+namespace form_builder.Builders
+{
+    public class AppointmentTypeBuilder
+    {
+        private string _environment = "test";
+        private Guid _appointmentId = Guid.NewGuid();
+        private List<BookingResource> _optionalResources = new List<BookingResource>();
+
+        public AppointmentType Build() => new AppointmentType
+        {
+            Environment = _environment,
+            AppointmentId = _appointmentId,
+            OptionalResources = _optionalResources
+        };
+
+        public AppointmentTypeBuilder WithAppointmentId(Guid value)
+        {
+            _appointmentId = value;
+
+            return this;
+        }
+
+        public AppointmentTypeBuilder WithEnvironment(string value)
+        {
+            _environment = value;
+
+            return this;
+        }
+
+        public AppointmentTypeBuilder WithOptionalResource(BookingResource resource)
+        {
+            if(_optionalResources == null)
+                _optionalResources = new List<BookingResource>();
+
+            _optionalResources.Add(resource);
+
+            return this;
+        }
+    }
+}

--- a/src/Builders/ElementBuilder.cs
+++ b/src/Builders/ElementBuilder.cs
@@ -208,23 +208,15 @@ namespace form_builder.Builders
             return this;
         }
 
-        public ElementBuilder WithAppointmentType(Guid value)
+        public ElementBuilder WithAppointmentType(AppointmentType value)
         {
-            _property.AppointmentType = value;
+            if (_property.AppointmentTypes == null)
+                _property.AppointmentTypes = new List<AppointmentType>();
+
+            _property.AppointmentTypes.Add(value);
 
             return this;
         }
-
-        public ElementBuilder WithBookingResource(BookingResource value)
-        {
-            if (_property.OptionalResources == null)
-                _property.OptionalResources = new List<BookingResource>();
-
-            _property.OptionalResources.Add(value);
-
-            return this;
-        }
-
 
         public ElementBuilder WithNumeric(bool value)
         {

--- a/src/Extensions/ListExtension.cs
+++ b/src/Extensions/ListExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using form_builder.Models;
 
 namespace form_builder.Extensions
 {
@@ -12,5 +13,7 @@ namespace form_builder.Extensions
                   ? string.Join(", ", value.Take(value.Count - 1)).ToUpper() + $" or {value.Last().ToUpper()}"
                   : value.First().ToUpper();
         }
+
+        public static AppointmentType GetAppointmentTypeForEnvironment(this List<AppointmentType> value, string environment) => value.First(_ => _.Environment.ToLower().Equals(environment.ToLower()));
     }
 }

--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -703,7 +703,7 @@ namespace form_builder.Helpers.PageHelpers
                     var appointmentTypeForEnv = booking.Properties.AppointmentTypes.FirstOrDefault(_ => _.Environment.ToLower().Equals(_environment.EnvironmentName.ToLower()) && !_.AppointmentId.Equals(Guid.Empty));
 
                     if (appointmentTypeForEnv == null)
-                        throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element requires an AppointmentTypes property with a valid AppointmentID for the environment");
+                        throw new ApplicationException("PageHelper:CheckForBookingElement, No appointment type found for current environment or empty AppointmentID");
 
                     if (appointmentTypeForEnv.OptionalResources.Any())
                     {

--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -697,12 +697,17 @@ namespace form_builder.Helpers.PageHelpers
                     if (string.IsNullOrEmpty(booking.Properties.BookingProvider))
                         throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element requires a valid booking provider property.");
 
-                    if (booking.Properties.AppointmentType == Guid.Empty)
-                        throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element requires a AppointmentType property.");
+                    if (!booking.Properties.AppointmentTypes.Any())
+                        throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element requires a AppointmentTypes property.");
 
-                    if (booking.Properties.OptionalResources.Any())
+                    var appointmentTypeForEnv = booking.Properties.AppointmentTypes.FirstOrDefault(_ => _.Environment.ToLower().Equals(_environment.EnvironmentName.ToLower()) && !_.AppointmentId.Equals(Guid.Empty));
+
+                    if (appointmentTypeForEnv == null)
+                        throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element requires an AppointmentTypes property with a valid AppointmentID for the environment");
+
+                    if (appointmentTypeForEnv.OptionalResources.Any())
                     {
-                        booking.Properties.OptionalResources.ForEach(resource =>
+                        appointmentTypeForEnv.OptionalResources.ForEach(resource =>
                         {
                             if (resource.Quantity <= 0)
                                 throw new ApplicationException("PageHelper:CheckForBookingElement, Booking element optional resources are invalid, cannot have a quantity less than 0");

--- a/src/Models/AppointmentType.cs
+++ b/src/Models/AppointmentType.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using StockportGovUK.NetStandard.Models.Booking.Request;
+
+namespace form_builder.Models
+{
+    public class AppointmentType
+    {
+        public string Environment { get; set; }
+        public Guid AppointmentId { get; set; }
+        public List<BookingResource> OptionalResources { get; set; } = new List<BookingResource>();
+    }
+}

--- a/src/Models/Properties/ElementProperties/BookingProperty.cs
+++ b/src/Models/Properties/ElementProperties/BookingProperty.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using StockportGovUK.NetStandard.Models.Booking.Request;
 
 namespace form_builder.Models.Properties.ElementProperties
 {
@@ -8,11 +6,10 @@ namespace form_builder.Models.Properties.ElementProperties
     {
         public string BookingProvider { get; set; }
         public int SearchPeriod = 12;
-        public Guid AppointmentType { get; set; }
+        public List<AppointmentType> AppointmentTypes { get; set; }  = new List<AppointmentType>();
         public bool CheckYourBooking { get; set; }
         public string AppointmentTime { get; set; }
         public string NextAvailableIAG { get; set; } = "This is the next available appointment.";
-        public List<BookingResource> OptionalResources { get; set; } = new List<BookingResource>();
         public string NoAvailableTimeForBookingType { get; set; } = "appointments";
         public string CustomerAddressId { get; set; }
     }

--- a/tests/unit-tests/Builders/AppointmentTypeBuilder.cs
+++ b/tests/unit-tests/Builders/AppointmentTypeBuilder.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using form_builder.Models;
 using StockportGovUK.NetStandard.Models.Booking.Request;
 
-namespace form_builder.Builders
+namespace form_builder_tests.Builders
 {
     public class AppointmentTypeBuilder
     {

--- a/tests/unit-tests/UnitTests/Extensions/ListExtensionsTests.cs
+++ b/tests/unit-tests/UnitTests/Extensions/ListExtensionsTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using form_builder.Extensions;
+using form_builder.Models;
+using StockportGovUK.NetStandard.Models.Booking.Request;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.Extensions
+{
+    public class ListExtensionsTests
+    {
+        [Fact]
+        public void GetAppointmentTypeForEnvironment_ShouldReturnAppointmenType_Object()
+        {
+            var id = Guid.NewGuid();
+            var testList = new List<AppointmentType>
+            {
+                new AppointmentType 
+                {
+                    Environment = "test",
+                    AppointmentId = id,
+                    OptionalResources = new List<BookingResource>{
+                        new BookingResource()
+                    }
+                }
+            };
+            var result = testList.GetAppointmentTypeForEnvironment("test");
+
+            
+            Assert.NotNull(result);
+            Assert.Equal(id, result.AppointmentId);
+            Assert.Single(result.OptionalResources);
+        }
+
+        [Fact]
+        public void GetAppointmentTypeForEnvironment_Should_Throw_Exception_When_ListDoesNotContain_Environemnt()
+        {
+            var testList = new List<AppointmentType>();
+
+            Assert.Throws<InvalidOperationException>(() => testList.GetAppointmentTypeForEnvironment("unknown-env"));
+        }
+    }
+}

--- a/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
@@ -2805,7 +2805,7 @@ namespace form_builder_tests.UnitTests.Helpers
 
             // Act
             var result = Assert.Throws<ApplicationException>(() => _pageHelper.CheckForBookingElement(pages));
-            Assert.Equal("PageHelper:CheckForBookingElement, Booking element requires an AppointmentTypes property with a valid AppointmentID for the environment", result.Message);
+            Assert.Equal("PageHelper:CheckForBookingElement, No appointment type found for current environment or empty AppointmentID", result.Message);
         }
 
         [Fact]
@@ -2834,7 +2834,7 @@ namespace form_builder_tests.UnitTests.Helpers
 
             // Act
             var result = Assert.Throws<ApplicationException>(() => _pageHelper.CheckForBookingElement(pages));
-            Assert.Equal("PageHelper:CheckForBookingElement, Booking element requires an AppointmentTypes property with a valid AppointmentID for the environment", result.Message);
+            Assert.Equal("PageHelper:CheckForBookingElement, No appointment type found for current environment or empty AppointmentID", result.Message);
         }
 
         [Fact]

--- a/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
@@ -2630,6 +2630,57 @@ namespace form_builder_tests.UnitTests.Helpers
             _pageHelper.CheckUploadedFilesSummaryQuestionsIsSet(pages);
         }
 
+        
+        [Fact]
+        public void CheckForBookingElement_Should_Not_Throw_OnValid_BookingElement()
+        {
+            // Arrange
+            var pages = new List<Page>();
+
+            var appointmentType = new AppointmentTypeBuilder()
+                .WithEnvironment("local")
+                .Build();
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Booking)
+                .WithQuestionId("booking")
+                .WithBookingProvider("TestProvider")
+                .WithAppointmentType(appointmentType)
+                .Build();
+
+            var firstname = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("firstname")
+                .WithTargetMapping("customer.firstname")
+                .Build();
+
+            var lastname = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("lastname")
+                .WithTargetMapping("customer.lastname")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var customerpage = new PageBuilder()
+                .WithElement(firstname)
+                .WithElement(lastname)
+                .Build();
+
+            var appointment = new PageBuilder()
+                .WithPageSlug(BookingConstants.NO_APPOINTMENT_AVAILABLE)
+                .Build();
+
+            pages.Add(page);
+            pages.Add(appointment);
+            pages.Add(customerpage);
+
+            // Act
+            _pageHelper.CheckForBookingElement(pages);
+        }
+
         [Fact]
         public void CheckForBookingElement_Throw_ApplicationException_WhenForm_DoenotContain_RequiredCustomerFields()
         {
@@ -2640,7 +2691,7 @@ namespace form_builder_tests.UnitTests.Helpers
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
                 .WithBookingProvider("Fake")
-                .WithAppointmentType(Guid.NewGuid())
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "local" })
                 .Build();
 
             var page = new PageBuilder()
@@ -2669,7 +2720,7 @@ namespace form_builder_tests.UnitTests.Helpers
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
                 .WithBookingProvider("Fake")
-                .WithAppointmentType(Guid.NewGuid())
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "local" })
                 .Build();
 
             var page = new PageBuilder()
@@ -2703,7 +2754,7 @@ namespace form_builder_tests.UnitTests.Helpers
 
             // Act
             var result = Assert.Throws<ApplicationException>(() => _pageHelper.CheckForBookingElement(pages));
-            Assert.Equal("PageHelper:CheckForBookingElement, Booking element requires a AppointmentType property.", result.Message);
+            Assert.Equal("PageHelper:CheckForBookingElement, Booking element requires a AppointmentTypes property.", result.Message);
         }
 
         [Fact]
@@ -2715,7 +2766,7 @@ namespace form_builder_tests.UnitTests.Helpers
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(Guid.NewGuid())
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "local" })
                 .Build();
 
             var page = new PageBuilder()
@@ -2730,17 +2781,78 @@ namespace form_builder_tests.UnitTests.Helpers
         }
 
         [Fact]
-        public void CheckForBookingElement_Throw_ApplicationException_WhenBookingElement_Contains_EmptyGuid_ForOptionalResources()
+        public void CheckForBookingElement_Throw_ApplicationException_WhenBookingElement_DoesNotContain_AppointmentTypes_ForCurrent_Env()
         {
             // Arrange
             var pages = new List<Page>();
+
+            var appointmentType = new AppointmentTypeBuilder()
+                .WithEnvironment("unknown")
+                .Build();
 
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
                 .WithBookingProvider("TestProvider")
-                .WithAppointmentType(Guid.NewGuid())
-                .WithBookingResource(new BookingResource { ResourceId = Guid.Empty, Quantity = 1 })
+                .WithAppointmentType(appointmentType)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            pages.Add(page);
+
+            // Act
+            var result = Assert.Throws<ApplicationException>(() => _pageHelper.CheckForBookingElement(pages));
+            Assert.Equal("PageHelper:CheckForBookingElement, Booking element requires an AppointmentTypes property with a valid AppointmentID for the environment", result.Message);
+        }
+
+        [Fact]
+        public void CheckForBookingElement_Throw_ApplicationException_WhenBookingElement_Contains_AppointmentTypes_ForCurrent_Env_But_Empty_AppointmentGuid()
+        {
+            // Arrange
+            var pages = new List<Page>();
+
+            var appointmentType = new AppointmentTypeBuilder()
+                .WithEnvironment("local")
+                .WithAppointmentId(Guid.Empty)
+                .Build();
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Booking)
+                .WithQuestionId("booking")
+                .WithBookingProvider("TestProvider")
+                .WithAppointmentType(appointmentType)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            pages.Add(page);
+
+            // Act
+            var result = Assert.Throws<ApplicationException>(() => _pageHelper.CheckForBookingElement(pages));
+            Assert.Equal("PageHelper:CheckForBookingElement, Booking element requires an AppointmentTypes property with a valid AppointmentID for the environment", result.Message);
+        }
+
+        [Fact]
+        public void CheckForBookingElement_Throw_ApplicationException_WhenBookingElement_Contains_EmptyGuid_ForOptionalResources()
+        {
+            // Arrange
+            var pages = new List<Page>();
+
+            var appointmentType = new AppointmentTypeBuilder()
+                .WithEnvironment("local")
+                .WithOptionalResource(new BookingResource { ResourceId = Guid.Empty, Quantity = 1 })
+                .Build();
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Booking)
+                .WithQuestionId("booking")
+                .WithBookingProvider("TestProvider")
+                .WithAppointmentType(appointmentType)
                 .Build();
 
             var page = new PageBuilder()

--- a/tests/unit-tests/UnitTests/Models/Elements/BookingTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/BookingTests.cs
@@ -37,7 +37,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                .WithType(EElementType.Booking)
                .WithBookingProvider("testBookingProvider")
                .WithQuestionId("bookingQuestion")
-               .WithAppointmentType(Guid.NewGuid())
+               .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
                .WithCheckYourBooking(true)
                .Build();
 
@@ -101,7 +101,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(Guid.NewGuid())
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
                 .WithCheckYourBooking(true)
                 .Build();
 
@@ -169,7 +169,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                .WithType(EElementType.Booking)
                .WithBookingProvider("testBookingProvider")
                .WithQuestionId("bookingQuestion")
-               .WithAppointmentType(Guid.NewGuid())
+               .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
                .WithCheckYourBooking(true)
                .Build();
 
@@ -248,7 +248,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(Guid.NewGuid())
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
                 .WithCheckYourBooking(true)
                 .Build();
 
@@ -327,7 +327,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(Guid.NewGuid())
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
                 .WithCheckYourBooking(true)
                 .Build();
 
@@ -391,7 +391,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(Guid.NewGuid())
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
                 .WithCheckYourBooking(true)
                 .Build();
 
@@ -457,7 +457,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(Guid.NewGuid())
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
                 .WithCheckYourBooking(true)
                 .WithNoAvailableTimeForBookingType("test")
                 .Build();
@@ -535,7 +535,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(Guid.NewGuid())
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
                 .WithCheckYourBooking(true)
                 .WithNoAvailableTimeForBookingType("test2")
                 .Build();

--- a/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
@@ -20,6 +20,7 @@ using form_builder.Services.BookingService.Entities;
 using form_builder.Services.MappingService;
 using form_builder.Services.PageService.Entities;
 using form_builder_tests.Builders;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
 using StockportGovUK.NetStandard.Models.Booking.Request;
@@ -39,8 +40,8 @@ namespace form_builder_tests.UnitTests.Services
         private readonly Mock<IPageFactory> _mockPageFactory = new Mock<IPageFactory>();
         private readonly Mock<IMappingService> _mockMappingService = new Mock<IMappingService>();
         private readonly Mock<IOptions<DistributedCacheExpirationConfiguration>> _mockdistributedCacheExpirationConfiguration = new Mock<IOptions<DistributedCacheExpirationConfiguration>>();
+        private readonly Mock<IWebHostEnvironment> _mockHostingEnv = new Mock<IWebHostEnvironment>();
         private readonly DistributedCacheExpirationConfiguration _cacheConfig = new DistributedCacheExpirationConfiguration { Booking = 5, BookingNoAppointmentsAvailable = 10 };
-
         public BookingServiceTests()
         {
             _mockdistributedCacheExpirationConfiguration.Setup(_ => _.Value).Returns(_cacheConfig);
@@ -53,12 +54,15 @@ namespace form_builder_tests.UnitTests.Services
                 _bookingProvider.Object
             };
 
+            _mockHostingEnv.Setup(_ => _.EnvironmentName).Returns("test");
+
             _service = new BookingService(
               _mockDistributedCache.Object,
               _mockPageHelper.Object,
               _bookingProviders,
               _mockPageFactory.Object,
               _mockMappingService.Object,
+              _mockHostingEnv.Object,
               _mockdistributedCacheExpirationConfiguration.Object);
         }
 
@@ -105,7 +109,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(guid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = guid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -146,12 +150,16 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals("guid"))))
                 .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new FormAnswers { FormData = new Dictionary<string, object>() }));
 
+            var appointmentType = new AppointmentTypeBuilder()
+                .WithAppointmentId(guid)
+                .WithOptionalResource(new BookingResource { ResourceId = bookingResourceId, Quantity = bookingResourceQuantity })
+                .Build();
+
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(guid)
-                .WithBookingResource(new BookingResource { ResourceId = bookingResourceId, Quantity = bookingResourceQuantity })
+                .WithAppointmentType(appointmentType)
                 .Build();
 
             var page = new PageBuilder()
@@ -190,7 +198,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(guid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = guid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -229,7 +237,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(guid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = guid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -268,7 +276,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(guid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = guid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -296,7 +304,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(guid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = guid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -326,7 +334,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(guid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = guid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -360,7 +368,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(guid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = guid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -399,7 +407,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(guid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = guid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -429,7 +437,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(appointmentTypeGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = appointmentTypeGuid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -469,7 +477,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(appointmentTypeGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = appointmentTypeGuid, Environment = "test" })
                 .WithCheckYourBooking(false)
                 .Build();
 
@@ -511,7 +519,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(appointmentTypeGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = appointmentTypeGuid, Environment = "test" })
                 .WithCheckYourBooking(true)
                 .Build();
 
@@ -550,7 +558,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(appointmentTypeGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = appointmentTypeGuid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -591,7 +599,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(appointmentTypeGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = appointmentTypeGuid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -634,7 +642,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(appointmentTypeGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = appointmentTypeGuid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()
@@ -674,7 +682,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(appointmentTypeGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = appointmentTypeGuid, Environment = "test" })
                 .Build();
 
             var page = new PageBuilder()

--- a/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
@@ -14,6 +14,7 @@ using form_builder.Providers.SchemaProvider;
 using form_builder.Providers.StorageProvider;
 using form_builder.Services.MappingService;
 using form_builder_tests.Builders;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -32,6 +33,7 @@ namespace form_builder_tests.UnitTests.Services
         private readonly Mock<IElementMapper> _mockElementMapper = new Mock<IElementMapper>();
         private readonly Mock<ISchemaFactory> _mockSchemaFactory = new Mock<ISchemaFactory>();
         private readonly Mock<ILogger<MappingService>> _mockLogger = new Mock<ILogger<MappingService>>();
+        private readonly Mock<IWebHostEnvironment> _mockHostingEnv = new Mock<IWebHostEnvironment>();
         private readonly Mock<IOptions<DistributedCacheExpirationConfiguration>> _mockDistributedCacheExpirationConfiguration = new Mock<IOptions<DistributedCacheExpirationConfiguration>>();
 
         public MappingServiceTests()
@@ -68,7 +70,9 @@ namespace form_builder_tests.UnitTests.Services
             _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
-            _service = new MappingService(_mockDistrubutedCache.Object, _mockElementMapper.Object, _mockSchemaFactory.Object, _mockDistributedCacheExpirationConfiguration.Object, _mockLogger.Object);
+            _mockHostingEnv.Setup(_ => _.EnvironmentName).Returns("test");
+
+            _service = new MappingService(_mockDistrubutedCache.Object, _mockElementMapper.Object, _mockSchemaFactory.Object, _mockHostingEnv.Object, _mockDistributedCacheExpirationConfiguration.Object, _mockLogger.Object);
         }
 
         [Fact]
@@ -576,7 +580,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(bookingGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "test" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {
@@ -666,7 +670,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
                 .WithCustomerAddressId("address")
-                .WithAppointmentType(bookingGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "test" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {
@@ -714,7 +718,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(bookingGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "test" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {
@@ -755,7 +759,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(bookingGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "test" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {
@@ -792,7 +796,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(bookingGuid)
+                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "test" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {


### PR DESCRIPTION
### Description
Updated structure for apointment type within booking element to allow for different values across environments. Additionally to this moved OptionalResoucres to allow for different values within env aswell.

Updated wiki:
https://github.com/smbc-digital/form-builder/wiki/Booking

**old**
```json
{
          "Type": "Booking",
          "Properties": {
            "AppointmentType":"0000-0000-0000-0000-0000",
            "OptionalResources": [
             {
                 "ResourceId": "0000-0000-0000-0000-0000",
                 "Quantity": 1
              }
           ]
          }
        },
```

**new**
```json
 {
                    "Type": "Booking",
                    "Properties": {
                        "AppointmentTypes": [
                            {
                                "Environment": "local",
                                "AppointmentId":"0000-0000-0000-0000-0000",
                                "OptionalResources": [ 
                                 {
                                     "ResourceId": "0000-0000-0000-0000-0000",
                                     "Quantity": 1
                                }
                               ]
                            }
                        ]
                    }
                },
```
### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary