### PR TITLE
fix(ElementHelper): use Page Title as Summary label for Address, Stre…

### DIFF
--- a/src/ContentFactory/SuccessPageFactory/SuccessPageFactory.cs
+++ b/src/ContentFactory/SuccessPageFactory/SuccessPageFactory.cs
@@ -9,6 +9,7 @@ using form_builder.Models;
 using form_builder.Models.Elements;
 using form_builder.Providers.StorageProvider;
 using form_builder.Services.PageService.Entities;
+using Microsoft.AspNetCore.Hosting;
 
 namespace form_builder.ContentFactory.SuccessPageFactory
 {
@@ -18,12 +19,16 @@ namespace form_builder.ContentFactory.SuccessPageFactory
         private readonly IPageFactory _pageFactory;
         private readonly ISessionHelper _sessionHelper;
         private readonly IDistributedCacheWrapper _distributedCache;
-        public SuccessPageFactory(IPageHelper pageHelper, IPageFactory pageFactory, ISessionHelper sessionHelper, IDistributedCacheWrapper distributedCache)
+        private readonly IWebHostEnvironment _environment;
+        public SuccessPageFactory(IPageHelper pageHelper, IPageFactory pageFactory,
+            ISessionHelper sessionHelper, IDistributedCacheWrapper distributedCache,
+            IWebHostEnvironment environment)
         {
             _pageHelper = pageHelper;
             _pageFactory = pageFactory;
             _sessionHelper = sessionHelper;
             _distributedCache = distributedCache;
+            _environment = environment;
         }
 
         public async Task<SuccessPageEntity> Build(string form, FormSchema baseForm, string sessionGuid, FormAnswers formAnswers, EBehaviourType behaviourType)
@@ -55,12 +60,13 @@ namespace form_builder.ContentFactory.SuccessPageFactory
 
             if (baseForm.DocumentDownload)
             {
-                baseForm.DocumentType.ForEach((docType) =>
+                var sourceBase = _environment.EnvironmentName.Equals("local") ? "/document/Summary" : "/v2/document/Summary";
+                baseForm.DocumentType.ForEach(docType =>
                 {
                     var element = new ElementBuilder()
                         .WithType(EElementType.DocumentDownload)
                         .WithLabel($"Download {docType} document")
-                        .WithSource($"/v2/document/Summary/{docType}/{sessionGuid}")
+                        .WithSource($"{sourceBase}/{docType}/{sessionGuid}")
                         .WithDocumentType(docType)
                         .Build();
 

--- a/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
+++ b/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
@@ -26,19 +26,7 @@ namespace form_builder.Helpers.DocumentCreation
                 formSchemaQuestions.ForEach(question =>
                 {
                     var answer = _elementMapper.GetAnswerStringValue(question, formAnswers);
-
-                    if (question.Type.Equals(EElementType.Address)
-                        || question.Type.Equals(EElementType.Street)
-                        || question.Type.Equals(EElementType.Organisation))
-                    {
-                        summaryBuilder.Add(
-                            $"{page.Title}{(question.Properties.Optional ? " (optional)" : string.Empty)}", answer,
-                            question.Type);
-                    }
-                    else
-                    {
-                        summaryBuilder.Add(question.GetLabelText(), answer, question.Type);
-                    }
+                    summaryBuilder.Add(question.GetLabelText(page.Title), answer, question.Type);
 
                     summaryBuilder.AddBlankLine();
                 });

--- a/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
+++ b/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
@@ -16,13 +16,17 @@ namespace form_builder.Helpers.DocumentCreation
         {
             var summaryBuilder = new SummaryAnswerBuilder();
 
-            var formSchemaQuestions = formSchema.Pages
-                .Where(_ => _.Elements != null)
-                .SelectMany(_ => _.ValidatableElements)
-                .ToList();
+            //var formSchemaQuestions = formSchema.Pages
+            //    .Where(_ => _.Elements != null)
+            //    .SelectMany(_ => _.ValidatableElements)
+            //    .ToList();
 
             formSchema.Pages.ForEach(page =>
             {
+                var formSchemaQuestions = page.ValidatableElements
+                    .Where(_ => _ != null)
+                    .ToList();
+
                 formSchemaQuestions.ForEach(question =>
                 {
                     var answer = _elementMapper.GetAnswerStringValue(question, formAnswers);

--- a/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
+++ b/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
@@ -16,11 +16,6 @@ namespace form_builder.Helpers.DocumentCreation
         {
             var summaryBuilder = new SummaryAnswerBuilder();
 
-            //var formSchemaQuestions = formSchema.Pages
-            //    .Where(_ => _.Elements != null)
-            //    .SelectMany(_ => _.ValidatableElements)
-            //    .ToList();
-
             formSchema.Pages.ForEach(page =>
             {
                 var formSchemaQuestions = page.ValidatableElements

--- a/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
+++ b/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using form_builder.Builders.Document;
+using form_builder.Enum;
 using form_builder.Mappers;
 using form_builder.Models;
 
@@ -15,18 +16,32 @@ namespace form_builder.Helpers.DocumentCreation
         {
             var summaryBuilder = new SummaryAnswerBuilder();
 
-            var formSchemaQuestions = formSchema.Pages.ToList()
+            var formSchemaQuestions = formSchema.Pages
                 .Where(_ => _.Elements != null)
                 .SelectMany(_ => _.ValidatableElements)
                 .ToList();
 
-            formSchemaQuestions.ForEach(question =>
+            formSchema.Pages.ForEach(page =>
             {
-                var answer = _elementMapper.GetAnswerStringValue(question, formAnswers);
+                formSchemaQuestions.ForEach(question =>
+                {
+                    var answer = _elementMapper.GetAnswerStringValue(question, formAnswers);
 
-                summaryBuilder.Add(question.GetLabelText(), answer, question.Type);
+                    if (question.Type.Equals(EElementType.Address)
+                        || question.Type.Equals(EElementType.Street)
+                        || question.Type.Equals(EElementType.Organisation))
+                    {
+                        summaryBuilder.Add(
+                            $"{page.Title}{(question.Properties.Optional ? " (optional)" : string.Empty)}", answer,
+                            question.Type);
+                    }
+                    else
+                    {
+                        summaryBuilder.Add(question.GetLabelText(), answer, question.Type);
+                    }
 
-                summaryBuilder.AddBlankLine();
+                    summaryBuilder.AddBlankLine();
+                });
             });
 
             return summaryBuilder.Build();

--- a/src/Helpers/ElementHelpers/ElementHelper.cs
+++ b/src/Helpers/ElementHelpers/ElementHelper.cs
@@ -220,16 +220,7 @@ namespace form_builder.Helpers.ElementHelpers
                 formSchemaQuestions.ForEach(question =>
                 {
                     var answer = _elementMapper.GetAnswerStringValue(question, formAnswers);
-                    if (question.Type.Equals(EElementType.Address)
-                        || question.Type.Equals(EElementType.Street)
-                        || question.Type.Equals(EElementType.Organisation))
-                    {
-                        summaryBuilder.Add($"{page.Title}{(question.Properties.Optional ? " (optional)" : string.Empty)}", answer, question.Type);
-                    }
-                    else
-                    {
-                        summaryBuilder.Add(question.GetLabelText(), answer, question.Type);
-                    }
+                    summaryBuilder.Add(question.GetLabelText(page.Title), answer, question.Type);
                 });
 
                 pageSummary.Answers = summaryBuilder.Build();

--- a/src/Helpers/ElementHelpers/ElementHelper.cs
+++ b/src/Helpers/ElementHelpers/ElementHelper.cs
@@ -220,7 +220,16 @@ namespace form_builder.Helpers.ElementHelpers
                 formSchemaQuestions.ForEach(question =>
                 {
                     var answer = _elementMapper.GetAnswerStringValue(question, formAnswers);
-                    summaryBuilder.Add(question.GetLabelText(), answer, question.Type);
+                    if (question.Type.Equals(EElementType.Address)
+                        || question.Type.Equals(EElementType.Street)
+                        || question.Type.Equals(EElementType.Organisation))
+                    {
+                        summaryBuilder.Add($"{page.Title}{(question.Properties.Optional ? " (optional)" : string.Empty)}", answer, question.Type);
+                    }
+                    else
+                    {
+                        summaryBuilder.Add(question.GetLabelText(), answer, question.Type);
+                    }
                 });
 
                 pageSummary.Answers = summaryBuilder.Build();

--- a/src/Models/Elements/Address.cs
+++ b/src/Models/Elements/Address.cs
@@ -45,6 +45,8 @@ namespace form_builder.Models.Elements
             }
         }
 
+        public override string GetLabelText(string pageTitle) => $"{pageTitle}{(Properties.Optional ? " (optional)" : string.Empty)}";
+
         public Address()
         {
             Type = EElementType.Address;

--- a/src/Models/Elements/Address.cs
+++ b/src/Models/Elements/Address.cs
@@ -45,8 +45,6 @@ namespace form_builder.Models.Elements
             }
         }
 
-        public override string GetLabelText() => $"Address{(Properties.Optional ? " (optional)" : string.Empty)}";
-
         public Address()
         {
             Type = EElementType.Address;

--- a/src/Models/Elements/Booking.cs
+++ b/src/Models/Elements/Booking.cs
@@ -45,7 +45,7 @@ namespace form_builder.Models.Elements
         public bool DisplayNextMonthArrow => NextSelectableMonth <= new DateTime(DateTime.Now.Year, DateTime.Now.Month, 1).AddMonths(Properties.SearchPeriod);
         [JsonIgnore]
         public bool DisplayPreviousMonthArrow => new DateTime(CurrentSelectedMonth.Date.Year, CurrentSelectedMonth.Date.Month, 1) > FirstAvailableMonth;
-        public override string GetLabelText() => $"Booking{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public override string GetLabelText(string pageTitle) => $"Booking{(Properties.Optional ? " (optional)" : string.Empty)}";
         public string FormName { get; set; }
         public string ReservedBookingId { get; set; }
         public string ReservedBookingDate { get; set; }

--- a/src/Models/Elements/Element.cs
+++ b/src/Models/Elements/Element.cs
@@ -115,6 +115,6 @@ namespace form_builder.Models.Elements
 
         private bool DisplayOptional => Properties.Optional;
 
-        public virtual string GetLabelText() => $"{Properties.Label}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public virtual string GetLabelText(string pageTitle) => $"{Properties.Label}{(Properties.Optional ? " (optional)" : string.Empty)}";
     }
 }

--- a/src/Models/Elements/IElement.cs
+++ b/src/Models/Elements/IElement.cs
@@ -40,6 +40,6 @@ namespace form_builder.Models.Elements
 
         string GenerateFieldsetProperties();
 
-        string GetLabelText();
+        string GetLabelText(string pageTitle);
     }
 }

--- a/src/Models/Elements/Map.cs
+++ b/src/Models/Elements/Map.cs
@@ -34,6 +34,6 @@ namespace form_builder.Models.Elements
             return viewRender.RenderAsync(Type.ToString(), this);
         }
 
-        public override string GetLabelText() => "Map";
+        public override string GetLabelText(string pageTitle) => "Map";
     }
 }

--- a/src/Models/Elements/Organisation.cs
+++ b/src/Models/Elements/Organisation.cs
@@ -43,6 +43,8 @@ namespace form_builder.Models.Elements
             }
         }
 
+        public override string GetLabelText(string pageTitle) => $"{pageTitle}{(Properties.Optional ? " (optional)" : string.Empty)}";
+
         public Organisation()
         {
             Type = EElementType.Organisation;

--- a/src/Models/Elements/Street.cs
+++ b/src/Models/Elements/Street.cs
@@ -43,8 +43,6 @@ namespace form_builder.Models.Elements
             }
         }
 
-        public override string GetLabelText() => $"Street{(Properties.Optional ? " (optional)" : string.Empty)}";
-
         public Street()
         {
             Type = EElementType.Street;

--- a/src/Models/Elements/Street.cs
+++ b/src/Models/Elements/Street.cs
@@ -43,6 +43,8 @@ namespace form_builder.Models.Elements
             }
         }
 
+        public override string GetLabelText(string pageTitle) => $"{pageTitle}{(Properties.Optional ? " (optional)" : string.Empty)}";
+
         public Street()
         {
             Type = EElementType.Street;

--- a/tests/unit-tests/UnitTests/ContentFactory/SuccessPageContentFactoryTests.cs
+++ b/tests/unit-tests/UnitTests/ContentFactory/SuccessPageContentFactoryTests.cs
@@ -13,6 +13,7 @@ using form_builder.Models.Elements;
 using form_builder.Providers.StorageProvider;
 using form_builder.ViewModels;
 using form_builder_tests.Builders;
+using Microsoft.AspNetCore.Hosting;
 using Moq;
 using Xunit;
 
@@ -25,6 +26,7 @@ namespace form_builder_tests.UnitTests.ContentFactory
         private readonly Mock<IPageFactory> _mockPageContentFactory = new Mock<IPageFactory>();
         private readonly Mock<ISessionHelper> _mockSessionHelper = new Mock<ISessionHelper>();
         private readonly Mock<IDistributedCacheWrapper> _mockDistributedCache = new Mock<IDistributedCacheWrapper>();
+        private readonly Mock<IWebHostEnvironment> _mockWebHostEnvironment = new Mock<IWebHostEnvironment>();
 
         public SuccessPageContentFactoryTests()
         {
@@ -32,7 +34,10 @@ namespace form_builder_tests.UnitTests.ContentFactory
                 _mockPageHelper.Object,
                 _mockPageContentFactory.Object,
                 _mockSessionHelper.Object,
-                _mockDistributedCache.Object);
+                _mockDistributedCache.Object,
+                _mockWebHostEnvironment.Object);
+
+            _mockWebHostEnvironment.Setup(_ => _.EnvironmentName).Returns("local");
         }
 
         private static readonly Page Page = new PageBuilder()

--- a/tests/unit-tests/UnitTests/Helpers/DocumentCreationHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/DocumentCreationHelperTests.cs
@@ -101,6 +101,42 @@ namespace form_builder_tests.UnitTests.Helpers
             Assert.Equal($"{labelText}: {value}", result[0]);
         }
 
+        [Theory]
+        [InlineData(EElementType.Address)]
+        [InlineData(EElementType.Street)]
+        [InlineData(EElementType.Organisation)]
+        public void GenerateQuestionAndAnswersList_ShouldReturn_TitleAsLabel_For_ElementType(EElementType type)
+        {
+            // Arrange
+            var value = "value";
+            _mockElementMapper
+                .Setup(_ => _.GetAnswerStringValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()))
+                .Returns(value);
+
+            var formAnswers = new FormAnswers { Pages = new List<PageAnswers>() };
+            var titleText = "I am a title";
+
+            var element = new ElementBuilder()
+                .WithType(type)
+                .WithQuestionId("testQuestion")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithPageTitle(titleText)
+                .Build();
+
+            var formSchema = new FormSchemaBuilder()
+                .WithPage(page)
+                .Build();
+
+            // Act
+            var result = _documentCreation.GenerateQuestionAndAnswersList(formAnswers, formSchema);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal($"{titleText}: {value}", result[0]);
+        }
+
         [Fact]
         public void GenerateQuestionAndAnswersList_ShouldReturn_ListOfMultipleItems()
         {

--- a/tests/unit-tests/UnitTests/Helpers/ElementHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/ElementHelperTests.cs
@@ -659,6 +659,45 @@ namespace form_builder_tests.UnitTests.Helpers
             Assert.Single(result);
         }
 
+        [Theory]
+        [InlineData(EElementType.Address, "Address Title")]
+        [InlineData(EElementType.Street, "Street title")]
+        [InlineData(EElementType.Organisation, "Organisation title")]
+        public void GenerateQuestionAndAnswersList_ShouldReturnFormSummary_WithPageTitleAsLabel(EElementType type, string title)
+        {
+            _mockDistributedCacheWrapper.Setup(_ => _.GetString(It.IsAny<string>()))
+                .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new FormAnswers { Pages = new List<PageAnswers> { new PageAnswers { PageSlug = "page-one", Answers = new List<Answers> { new Answers { QuestionId = "question", Response = "test answer" } } } } }));
+
+            _mockElementMapper
+                .Setup(_ => _.GetAnswerStringValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()))
+                .Returns("address");
+
+            var behaviour = new BehaviourBuilder()
+                .WithBehaviourType(EBehaviourType.SubmitForm)
+                .Build();
+
+            var element = new ElementBuilder()
+                .WithQuestionId("question")
+                .WithType(type)
+                .WithAddressProvider("testProvider")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithPageSlug("page-one")
+                .WithBehaviour(behaviour)
+                .WithPageTitle(title)
+                .Build();
+
+            var formSchema = new FormSchemaBuilder()
+                .WithPage(page)
+                .Build();
+
+            var result = _elementHelper.GenerateQuestionAndAnswersList("12345", formSchema);
+
+            Assert.NotNull(result[0].Answers[title]);
+        }
+
         [Fact]
         public void GenerateValidDocumentUploadUrl_ShouldReturnUrlWithCaseRefEncoded()
         {


### PR DESCRIPTION
…et, Organisation. Also for DocumentCreation

### Description
Amend logic in ElementHelper and DocumentCreationHelper to use the page title as the Summary key for Address, Street, and Organisation Element types.
Remove unused GetLabelText from Address and Street Element
Add unit tests

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary