### PR TITLE
fix(OrderBy): OrderBy only runs on Radio/Checkbox

### DIFF
--- a/src/Builders/ElementBuilder.cs
+++ b/src/Builders/ElementBuilder.cs
@@ -435,5 +435,12 @@ namespace form_builder.Builders
 
             return this;
         }
+
+        public ElementBuilder WithOrderOptionsAlphabetically(bool value)
+        {
+            _property.OrderOptionsAlphabetically = value;
+
+            return this;
+        }
     }
 }

--- a/src/Helpers/ElementHelpers/ElementHelper.cs
+++ b/src/Helpers/ElementHelpers/ElementHelper.cs
@@ -239,5 +239,11 @@ namespace form_builder.Helpers.ElementHelpers
                 ? $"{urlOrigin}{urlPath}"
                 : $"{urlOrigin}v2/{urlPath}";
         }
+
+        public void OrderOptionsAlphabetically(Element element)
+        {
+            if (element.Properties.OrderOptionsAlphabetically)
+                element.Properties.Options.Sort((x, y) => x.Text.CompareTo(y.Text));
+        }
     }
 }

--- a/src/Helpers/ElementHelpers/IElementHelper.cs
+++ b/src/Helpers/ElementHelpers/IElementHelper.cs
@@ -39,5 +39,6 @@ namespace form_builder.Helpers.ElementHelpers
         List<PageSummary> GenerateQuestionAndAnswersList(string guid, FormSchema formSchema);
 
         string GenerateDocumentUploadUrl(Element element, FormSchema formSchema, FormAnswers formAnswers);
+        void OrderOptionsAlphabetically(Element element);
     }
 }

--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -73,9 +73,6 @@ namespace form_builder.Helpers.PageHelpers
                     await AddDynamicOptions(element, formAnswers);
                 }
 
-                if (element.Properties.OrderOptionsAlphabetically)
-                    element.Properties.Options.Sort((x, y) => x.Text.CompareTo(y.Text));
-
                 string html = await element.RenderAsync(
                     _viewRender, _elementHelper, guid,
                     viewModel, page, baseForm, _environment,

--- a/src/Models/Elements/Checkbox.cs
+++ b/src/Models/Elements/Checkbox.cs
@@ -28,9 +28,7 @@ namespace form_builder.Models.Elements
             elementHelper.CheckForQuestionId(this);
             elementHelper.CheckForLabel(this);
             elementHelper.CheckForCheckBoxListValues(this);
-
-            if (Properties.OrderOptionsAlphabetically)
-                Properties.Options.Sort((x, y) => x.Text.CompareTo(y.Text));
+            elementHelper.OrderOptionsAlphabetically(this);
 
             return viewRender.RenderAsync(Type.ToString(), this);
         }

--- a/src/Models/Elements/Checkbox.cs
+++ b/src/Models/Elements/Checkbox.cs
@@ -29,6 +29,9 @@ namespace form_builder.Models.Elements
             elementHelper.CheckForLabel(this);
             elementHelper.CheckForCheckBoxListValues(this);
 
+            if (Properties.OrderOptionsAlphabetically)
+                Properties.Options.Sort((x, y) => x.Text.CompareTo(y.Text));
+
             return viewRender.RenderAsync(Type.ToString(), this);
         }
     }

--- a/src/Models/Elements/Radio.cs
+++ b/src/Models/Elements/Radio.cs
@@ -28,9 +28,7 @@ namespace form_builder.Models.Elements
             elementHelper.CheckForLabel(this);
             elementHelper.CheckForRadioOptions(this);
             elementHelper.ReCheckPreviousRadioOptions(this);
-
-            if (Properties.OrderOptionsAlphabetically)
-                Properties.Options.Sort((x, y) => x.Text.CompareTo(y.Text));
+            elementHelper.OrderOptionsAlphabetically(this);
 
             return await viewRender.RenderAsync(Type.ToString(), this);
         }

--- a/src/Models/Elements/Radio.cs
+++ b/src/Models/Elements/Radio.cs
@@ -28,6 +28,10 @@ namespace form_builder.Models.Elements
             elementHelper.CheckForLabel(this);
             elementHelper.CheckForRadioOptions(this);
             elementHelper.ReCheckPreviousRadioOptions(this);
+
+            if (Properties.OrderOptionsAlphabetically)
+                Properties.Options.Sort((x, y) => x.Text.CompareTo(y.Text));
+
             return await viewRender.RenderAsync(Type.ToString(), this);
         }
     }

--- a/tests/unit-tests/UnitTests/Helpers/ElementHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/ElementHelperTests.cs
@@ -735,5 +735,77 @@ namespace form_builder_tests.UnitTests.Helpers
             Assert.Equal($"{urlOrigin}{urlPath}", results);
             Assert.Contains(caseReference, results);
         }
+
+        [Fact]
+        public void OrderOptionsAlphabetically_Should_OrderOptions_When_OrderOptionsAlphabetically_Is_True()
+        {
+            //Arrange          
+            var options = new List<Option> {
+                new Option {
+                    Text = "X",
+                    Value = "X"
+                },
+                new Option {
+                    Text = "A",
+                    Value = "A"
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Checkbox)
+                .WithOptions(options)
+                .WithOrderOptionsAlphabetically(true)
+                .WithQuestionId("test")
+                .Build();
+
+            var elementHelper = new ElementHelper(
+                _mockDistributedCacheWrapper.Object,
+                _mockElementMapper.Object,
+                _mockWebHostEnvironment.Object,
+                _mockHttpContextAccessor.Object
+                );
+            //Act
+            elementHelper.OrderOptionsAlphabetically(element);
+
+        //Assert
+            Assert.Equal("A", element.Properties.Options[0].Text);
+            Assert.Equal("X", element.Properties.Options[1].Text);
+        }
+
+        [Fact]
+        public void OrderOptionsAlphabetically_Should_Not_OrderOptions_When_OrderOptionsAlphabetically_Is_False()
+        {
+            //Arrange          
+            var options = new List<Option> {
+                new Option {
+                    Text = "X",
+                    Value = "X"
+                },
+                new Option {
+                    Text = "A",
+                    Value = "A"
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Checkbox)
+                .WithOptions(options)
+                .WithOrderOptionsAlphabetically(false)
+                .WithQuestionId("test")
+                .Build();
+
+            var elementHelper = new ElementHelper(
+                _mockDistributedCacheWrapper.Object,
+                _mockElementMapper.Object,
+                _mockWebHostEnvironment.Object,
+                _mockHttpContextAccessor.Object
+                );
+            //Act
+            elementHelper.OrderOptionsAlphabetically(element);
+
+            //Assert
+            Assert.Equal("X", element.Properties.Options[0].Text);
+            Assert.Equal("A", element.Properties.Options[1].Text);
+        }
     }
 }

--- a/tests/unit-tests/UnitTests/Models/Elements/CheckboxTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/CheckboxTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using form_builder.Builders;
 using form_builder.Enum;
@@ -8,7 +7,6 @@ using form_builder.Helpers.ElementHelpers;
 using form_builder.Helpers.ViewRender;
 using form_builder.Models;
 using form_builder.Models.Elements;
-using form_builder_tests.Builders;
 using Microsoft.AspNetCore.Hosting;
 using Moq;
 using Xunit;
@@ -22,27 +20,12 @@ namespace form_builder_tests.UnitTests.Models.Elements
         private readonly Mock<IWebHostEnvironment> _mockHostingEnv = new ();
 
         [Fact]
-        public async Task RenderAsync_Should_OrderOptions_When_OrderOptionsAlphabetically_Is_True()
+        public async Task RenderAsync_Should_Call_ElementHelper_ToCheck_If_Options_NeedToBeOrdered()
         {
             //Arrange
-            Checkbox callback = new ();
-            _mockIViewRender.Setup(_ => _.RenderAsync(It.IsAny<string>(), It.IsAny<Checkbox>(), null))
-                .Callback<string, Checkbox, Dictionary<string, object>>((x, y, z) => callback = y);
-
-            var options = new List<Option> {
-                new Option {
-                    Text = "X",
-                    Value = "X"
-                },
-                new Option {
-                    Text = "A",
-                    Value = "A"
-                }
-            };
-
+            //Arrange
             var element = new ElementBuilder()
                 .WithType(EElementType.Checkbox)
-                .WithOptions(options)
                 .WithOrderOptionsAlphabetically(true)
                 .WithQuestionId("test")
                 .Build();
@@ -62,53 +45,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                 formAnswers);
 
             //Assert
-            Assert.Equal("A",callback.Properties.Options[0].Text);
-            Assert.Equal("X",callback.Properties.Options[1].Text);
-        }
-      
-        [Fact]
-        public async Task RenderAsync_Should_Not_OrderOptions_When_OrderOptionsAlphabetically_Is_False()
-        {
-              //Arrange
-            Checkbox callback = new ();
-            _mockIViewRender.Setup(_ => _.RenderAsync(It.IsAny<string>(), It.IsAny<Checkbox>(), null))
-                .Callback<string, Checkbox, Dictionary<string, object>>((x, y, z) => callback = y);
-
-            var options = new List<Option> {
-                new Option {
-                    Text = "X",
-                    Value = "X"
-                },
-                new Option {
-                    Text = "A",
-                    Value = "A"
-                }
-            };
-
-            var element = new ElementBuilder()
-                .WithType(EElementType.Checkbox)
-                .WithOptions(options)
-                .WithOrderOptionsAlphabetically(false)
-                .WithQuestionId("test")
-                .Build();
-
-            var viewModel = new Dictionary<string, dynamic>();
-
-            var formAnswers = new FormAnswers();
-            //Act
-            await element.RenderAsync(
-                _mockIViewRender.Object,
-                _mockElementHelper.Object,
-                "",
-                viewModel,
-                new Page(),
-                new FormSchema(),
-                _mockHostingEnv.Object,
-                formAnswers);
-
-            //Assert
-            Assert.Equal("X",callback.Properties.Options[0].Text);
-            Assert.Equal("A",callback.Properties.Options[1].Text);
+            _mockElementHelper.Verify(_ => _.OrderOptionsAlphabetically(It.IsAny<Element>()), Times.Once);
         }
     }
 }

--- a/tests/unit-tests/UnitTests/Models/Elements/CheckboxTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/CheckboxTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using form_builder.Builders;
+using form_builder.Enum;
+using form_builder.Helpers.ElementHelpers;
+using form_builder.Helpers.ViewRender;
+using form_builder.Models;
+using form_builder.Models.Elements;
+using form_builder_tests.Builders;
+using Microsoft.AspNetCore.Hosting;
+using Moq;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.Models.Elements
+{
+    public class CheckboxTests
+    {
+        private readonly Mock<IViewRender> _mockIViewRender = new ();
+        private readonly Mock<IElementHelper> _mockElementHelper = new ();
+        private readonly Mock<IWebHostEnvironment> _mockHostingEnv = new ();
+
+        [Fact]
+        public async Task RenderAsync_Should_OrderOptions_When_OrderOptionsAlphabetically_Is_True()
+        {
+            //Arrange
+            Checkbox callback = new ();
+            _mockIViewRender.Setup(_ => _.RenderAsync(It.IsAny<string>(), It.IsAny<Checkbox>(), null))
+                .Callback<string, Checkbox, Dictionary<string, object>>((x, y, z) => callback = y);
+
+            var options = new List<Option> {
+                new Option {
+                    Text = "X",
+                    Value = "X"
+                },
+                new Option {
+                    Text = "A",
+                    Value = "A"
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Checkbox)
+                .WithOptions(options)
+                .WithOrderOptionsAlphabetically(true)
+                .WithQuestionId("test")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>();
+
+            var formAnswers = new FormAnswers();
+            //Act
+            await element.RenderAsync(
+                _mockIViewRender.Object,
+                _mockElementHelper.Object,
+                "",
+                viewModel,
+                new Page(),
+                new FormSchema(),
+                _mockHostingEnv.Object,
+                formAnswers);
+
+            //Assert
+            Assert.Equal("A",callback.Properties.Options[0].Text);
+            Assert.Equal("X",callback.Properties.Options[1].Text);
+        }
+      
+        [Fact]
+        public async Task RenderAsync_Should_Not_OrderOptions_When_OrderOptionsAlphabetically_Is_False()
+        {
+              //Arrange
+            Checkbox callback = new ();
+            _mockIViewRender.Setup(_ => _.RenderAsync(It.IsAny<string>(), It.IsAny<Checkbox>(), null))
+                .Callback<string, Checkbox, Dictionary<string, object>>((x, y, z) => callback = y);
+
+            var options = new List<Option> {
+                new Option {
+                    Text = "X",
+                    Value = "X"
+                },
+                new Option {
+                    Text = "A",
+                    Value = "A"
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Checkbox)
+                .WithOptions(options)
+                .WithOrderOptionsAlphabetically(false)
+                .WithQuestionId("test")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>();
+
+            var formAnswers = new FormAnswers();
+            //Act
+            await element.RenderAsync(
+                _mockIViewRender.Object,
+                _mockElementHelper.Object,
+                "",
+                viewModel,
+                new Page(),
+                new FormSchema(),
+                _mockHostingEnv.Object,
+                formAnswers);
+
+            //Assert
+            Assert.Equal("X",callback.Properties.Options[0].Text);
+            Assert.Equal("A",callback.Properties.Options[1].Text);
+        }
+    }
+}

--- a/tests/unit-tests/UnitTests/Models/Elements/RadioTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/RadioTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using form_builder.Builders;
+using form_builder.Enum;
+using form_builder.Helpers.ElementHelpers;
+using form_builder.Helpers.ViewRender;
+using form_builder.Models;
+using form_builder.Models.Elements;
+using Microsoft.AspNetCore.Hosting;
+using Moq;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.Models.Elements
+{
+    public class RadioTests
+    {
+        private readonly Mock<IViewRender> _mockIViewRender = new ();
+        private readonly Mock<IElementHelper> _mockElementHelper = new ();
+        private readonly Mock<IWebHostEnvironment> _mockHostingEnv = new ();
+
+        [Fact]
+        public async Task RenderAsync_Should_OrderOptions_When_OrderOptionsAlphabetically_Is_True()
+        {
+            //Arrange
+            Checkbox callback = new ();
+            _mockIViewRender.Setup(_ => _.RenderAsync(It.IsAny<string>(), It.IsAny<Checkbox>(), null))
+                .Callback<string, Checkbox, Dictionary<string, object>>((x, y, z) => callback = y);
+
+            var options = new List<Option> {
+                new Option {
+                    Text = "X",
+                    Value = "X"
+                },
+                new Option {
+                    Text = "A",
+                    Value = "A"
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Checkbox)
+                .WithOptions(options)
+                .WithOrderOptionsAlphabetically(true)
+                .WithQuestionId("test")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>();
+
+            var formAnswers = new FormAnswers();
+            //Act
+            await element.RenderAsync(
+                _mockIViewRender.Object,
+                _mockElementHelper.Object,
+                "",
+                viewModel,
+                new Page(),
+                new FormSchema(),
+                _mockHostingEnv.Object,
+                formAnswers);
+
+            //Assert
+            Assert.Equal("A",callback.Properties.Options[0].Text);
+            Assert.Equal("X",callback.Properties.Options[1].Text);
+        }
+      
+        [Fact]
+        public async Task RenderAsync_Should_Not_OrderOptions_When_OrderOptionsAlphabetically_Is_False()
+        {
+              //Arrange
+            Checkbox callback = new ();
+            _mockIViewRender.Setup(_ => _.RenderAsync(It.IsAny<string>(), It.IsAny<Checkbox>(), null))
+                .Callback<string, Checkbox, Dictionary<string, object>>((x, y, z) => callback = y);
+
+            var options = new List<Option> {
+                new Option {
+                    Text = "X",
+                    Value = "X"
+                },
+                new Option {
+                    Text = "A",
+                    Value = "A"
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Checkbox)
+                .WithOptions(options)
+                .WithOrderOptionsAlphabetically(false)
+                .WithQuestionId("test")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>();
+
+            var formAnswers = new FormAnswers();
+            //Act
+            await element.RenderAsync(
+                _mockIViewRender.Object,
+                _mockElementHelper.Object,
+                "",
+                viewModel,
+                new Page(),
+                new FormSchema(),
+                _mockHostingEnv.Object,
+                formAnswers);
+
+            //Assert
+            Assert.Equal("X",callback.Properties.Options[0].Text);
+            Assert.Equal("A",callback.Properties.Options[1].Text);
+        }
+    }
+}

--- a/tests/unit-tests/UnitTests/Models/Elements/RadioTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/RadioTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using form_builder.Builders;
@@ -20,27 +19,11 @@ namespace form_builder_tests.UnitTests.Models.Elements
         private readonly Mock<IWebHostEnvironment> _mockHostingEnv = new ();
 
         [Fact]
-        public async Task RenderAsync_Should_OrderOptions_When_OrderOptionsAlphabetically_Is_True()
+        public async Task RenderAsync_Should_Call_ElementHelper_ToCheck_If_Options_NeedToBeOrdered()
         {
             //Arrange
-            Checkbox callback = new ();
-            _mockIViewRender.Setup(_ => _.RenderAsync(It.IsAny<string>(), It.IsAny<Checkbox>(), null))
-                .Callback<string, Checkbox, Dictionary<string, object>>((x, y, z) => callback = y);
-
-            var options = new List<Option> {
-                new Option {
-                    Text = "X",
-                    Value = "X"
-                },
-                new Option {
-                    Text = "A",
-                    Value = "A"
-                }
-            };
-
             var element = new ElementBuilder()
-                .WithType(EElementType.Checkbox)
-                .WithOptions(options)
+                .WithType(EElementType.Radio)
                 .WithOrderOptionsAlphabetically(true)
                 .WithQuestionId("test")
                 .Build();
@@ -60,53 +43,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
                 formAnswers);
 
             //Assert
-            Assert.Equal("A",callback.Properties.Options[0].Text);
-            Assert.Equal("X",callback.Properties.Options[1].Text);
-        }
-      
-        [Fact]
-        public async Task RenderAsync_Should_Not_OrderOptions_When_OrderOptionsAlphabetically_Is_False()
-        {
-              //Arrange
-            Checkbox callback = new ();
-            _mockIViewRender.Setup(_ => _.RenderAsync(It.IsAny<string>(), It.IsAny<Checkbox>(), null))
-                .Callback<string, Checkbox, Dictionary<string, object>>((x, y, z) => callback = y);
-
-            var options = new List<Option> {
-                new Option {
-                    Text = "X",
-                    Value = "X"
-                },
-                new Option {
-                    Text = "A",
-                    Value = "A"
-                }
-            };
-
-            var element = new ElementBuilder()
-                .WithType(EElementType.Checkbox)
-                .WithOptions(options)
-                .WithOrderOptionsAlphabetically(false)
-                .WithQuestionId("test")
-                .Build();
-
-            var viewModel = new Dictionary<string, dynamic>();
-
-            var formAnswers = new FormAnswers();
-            //Act
-            await element.RenderAsync(
-                _mockIViewRender.Object,
-                _mockElementHelper.Object,
-                "",
-                viewModel,
-                new Page(),
-                new FormSchema(),
-                _mockHostingEnv.Object,
-                formAnswers);
-
-            //Assert
-            Assert.Equal("X",callback.Properties.Options[0].Text);
-            Assert.Equal("A",callback.Properties.Options[1].Text);
+            _mockElementHelper.Verify(_ => _.OrderOptionsAlphabetically(It.IsAny<Element>()), Times.Once);
         }
     }
 }


### PR DESCRIPTION
### Description
Moved OrderOptions property check into Element helper which is now called within Radio/Checkbox render method

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary