### PR TITLE
refactor(SchemaProvider): Modified ValidateSchemaName to do an equal check not contains on SchemaName

### DIFF
--- a/tests/unit-tests/UnitTests/Providers/SchemaProvider/S3FileSchemaProviderTests.cs
+++ b/tests/unit-tests/UnitTests/Providers/SchemaProvider/S3FileSchemaProviderTests.cs
@@ -1,6 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Amazon.S3;
+using Amazon.S3.Model;
 using form_builder.Configuration;
 using form_builder.Gateways;
 using form_builder.Providers.SchemaProvider;
@@ -24,11 +28,15 @@ namespace form_builder_tests.UnitTests.Providers.SchemaProvider
         private readonly Mock<IOptions<DistributedCacheConfiguration>> _mockDistributedCacheConfiguration = new();
         private readonly Mock<IOptions<DistributedCacheExpirationConfiguration>> _mockDistributedCacheExpirationConfiguration = new();
         private readonly Mock<ILogger<ISchemaProvider>> _mockLogger = new();
+        private const int _indexExpiry = 10;
 
         public S3FileSchemaProviderTests()
         {
             _mockHostingEnv.Setup(_ => _.EnvironmentName).Returns("uitest");
             _mockConfiguration.Setup(_ => _["S3BucketKey"]).Returns("forms-storage");
+            _mockConfiguration.Setup(_ => _["ApplicationVersion"]).Returns("v2");
+            _mockDistributedCacheConfiguration.Setup(_ => _.Value).Returns(new DistributedCacheConfiguration { UseDistributedCache = true });
+            _mockDistributedCacheExpirationConfiguration.Setup(_ => _.Value).Returns(new DistributedCacheExpirationConfiguration { Index = _indexExpiry });
             _s3Schema = new S3FileSchemaProvider(_mockS3Gateway.Object, _mockHostingEnv.Object, _mockDistributedCacheWrapper.Object, _mockConfiguration.Object, _mockDistributedCacheConfiguration.Object, _mockDistributedCacheExpirationConfiguration.Object, _mockLogger.Object);
         }
 
@@ -52,6 +60,67 @@ namespace form_builder_tests.UnitTests.Providers.SchemaProvider
             var result = await Assert.ThrowsAsync<Exception>(() => _s3Schema.Get<string>("name"));
             _mockS3Gateway.Verify(_ => _.GetObject(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             Assert.StartsWith("S3FileSchemaProvider: An error has occured while attempting to deserialize object, Exception:", result.Message);
+        }
+
+        [Fact]
+        public async Task ValidateSchemaName_ShouldReturnTrue_AndMatch_Schema_ToRequested_SchemaName()
+        {
+            var schemaName = "test-form-name";
+            _mockDistributedCacheWrapper.Setup(_ => _.GetString(It.IsAny<string>()))
+                .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new List<string>
+                {
+                    $"{schemaName}.json"
+                }));
+            var result = await _s3Schema.ValidateSchemaName(schemaName);
+            
+            Assert.True(result);
+        }
+        
+        [Theory]
+        [InlineData("test-form-nam")]
+        [InlineData("est-form-name")]
+        [InlineData("test")]
+        [InlineData("form-name")]
+        public async Task ValidateSchemaName_ShouldReturnFalse_When_Requested_SchemaName_IsNot_In_Index(string formName)
+        {
+            _mockDistributedCacheWrapper.Setup(_ => _.GetString(It.IsAny<string>()))
+                .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new List<string>
+                {
+                    $"test-form-name.json"
+                }));
+            var result = await _s3Schema.ValidateSchemaName(formName);
+            
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ValidateSchemaName_Should_Call_ToIndex_Schema_WhenNotCurrently_InCache()
+        {
+            var schemaName = "test-form-name";
+            _mockDistributedCacheWrapper.Setup(_ => _.GetString(It.IsAny<string>()))
+                .Returns(string.Empty);
+
+            _mockS3Gateway.Setup(_ => _.ListObjectsV2(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ListObjectsV2Response{ S3Objects = new List<S3Object>{ new S3Object { Key = "Int/v2/testform.json" } } });
+
+            var result = await _s3Schema.ValidateSchemaName(schemaName);
+            
+            _mockS3Gateway.Verify(_ => _.ListObjectsV2(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mockDistributedCacheWrapper.Verify(_ => _.SetStringAsync(It.IsAny<string>(), It.IsAny<string>(), It.Is<int>(_ => _.Equals(_indexExpiry)), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ValidateSchemaName_Should_Remove_BucketPrefix_WhenIndexing_List()
+        {
+            var testIndexKey = "Int/v2/test-form-name.json";
+            var expected = "test-form-name.json";
+            _mockS3Gateway.Setup(_ => _.ListObjectsV2(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ListObjectsV2Response{ S3Objects = new List<S3Object>{ new S3Object { Key = testIndexKey } } });
+
+            var result = await _s3Schema.IndexSchema();
+            
+            Assert.Single(result);
+            Assert.Equal(expected, result.First());
         }
     }
 }


### PR DESCRIPTION
### Description
Updated `IndexSchema` to index the schemas without the bucker prefix and change  `ValidateSchemaName` to do an equal comparison rather then contains. 

This change has been done due to an issue where if u had a form with the name `track-a-report`, in theory requesting the form `a` would work or `report` as it was contains previously.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary