### PR TITLE
feat(summary): ability to allow custom labels to be used on summary

### DIFF
--- a/src/Builders/ElementBuilder.cs
+++ b/src/Builders/ElementBuilder.cs
@@ -6,7 +6,6 @@ using form_builder.Enum;
 using form_builder.Models;
 using form_builder.Models.Elements;
 using form_builder.Models.Properties.ElementProperties;
-using StockportGovUK.NetStandard.Models.Booking.Request;
 
 namespace form_builder.Builders
 {
@@ -426,6 +425,13 @@ namespace form_builder.Builders
         public ElementBuilder WithIsDateEqualityAllowed(bool allowed)
         {
             _property.IsDateEqualityAllowed = allowed;
+
+            return this;
+        }
+
+        public ElementBuilder WithSummaryLabel(string value)
+        {
+            _property.SummaryLabel = value;
 
             return this;
         }

--- a/src/Factories/Transform/ReusableElements/ReusableElementSchemaTransformFactory.cs
+++ b/src/Factories/Transform/ReusableElements/ReusableElementSchemaTransformFactory.cs
@@ -84,6 +84,9 @@ namespace form_builder.Factories.Transform.ReusableElements
             if (!string.IsNullOrEmpty(reusableElement.Properties.CustomValidationMessage))
                 substituteElement.Properties.CustomValidationMessage = reusableElement.Properties.CustomValidationMessage;
 
+            if (!string.IsNullOrEmpty(reusableElement.Properties.SummaryLabel))
+                substituteElement.Properties.SummaryLabel = reusableElement.Properties.SummaryLabel;
+
             return substituteElement;
         }
 

--- a/src/Models/Elements/Address.cs
+++ b/src/Models/Elements/Address.cs
@@ -45,7 +45,8 @@ namespace form_builder.Models.Elements
             }
         }
 
-        public override string GetLabelText(string pageTitle) => $"{pageTitle}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        
 
         public Address()
         {

--- a/src/Models/Elements/Address.cs
+++ b/src/Models/Elements/Address.cs
@@ -45,7 +45,7 @@ namespace form_builder.Models.Elements
             }
         }
 
-        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{GetIsOptionalLabelText()}";
         
 
         public Address()

--- a/src/Models/Elements/Booking.cs
+++ b/src/Models/Elements/Booking.cs
@@ -45,7 +45,7 @@ namespace form_builder.Models.Elements
         public bool DisplayNextMonthArrow => NextSelectableMonth <= new DateTime(DateTime.Now.Year, DateTime.Now.Month, 1).AddMonths(Properties.SearchPeriod);
         [JsonIgnore]
         public bool DisplayPreviousMonthArrow => new DateTime(CurrentSelectedMonth.Date.Year, CurrentSelectedMonth.Date.Month, 1) > FirstAvailableMonth;
-        public override string GetLabelText(string pageTitle) => $"Booking{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? "Booking" : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
         public string FormName { get; set; }
         public string ReservedBookingId { get; set; }
         public string ReservedBookingDate { get; set; }

--- a/src/Models/Elements/Booking.cs
+++ b/src/Models/Elements/Booking.cs
@@ -45,7 +45,7 @@ namespace form_builder.Models.Elements
         public bool DisplayNextMonthArrow => NextSelectableMonth <= new DateTime(DateTime.Now.Year, DateTime.Now.Month, 1).AddMonths(Properties.SearchPeriod);
         [JsonIgnore]
         public bool DisplayPreviousMonthArrow => new DateTime(CurrentSelectedMonth.Date.Year, CurrentSelectedMonth.Date.Month, 1) > FirstAvailableMonth;
-        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? "Booking" : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? "Booking" : Properties.SummaryLabel)}{GetIsOptionalLabelText()}";
         public string FormName { get; set; }
         public string ReservedBookingId { get; set; }
         public string ReservedBookingDate { get; set; }

--- a/src/Models/Elements/Element.cs
+++ b/src/Models/Elements/Element.cs
@@ -115,6 +115,6 @@ namespace form_builder.Models.Elements
 
         private bool DisplayOptional => Properties.Optional;
 
-        public virtual string GetLabelText(string pageTitle) => $"{Properties.Label}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public virtual string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? Properties.Label : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
     }
 }

--- a/src/Models/Elements/Element.cs
+++ b/src/Models/Elements/Element.cs
@@ -115,6 +115,8 @@ namespace form_builder.Models.Elements
 
         private bool DisplayOptional => Properties.Optional;
 
-        public virtual string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? Properties.Label : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public virtual string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? Properties.Label : Properties.SummaryLabel)}{GetIsOptionalLabelText()}";
+
+        protected string GetIsOptionalLabelText() => $"{(Properties.Optional ? " (optional)" : string.Empty)}";
     }
 }

--- a/src/Models/Elements/Map.cs
+++ b/src/Models/Elements/Map.cs
@@ -34,6 +34,6 @@ namespace form_builder.Models.Elements
             return viewRender.RenderAsync(Type.ToString(), this);
         }
 
-        public override string GetLabelText(string pageTitle) => "Map";
+        public override string GetLabelText(string pageTitle) => string.IsNullOrEmpty(Properties.SummaryLabel) ? "Map" : Properties.SummaryLabel;
     }
 }

--- a/src/Models/Elements/Organisation.cs
+++ b/src/Models/Elements/Organisation.cs
@@ -43,7 +43,7 @@ namespace form_builder.Models.Elements
             }
         }
 
-        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{GetIsOptionalLabelText()}";
 
         public Organisation()
         {

--- a/src/Models/Elements/Organisation.cs
+++ b/src/Models/Elements/Organisation.cs
@@ -43,7 +43,7 @@ namespace form_builder.Models.Elements
             }
         }
 
-        public override string GetLabelText(string pageTitle) => $"{pageTitle}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
 
         public Organisation()
         {

--- a/src/Models/Elements/Street.cs
+++ b/src/Models/Elements/Street.cs
@@ -43,7 +43,7 @@ namespace form_builder.Models.Elements
             }
         }
 
-        public override string GetLabelText(string pageTitle) => $"{pageTitle}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
 
         public Street()
         {

--- a/src/Models/Elements/Street.cs
+++ b/src/Models/Elements/Street.cs
@@ -43,7 +43,7 @@ namespace form_builder.Models.Elements
             }
         }
 
-        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{(Properties.Optional ? " (optional)" : string.Empty)}";
+        public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{GetIsOptionalLabelText()}";
 
         public Street()
         {

--- a/src/Models/Properties/ElementProperties/BaseProperty.cs
+++ b/src/Models/Properties/ElementProperties/BaseProperty.cs
@@ -67,5 +67,7 @@ namespace form_builder.Models.Properties.ElementProperties
         public bool isConditionalElement { get; set; } = false;
 
         public bool OrderOptionsAlphabetically { get; set; } = false;
+
+        public string SummaryLabel {get;set;} = string.Empty;
     }
 }

--- a/tests/unit-tests/UnitTests/Factories/Transform/ReusableElementSchemaTransformFactoryTests.cs
+++ b/tests/unit-tests/UnitTests/Factories/Transform/ReusableElementSchemaTransformFactoryTests.cs
@@ -257,6 +257,50 @@ namespace form_builder_tests.UnitTests.Factories.Transform
         }
 
         [Fact]
+        public async Task Transform_ShouldCall_TransformDataProvider_And_ShouldUpdate_SummaryLabel_WhenSupplied()
+        {
+            // Arrange
+            var summaryLabel = "custom summary label";
+            _transformDataProvider
+                .Setup(_ => _.Get(It.IsAny<string>()))
+                .ReturnsAsync(new Textbox
+                {
+                    Properties = new BaseProperty
+                    {
+                        QuestionId = "ReusableTest"
+                    }
+                });
+
+            ReusableElementSchemaTransformFactory = new ReusableElementSchemaTransformFactory(_transformDataProvider.Object);
+
+            var element = (Reusable)new ElementBuilder()
+                .WithType(EElementType.Reusable)
+                .WithQuestionId("ReusableTest")
+                .WithSummaryLabel(summaryLabel)
+                .Build();
+
+            element.ElementRef = "test";
+
+            // Act
+            var result = await ReusableElementSchemaTransformFactory.Transform(new FormSchema
+            {
+                Pages = new List<Page>{
+                    new Page()
+                    {
+                        Elements = new List<IElement>
+                        {
+                            element
+                        }
+                    }
+                }
+            });
+
+            // Assert
+            Assert.IsType<FormSchema>(result);
+            Assert.Equal(summaryLabel, result.Pages.FirstOrDefault().Elements.FirstOrDefault().Properties.SummaryLabel);
+        }
+
+        [Fact]
         public async Task Transform_ShouldCall_TransformDataProvider_And_ShouldUpdate_Hint_WhenSupplied()
         {
             // Arrange

--- a/tests/unit-tests/UnitTests/Models/Elements/AddressTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/AddressTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using form_builder.Builders;
 using form_builder.Constants;
+using form_builder.Enum;
 using form_builder.Helpers.ElementHelpers;
 using form_builder.Helpers.ViewRender;
 using form_builder.Models;
@@ -151,6 +153,41 @@ namespace form_builder_tests.UnitTests.Models.Elements
 
             //Assert
             Assert.Equal($"/{baseUrl}/{pageSlug}", callback.ReturnURL);
+        }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_IsDefined()
+        {
+            var label = "Custom label";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Address)
+                .WithQuestionId("address-test")
+                .WithSummaryLabel(label)
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal(label, result);
+        }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_Is_Not_Defined()
+        {
+            var pageTitle = "Page Title";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Address)
+                .WithQuestionId("address-test")
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(pageTitle);
+
+            //Assert
+            Assert.Equal(pageTitle, result);
         }
     }
 }

--- a/tests/unit-tests/UnitTests/Models/Elements/BookingTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/BookingTests.cs
@@ -593,5 +593,40 @@ namespace form_builder_tests.UnitTests.Models.Elements
             Assert.Equal(ETimePeriod.Afternoon, bookingElement.Times.First().TimePeriodCurrentlySelected);
             Assert.Equal("test2", bookingElement.Times.First().MorningAppointments.BookingType);
         }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_IsDefined()
+        {
+            var label = "Custom label";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Booking)
+                .WithQuestionId("booking-test")
+                .WithSummaryLabel(label)
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal(label, result);
+        }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_Is_Not_Defined()
+        {
+            var pageTitle = "Booking";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Booking)
+                .WithQuestionId("booking-test")
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal(pageTitle, result);
+        }
     }
 }

--- a/tests/unit-tests/UnitTests/Models/Elements/ElementTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/ElementTests.cs
@@ -1,0 +1,120 @@
+using form_builder.Builders;
+using form_builder.Enum;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.Models.Elements
+{
+    public class ElementTests
+    {
+
+        [Theory]
+        [InlineData(EElementType.Checkbox)]
+        [InlineData(EElementType.DateInput)]
+        [InlineData(EElementType.DatePicker)]
+        [InlineData(EElementType.MultipleFileUpload)]
+        [InlineData(EElementType.Radio)]
+        [InlineData(EElementType.Select)]
+        [InlineData(EElementType.Textarea)]
+        [InlineData(EElementType.Textbox)]
+        [InlineData(EElementType.TimeInput)]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_IsDefined(EElementType type)
+        {
+            var label = "Custom label";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(type)
+                .WithQuestionId("test-question-id")
+                .WithSummaryLabel(label)
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal(label, result);
+        }
+
+        [Theory]
+        [InlineData(EElementType.Checkbox)]
+        [InlineData(EElementType.DateInput)]
+        [InlineData(EElementType.DatePicker)]
+        [InlineData(EElementType.MultipleFileUpload)]
+        [InlineData(EElementType.Radio)]
+        [InlineData(EElementType.Select)]
+        [InlineData(EElementType.Textarea)]
+        [InlineData(EElementType.Textbox)]
+        [InlineData(EElementType.TimeInput)]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_IsDefined_AndOptional(EElementType type)
+        {
+            var label = "Custom label";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(type)
+                .WithQuestionId("test-question-id")
+                .WithSummaryLabel(label)
+                .WithOptional(true)
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal($"{label} (optional)", result);
+        }
+
+        [Theory]
+        [InlineData(EElementType.Checkbox)]
+        [InlineData(EElementType.DateInput)]
+        [InlineData(EElementType.DatePicker)]
+        [InlineData(EElementType.MultipleFileUpload)]
+        [InlineData(EElementType.Radio)]
+        [InlineData(EElementType.Select)]
+        [InlineData(EElementType.Textarea)]
+        [InlineData(EElementType.Textbox)]
+        [InlineData(EElementType.TimeInput)]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_Is_Not_Defined(EElementType type)
+        {
+            var label = "existing label";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(type)
+                .WithQuestionId("test-question-id")
+                .WithLabel(label)
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal(label, result);
+        }
+
+        [Theory]
+        [InlineData(EElementType.Checkbox)]
+        [InlineData(EElementType.DateInput)]
+        [InlineData(EElementType.DatePicker)]
+        [InlineData(EElementType.MultipleFileUpload)]
+        [InlineData(EElementType.Radio)]
+        [InlineData(EElementType.Select)]
+        [InlineData(EElementType.Textarea)]
+        [InlineData(EElementType.Textbox)]
+        [InlineData(EElementType.TimeInput)]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_Is_Not_Defined_And_Optional(EElementType type)
+        {
+            var label = "existing label";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(type)
+                .WithQuestionId("test-question-id")
+                .WithLabel(label)
+                .WithOptional(true)
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal($"{label} (optional)", result);
+        }
+    }
+}

--- a/tests/unit-tests/UnitTests/Models/Elements/MapTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/MapTests.cs
@@ -54,5 +54,40 @@ namespace form_builder_tests.UnitTests.Models.Elements
             _mockIViewRender.Verify(_ => _.RenderAsync(It.Is<string>(x => x.Equals("Map")), It.IsAny<Map>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
             _mockElementHelper.Verify(_ => _.CurrentValue<object>(It.IsAny<string>(), It.IsAny<Dictionary<string, dynamic>>(), It.IsAny<FormAnswers>(), It.IsAny<string>()), Times.Once);
         }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_IsDefined()
+        {
+            var label = "Custom label";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Map)
+                .WithQuestionId("map-test")
+                .WithSummaryLabel(label)
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal(label, result);
+        }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_Is_Not_Defined()
+        {
+            var elementTitle = "Map";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Map)
+                .WithQuestionId("map-test")
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal(elementTitle, result);
+        }
     }
 }

--- a/tests/unit-tests/UnitTests/Models/Elements/OrganisationTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/OrganisationTests.cs
@@ -105,5 +105,40 @@ namespace form_builder_tests.UnitTests.Models.Elements
             _mockIViewRender.Verify(_ => _.RenderAsync(It.Is<string>(x => x == "OrganisationSelect"), It.IsAny<form_builder.Models.Elements.Organisation>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
             Assert.Equal(2, callback.Items.Count);
         }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_IsDefined()
+        {
+            var label = "Custom label";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Street)
+                .WithQuestionId("org-test")
+                .WithSummaryLabel(label)
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal(label, result);
+        }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_Is_Not_Defined()
+        {
+            var pageTitle = "Page Title";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Street)
+                .WithQuestionId("org-test")
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(pageTitle);
+
+            //Assert
+            Assert.Equal(pageTitle, result);
+        }
     }
 }

--- a/tests/unit-tests/UnitTests/Models/Elements/StreetTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/StreetTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using form_builder.Builders;
 using form_builder.Constants;
+using form_builder.Enum;
 using form_builder.Helpers.ElementHelpers;
 using form_builder.Helpers.ViewRender;
 using form_builder.Models;
@@ -86,6 +88,41 @@ namespace form_builder_tests.UnitTests.Models.Elements
 
             //Assert
             _mockIViewRender.Verify(_ => _.RenderAsync(It.Is<string>(x => x.Equals("StreetSearch")), It.IsAny<Element>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
+        }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_IsDefined()
+        {
+            var label = "Custom label";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Street)
+                .WithQuestionId("street-test")
+                .WithSummaryLabel(label)
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(string.Empty);
+
+            //Assert
+            Assert.Equal(label, result);
+        }
+
+        [Fact]
+        public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_Is_Not_Defined()
+        {
+            var pageTitle = "Page Title";
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Street)
+                .WithQuestionId("street-test")
+                .Build();
+
+            //Act
+            var result = element.GetLabelText(pageTitle);
+
+            //Assert
+            Assert.Equal(pageTitle, result);
         }
     }
 }


### PR DESCRIPTION
### Description
Added new element property `SummaryLabel` to allow designs to override the label displayed on the summary page.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary