### PR TITLE
feat(deserialise_form_stream): S3 as Stream

### DIFF
--- a/src/Providers/SchemaProvider/S3FileSchemaProvider.cs
+++ b/src/Providers/SchemaProvider/S3FileSchemaProvider.cs
@@ -52,12 +52,11 @@ namespace form_builder.Providers.SchemaProvider
             {
                 var s3Result = await _s3Gateway.GetObject(_configuration["S3BucketKey"], $"{_environment.EnvironmentName.ToS3EnvPrefix()}/{_configuration["ApplicationVersion"]}/{schemaName}.json");
 
-                using (Stream responseStream = s3Result.ResponseStream)
-                using (StreamReader reader = new StreamReader(responseStream))
-                {
-                    var responseBody = reader.ReadToEnd();
-                    return JsonConvert.DeserializeObject<T>(responseBody);
-                }
+                using Stream responseStream = s3Result.ResponseStream;
+                using StreamReader sr = new(responseStream);
+                using JsonReader reader = new JsonTextReader(sr);
+                JsonSerializer serializer = new();
+                return serializer.Deserialize<T>(reader);
             }
             catch (AmazonS3Exception e)
             {

--- a/src/Providers/Transforms/Lookups/S3LookupTransformDataProvider.cs
+++ b/src/Providers/Transforms/Lookups/S3LookupTransformDataProvider.cs
@@ -29,12 +29,11 @@ namespace form_builder.Providers.Transforms.Lookups
             {
                 var s3Result = await _s3Gateway.GetObject(_configuration["S3BucketKey"], $"{_environment.EnvironmentName.ToS3EnvPrefix()}/Lookups/{schemaName}.json");
 
-                using (Stream responseStream = s3Result.ResponseStream)
-                using (StreamReader reader = new StreamReader(responseStream))
-                {
-                    var responseBody = reader.ReadToEnd();
-                    return JsonConvert.DeserializeObject<T>(responseBody);
-                }
+                using Stream responseStream = s3Result.ResponseStream;
+                using StreamReader sr = new(responseStream);
+                using JsonReader reader = new JsonTextReader(sr);
+                JsonSerializer serializer = new();
+                return serializer.Deserialize<T>(reader);
             }
             catch (AmazonS3Exception e)
             {

--- a/src/Providers/Transforms/PaymentConfiguration/S3PaymentConfigurationTransformDataProvider.cs
+++ b/src/Providers/Transforms/PaymentConfiguration/S3PaymentConfigurationTransformDataProvider.cs
@@ -29,12 +29,11 @@ namespace form_builder.Providers.Transforms.PaymentConfiguration
             {
                 var s3Result = await _s3Gateway.GetObject(_configuration["S3BucketKey"], $"{_environment.EnvironmentName.ToS3EnvPrefix()}/payment-config/paymentconfiguration.{_environment.EnvironmentName}.json");
 
-                using (Stream responseStream = s3Result.ResponseStream)
-                using (StreamReader reader = new StreamReader(responseStream))
-                {
-                    var responseBody = reader.ReadToEnd();
-                    return JsonConvert.DeserializeObject<T>(responseBody);
-                }
+                using Stream responseStream = s3Result.ResponseStream;
+                using StreamReader sr = new(responseStream);
+                using JsonReader reader = new JsonTextReader(sr);
+                JsonSerializer serializer = new();
+                return serializer.Deserialize<T>(reader);
             }
             catch (AmazonS3Exception e)
             {

--- a/src/Providers/Transforms/ReusableElements/S3ReusableElementTransformDataProvider.cs
+++ b/src/Providers/Transforms/ReusableElements/S3ReusableElementTransformDataProvider.cs
@@ -31,12 +31,11 @@ namespace form_builder.Providers.Transforms.ReusableElements
             {
                 var s3Result = await _s3Gateway.GetObject(_configuration["S3BucketKey"], $"{_environment.EnvironmentName.ToS3EnvPrefix()}/Elements/{schemaName}.json");
 
-                using (Stream responseStream = s3Result.ResponseStream)
-                using (StreamReader reader = new StreamReader(responseStream))
-                {
-                    var responseBody = reader.ReadToEnd();
-                    return JsonConvert.DeserializeObject<Element>(responseBody);
-                }
+                using Stream responseStream = s3Result.ResponseStream;
+                using StreamReader sr = new(responseStream);
+                using JsonReader reader = new JsonTextReader(sr);
+                JsonSerializer serializer = new();
+                return serializer.Deserialize<IElement>(reader);
             }
             catch (AmazonS3Exception e)
             {


### PR DESCRIPTION
### Description
Changed to deserialse from stream when calling json from S3 Buckets

You can test by editing the line of the schema provider
1) Service Collection Extensions > AddSchemaProvider > change "local" to use S3FileSchemaProvider
2) Then edit line S3FileSchemaProvider -Line 51:  var s3Result = await _s3Gateway.GetObject("forms-storage", $"Int/{_configuration["ApplicationVersion"]}/{schemaName}.json");
3) Load up a few forms and check it works...

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary