### PR TITLE
Summary sections

### DIFF
--- a/src/Builders/ElementBuilder.cs
+++ b/src/Builders/ElementBuilder.cs
@@ -442,5 +442,15 @@ namespace form_builder.Builders
 
             return this;
         }
+
+        public ElementBuilder withSummarySection(Section value)
+        {
+            if (_property.Sections is null)
+                _property.Sections = new List<Section>();
+
+            _property.Sections.Add(value);
+
+            return this;
+        }
     }
 }

--- a/src/Models/Elements/Summary.cs
+++ b/src/Models/Elements/Summary.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using form_builder.Enum;
 using form_builder.Helpers.ElementHelpers;
@@ -34,7 +32,7 @@ namespace form_builder.Models.Elements
 
             if (Properties.HasSummarySectionsDefined)
             {
-                var summaryViewModel = new SummarySectionViewModel
+                var summaryViewModel = new SummarySectionsViewModel
                 {
                     Sections = Properties.Sections.Select(_ => new SummarySection
                     {
@@ -47,7 +45,7 @@ namespace form_builder.Models.Elements
                 return await viewRender.RenderAsync(Type.ToString(), summaryViewModel);
             }
 
-            var summaryViewModelSingleSection = new SummarySectionViewModel
+            var summaryViewModelSingleSection = new SummarySectionsViewModel
             {
                 AllowEditing = Properties.AllowEditing,
                 Sections = new List<SummarySection>()
@@ -59,30 +57,6 @@ namespace form_builder.Models.Elements
             };
 
             return await viewRender.RenderAsync(Type.ToString(), summaryViewModelSingleSection);
-
-            htmlContent.AppendHtmlLine("<dl class=\"govuk-summary-list govuk-!-margin-bottom-9\">");
-            foreach (var pageSummary in pages)
-            {
-                foreach (var answer in pageSummary.Answers)
-                {
-                    htmlContent.AppendHtmlLine("<div class=\"govuk-summary-list__row\">");
-                    htmlContent.AppendHtmlLine($"<dt class=\"govuk-summary-list__key\">{answer.Key}</dt>");
-                    htmlContent.AppendHtmlLine($"<dd class=\"govuk-summary-list__value\">{answer.Value}</dd>");
-
-                    if (Properties != null && Properties.AllowEditing)
-                        htmlContent.AppendHtmlLine($"<dd class=\"govuk-summary-list__actions\"><a class=\"govuk-link\" href=\"{pageSummary.PageSlug}\">Change <span class=\"govuk-visually-hidden\">{answer.Key}</span></a></dd>");
-
-                    htmlContent.AppendHtmlLine("</div>");
-                }
-            }
-            htmlContent.AppendHtmlLine("</dl>");
-
-            using (var writer = new StringWriter())
-            {
-                htmlContent.WriteTo(writer, HtmlEncoder.Default);
-
-                return writer.ToString();
-            }
         }
     }
 }

--- a/src/Models/Properties/ElementProperties/SummaryProperty.cs
+++ b/src/Models/Properties/ElementProperties/SummaryProperty.cs
@@ -1,7 +1,18 @@
-﻿namespace form_builder.Models.Properties.ElementProperties
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace form_builder.Models.Properties.ElementProperties
 {
     public partial class BaseProperty
     {
         public bool AllowEditing { get; set; }
+        public List<Section> Sections { get; set; }
+        public bool HasSummarySectionsDefined => Sections != null && Sections.Any();
+    }
+
+    public class Section
+    {
+        public string Title { get; set; }
+        public List<string> Pages { get; set; }
     }
 }

--- a/src/Models/Properties/ElementProperties/SummaryProperty.cs
+++ b/src/Models/Properties/ElementProperties/SummaryProperty.cs
@@ -7,7 +7,7 @@ namespace form_builder.Models.Properties.ElementProperties
     {
         public bool AllowEditing { get; set; }
         public List<Section> Sections { get; set; }
-        public bool HasSummarySectionsDefined => Sections != null && Sections.Any();
+        public bool HasSummarySectionsDefined => Sections is not null && Sections.Any();
     }
 
     public class Section

--- a/src/Utils/Startup/ServiceCollectionExtensions.cs
+++ b/src/Utils/Startup/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;

--- a/src/Utils/Startup/ServiceCollectionExtensions.cs
+++ b/src/Utils/Startup/ServiceCollectionExtensions.cs
@@ -525,6 +525,7 @@ namespace form_builder.Utils.Startup
                 o.ViewLocationFormats.Add("/Views/Shared/Time/{0}" + RazorViewEngine.ViewExtension);
                 o.ViewLocationFormats.Add("/Views/Shared/TimeInput/{0}" + RazorViewEngine.ViewExtension);
                 o.ViewLocationFormats.Add("/Views/Shared/Warning/{0}" + RazorViewEngine.ViewExtension);
+                o.ViewLocationFormats.Add("/Views/Shared/Summary/{0}" + RazorViewEngine.ViewExtension);
             });
 
             return services;

--- a/src/Utils/Startup/ServiceCollectionExtensions.cs
+++ b/src/Utils/Startup/ServiceCollectionExtensions.cs
@@ -313,6 +313,8 @@ namespace form_builder.Utils.Startup
             services.AddSingleton<IFormSchemaIntegrityCheck, TemplatedEmailActionCheck>();
             services.AddSingleton<IFormSchemaIntegrityCheck, ValidateActionCheck>();
             services.AddSingleton<IFormSchemaIntegrityCheck, HasDuplicateQuestionIdsCheck>();
+            services.AddSingleton<IFormSchemaIntegrityCheck, SummaryElementFormCheck>();
+            
 
             services.AddSingleton<IBehaviourSchemaIntegrityCheck, CurrentEnvironmentSubmitSlugsCheck>();
             services.AddSingleton<IBehaviourSchemaIntegrityCheck, EmptyBehaviourSlugsCheck>();

--- a/src/Utils/Startup/ServiceCollectionExtensions.cs
+++ b/src/Utils/Startup/ServiceCollectionExtensions.cs
@@ -315,7 +315,6 @@ namespace form_builder.Utils.Startup
             services.AddSingleton<IFormSchemaIntegrityCheck, HasDuplicateQuestionIdsCheck>();
             services.AddSingleton<IFormSchemaIntegrityCheck, SummaryElementFormCheck>();
             
-
             services.AddSingleton<IBehaviourSchemaIntegrityCheck, CurrentEnvironmentSubmitSlugsCheck>();
             services.AddSingleton<IBehaviourSchemaIntegrityCheck, EmptyBehaviourSlugsCheck>();
             services.AddSingleton<IBehaviourSchemaIntegrityCheck, SubmitSlugsHaveAllPropertiesCheck>();

--- a/src/Validators/IntegrityChecks/Form/SummaryElementFormCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/SummaryElementFormCheck.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using System.Threading.Tasks;
+using form_builder.Enum;
+using form_builder.Models;
+
+namespace form_builder.Validators.IntegrityChecks.Form
+{
+    public class SummaryElementFormCheck : IFormSchemaIntegrityCheck
+    {
+        public IntegrityCheckResult Validate(FormSchema schema)
+        {
+            IntegrityCheckResult result = new();
+
+            if (!schema.Pages.Any(page => page.Elements.Any(element => element.Type.Equals(EElementType.Summary))))
+                return result;
+
+            var summaryElements = schema.Pages.SelectMany(page => page.Elements.Where(element => element.Type.Equals(EElementType.Summary))).ToList();
+
+
+            summaryElements.ForEach((element) =>
+            {
+                var properties = element.Properties;
+                if (properties.HasSummarySectionsDefined)
+                {
+                    properties.Sections.ForEach(_ =>
+                    {
+                        if (string.IsNullOrEmpty(_.Title))
+                        {
+                            result.AddFailureMessage($"FormSchemaIntegrityCheck::SummaryFormCheck, Summary section is defined but section title is empty. Please add a title for the section.");
+                        }
+
+                        if (_.Pages is null || _.Pages.Count.Equals(0))
+                        {
+                            result.AddFailureMessage($"FormSchemaIntegrityCheck::SummaryFormCheck, Summary section is defined but no pages have been specified to appear in the section.");
+                        }
+
+                        if (_.Pages is not null && _.Pages.Count > 0)
+                        {
+                            _.Pages.ForEach((x) =>
+                            {
+                                if (!schema.Pages.Any(_ => _.PageSlug.Equals(x)))
+                                {
+                                    result.AddFailureMessage($"FormSchemaIntegrityCheck::SummaryFormCheck, Summary section has a page slug defined which cannot be found. Verify '{x}' is a valid page slug within the schema.");
+                                }
+                            });
+                        }
+                    });
+                }
+            });
+
+            return result;
+        }
+
+        public async Task<IntegrityCheckResult> ValidateAsync(FormSchema schema) => await Task.Run(() => Validate(schema));
+    }
+}

--- a/src/Validators/IntegrityChecks/Form/SummaryElementFormCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/SummaryElementFormCheck.cs
@@ -16,7 +16,6 @@ namespace form_builder.Validators.IntegrityChecks.Form
 
             var summaryElements = schema.Pages.SelectMany(page => page.Elements.Where(element => element.Type.Equals(EElementType.Summary))).ToList();
 
-
             summaryElements.ForEach((element) =>
             {
                 var properties = element.Properties;

--- a/src/ViewModels/SummarySectionViewModel.cs
+++ b/src/ViewModels/SummarySectionViewModel.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using form_builder.Models;
+
+namespace form_builder.ViewModels
+{
+    public class SummarySectionViewModel
+    {
+        public List<SummarySection> Sections = new List<SummarySection>();
+        public bool AllowEditing { get; set; }
+    }
+
+    public class SummarySection
+    {
+        public string Title { get; set; }
+        public bool DisplaySectionHeading => !string.IsNullOrEmpty(Title);
+        public List<PageSummary> Pages { get; set; }
+    }
+}

--- a/src/ViewModels/SummarySectionsViewModel.cs
+++ b/src/ViewModels/SummarySectionsViewModel.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
+using System.Linq;
 using form_builder.Models;
 
 namespace form_builder.ViewModels
 {
-    public class SummarySectionViewModel
+    public class SummarySectionsViewModel
     {
         public List<SummarySection> Sections = new List<SummarySection>();
         public bool AllowEditing { get; set; }
@@ -12,7 +13,8 @@ namespace form_builder.ViewModels
     public class SummarySection
     {
         public string Title { get; set; }
-        public bool DisplaySectionHeading => !string.IsNullOrEmpty(Title);
         public List<PageSummary> Pages { get; set; }
+        public bool ContainsPages => Pages is not null && Pages.Any();
+        public bool DisplaySectionHeading => !string.IsNullOrEmpty(Title);
     }
 }

--- a/src/Views/Shared/Summary/Summary.cshtml
+++ b/src/Views/Shared/Summary/Summary.cshtml
@@ -9,7 +9,7 @@
             <h2 class="govuk-heading-m">@summarySection.Title</h2>
         }
 
-        <dl class="govuk-summary-list govuk-!-margin-bottom-9\">
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9">
             @foreach (var pageSummary in summarySection.Pages)
             {
                 @foreach (var answer in pageSummary.Answers)

--- a/src/Views/Shared/Summary/Summary.cshtml
+++ b/src/Views/Shared/Summary/Summary.cshtml
@@ -1,0 +1,28 @@
+@model SummarySectionViewModel
+
+@foreach (var summarySection in Model.Sections)
+{
+    @if(summarySection.DisplaySectionHeading)
+    {
+        <h2 class="govuk-heading-m">@summarySection.Title</h2>
+    }
+
+    <dl class="govuk-summary-list govuk-!-margin-bottom-9\">
+        @foreach (var pageSummary in summarySection.Pages)
+        {
+            @foreach (var answer in pageSummary.Answers)
+            {
+                <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">@answer.Key</dt>
+                <dd class="govuk-summary-list__value">@answer.Value</dd>
+
+                    @if (Model.AllowEditing){
+                        <dd class="govuk-summary-list__actions">
+                            <a class="govuk-link" href="@pageSummary.PageSlug">Change <span class="govuk-visually-hidden">@answer.Key</span></a>
+                        </dd>
+                    }
+                </div>
+            }
+        }
+    </dl>
+}

--- a/src/Views/Shared/Summary/Summary.cshtml
+++ b/src/Views/Shared/Summary/Summary.cshtml
@@ -1,28 +1,31 @@
-@model SummarySectionViewModel
+@model SummarySectionsViewModel
 
 @foreach (var summarySection in Model.Sections)
 {
-    @if(summarySection.DisplaySectionHeading)
+    @if(summarySection.ContainsPages)
     {
-        <h2 class="govuk-heading-m">@summarySection.Title</h2>
-    }
-
-    <dl class="govuk-summary-list govuk-!-margin-bottom-9\">
-        @foreach (var pageSummary in summarySection.Pages)
+        @if(summarySection.DisplaySectionHeading)
         {
-            @foreach (var answer in pageSummary.Answers)
-            {
-                <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">@answer.Key</dt>
-                <dd class="govuk-summary-list__value">@answer.Value</dd>
-
-                    @if (Model.AllowEditing){
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link" href="@pageSummary.PageSlug">Change <span class="govuk-visually-hidden">@answer.Key</span></a>
-                        </dd>
-                    }
-                </div>
-            }
+            <h2 class="govuk-heading-m">@summarySection.Title</h2>
         }
-    </dl>
+
+        <dl class="govuk-summary-list govuk-!-margin-bottom-9\">
+            @foreach (var pageSummary in summarySection.Pages)
+            {
+                @foreach (var answer in pageSummary.Answers)
+                {
+                    <div class="govuk-summary-list__row">
+                        <dt class="govuk-summary-list__key">@answer.Key</dt>
+                        <dd class="govuk-summary-list__value">@Html.Raw(answer.Value)</dd>
+
+                        @if (Model.AllowEditing){
+                            <dd class="govuk-summary-list__actions">
+                                <a class="govuk-link" href="@pageSummary.PageSlug">Change <span class="govuk-visually-hidden">@answer.Key</span></a>
+                            </dd>
+                        }
+                    </div>
+                }
+            }
+        </dl>
+    }
 }

--- a/tests/unit-tests/UnitTests/Models/Elements/SummaryTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/SummaryTests.cs
@@ -1,0 +1,155 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using form_builder.Builders;
+using form_builder.Enum;
+using form_builder.Helpers.ElementHelpers;
+using form_builder.Helpers.ViewRender;
+using form_builder.Models;
+using form_builder.Models.Elements;
+using form_builder.Models.Properties.ElementProperties;
+using form_builder.ViewModels;
+using form_builder_tests.Builders;
+using Microsoft.AspNetCore.Hosting;
+using Moq;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.Models.Elements
+{
+    public class SummaryTests
+    {
+        private readonly Mock<IViewRender> _mockIViewRender = new ();
+        private readonly Mock<IElementHelper> _mockElementHelper = new ();
+        private readonly Mock<IWebHostEnvironment> _mockHostingEnv = new ();
+
+        [Fact]
+        public async Task RenderAsync_ShouldCall_ViewRender_ToRenderSummaryView()
+        {
+            //Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>();
+
+            var schema = new FormSchemaBuilder()
+                .WithName("form-name")
+                .Build();
+
+            var formAnswers = new FormAnswers();
+
+            //Act
+            await element.RenderAsync(
+                _mockIViewRender.Object,
+                _mockElementHelper.Object,
+                string.Empty,
+                viewModel,
+                page,
+                schema,
+                _mockHostingEnv.Object,
+                formAnswers);
+
+            //Assert
+            _mockIViewRender.Verify(_ => _.RenderAsync(It.Is<string>(x => x.Equals("Summary")), It.IsAny<SummarySectionsViewModel>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task RenderAsync_ShouldCall_ViewRender_WithCorrect_ViewModel_ForSummaryWith_Sections()
+        {
+            //Arrange
+            var callback = new SummarySectionsViewModel();
+            var section = new Section {
+                Title = "title",
+                Pages = new List<string> {
+                    "page-one"
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .withSummarySection(section)
+                .withSummarySection(section)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithPageSlug("page-one")
+                .WithElement(element)
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>();
+
+            var schema = new FormSchemaBuilder()
+                .WithName("form-name")
+                .WithPage(page)
+                .Build();
+
+            var formAnswers = new FormAnswers();
+
+            _mockIViewRender.Setup(_ => _.RenderAsync(It.Is<string>(x => x.Equals("Summary")), It.IsAny<SummarySectionsViewModel>(), It.IsAny<Dictionary<string, object>>()))
+                .Callback<string, SummarySectionsViewModel, Dictionary<string, object>>((x,y,z) => callback = y);
+
+            _mockElementHelper.Setup(_ => _.GenerateQuestionAndAnswersList(It.IsAny<string>(), It.IsAny<FormSchema>()))
+                .Returns(new List<PageSummary>{new PageSummary { PageSlug = "page-one" }});
+
+            //Act
+            await element.RenderAsync(
+                _mockIViewRender.Object,
+                _mockElementHelper.Object,
+                string.Empty,
+                viewModel,
+                page,
+                schema,
+                _mockHostingEnv.Object,
+                formAnswers);
+
+            //Assert
+            _mockIViewRender.Verify(_ => _.RenderAsync(It.Is<string>(x => x.Equals("Summary")), It.IsAny<SummarySectionsViewModel>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
+            Assert.Equal(2, callback.Sections.Count);
+        }
+
+        [Fact]
+        public async Task RenderAsync_ShouldCall_ViewRender_WithCorrect_ViewModel_ForSummaryWithout_Sections()
+        {
+            //Arrange
+            var callback = new SummarySectionsViewModel();
+            var element = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithPageSlug("page-one")
+                .WithElement(element)
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>();
+
+            var schema = new FormSchemaBuilder()
+                .WithName("form-name")
+                .WithPage(page)
+                .Build();
+
+            var formAnswers = new FormAnswers();
+
+            _mockIViewRender.Setup(_ => _.RenderAsync(It.Is<string>(x => x.Equals("Summary")), It.IsAny<SummarySectionsViewModel>(), It.IsAny<Dictionary<string, object>>()))
+                .Callback<string, SummarySectionsViewModel, Dictionary<string, object>>((x,y,z) => callback = y);
+
+            //Act
+            await element.RenderAsync(
+                _mockIViewRender.Object,
+                _mockElementHelper.Object,
+                string.Empty,
+                viewModel,
+                page,
+                schema,
+                _mockHostingEnv.Object,
+                formAnswers);
+
+            //Assert
+            _mockIViewRender.Verify(_ => _.RenderAsync(It.Is<string>(x => x.Equals("Summary")), It.IsAny<SummarySectionsViewModel>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
+            Assert.Single(callback.Sections);
+        }
+    }
+}

--- a/tests/unit-tests/UnitTests/Validators/IntegrityChecks/Form/SummaryElementFormCheckTests.cs
+++ b/tests/unit-tests/UnitTests/Validators/IntegrityChecks/Form/SummaryElementFormCheckTests.cs
@@ -1,0 +1,248 @@
+using System.Collections.Generic;
+using System.Linq;
+using form_builder.Builders;
+using form_builder.Constants;
+using form_builder.Enum;
+using form_builder.Models.Properties.ElementProperties;
+using form_builder.Validators.IntegrityChecks.Form;
+using form_builder_tests.Builders;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.Validators.IntegrityChecks.Form
+{
+    public class SummaryElementFormCheckTests
+    {
+        private readonly SummaryElementFormCheck _validator = new SummaryElementFormCheck();
+
+        [Fact]
+        public void Validate_Should_Return_Error_WhenSummarySection_IsMissingTitle()
+        {
+            // Arrange
+            var section = new Section
+            {
+                Pages = new List<string> { "test-page" }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .withSummarySection(section)
+                .Build();
+
+            var page1 = new PageBuilder()
+                .WithPageSlug("test-page")
+                .WithElement(element)
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithName("test-name")
+                .WithPage(page1)
+                .Build();
+
+            // Act
+            var result = _validator.Validate(schema);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Single(result.Messages);
+            Assert.Equal($"{IntegrityChecksConstants.FAILURE}FormSchemaIntegrityCheck::SummaryFormCheck, Summary section is defined but section title is empty. Please add a title for the section.", result.Messages.First());
+        }
+
+        [Fact]
+        public void Validate_Should_Return_Error_WhenSummarySection_Has_NoPages_Defined_InSection()
+        {
+            // Arrange
+            var section = new Section
+            {
+                Title = "section title"
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .withSummarySection(section)
+                .Build();
+
+            var page1 = new PageBuilder()
+                .WithPageSlug("test-page")
+                .WithElement(element)
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithName("test-name")
+                .WithPage(page1)
+                .Build();
+
+            // Act
+            var result = _validator.Validate(schema);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Single(result.Messages);
+            Assert.Equal($"{IntegrityChecksConstants.FAILURE}FormSchemaIntegrityCheck::SummaryFormCheck, Summary section is defined but no pages have been specified to appear in the section.", result.Messages.First());
+        }
+
+        [Fact]
+        public void Validate_Should_Return_Error_WhenOne_SectionIsValid_AndOther_IsNotValid()
+        {
+            // Arrange
+            var sectionValid = new Section
+            {
+                Title = "section title",
+                Pages = new List<string> {
+                    "test-page"
+                }
+            };
+
+            var sectionInvalid = new Section
+            {
+                Title = "section title"
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .withSummarySection(sectionValid)
+                .withSummarySection(sectionInvalid)
+                .Build();
+
+            var page1 = new PageBuilder()
+                .WithPageSlug("test-page")
+                .WithElement(element)
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithName("test-name")
+                .WithPage(page1)
+                .Build();
+
+            // Act
+            var result = _validator.Validate(schema);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Single(result.Messages);
+            Assert.Equal($"{IntegrityChecksConstants.FAILURE}FormSchemaIntegrityCheck::SummaryFormCheck, Summary section is defined but no pages have been specified to appear in the section.", result.Messages.First());
+        }
+
+        [Fact]
+        public void Validate_Should_Return_Error_WhenSummarySection_Has_PageSlug_Which_Is_Unknown()
+        {
+            // Arrange
+            var pageSlug = "unknown-page";
+            var section = new Section
+            {
+                Title = "section title",
+                Pages = new List<string>
+                {
+                   pageSlug
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .withSummarySection(section)
+                .Build();
+
+            var page1 = new PageBuilder()
+                .WithPageSlug("test-page")
+                .WithElement(element)
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithName("test-name")
+                .WithPage(page1)
+                .Build();
+
+            // Act
+            var result = _validator.Validate(schema);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Single(result.Messages);
+            Assert.Equal($"{IntegrityChecksConstants.FAILURE}FormSchemaIntegrityCheck::SummaryFormCheck, Summary section has a page slug defined which cannot be found. Verify '{pageSlug}' is a valid page slug within the schema.", result.Messages.First());
+        }
+
+        [Fact]
+        public void Validate_Should_Return_Success_WhenSumary_Element_IsValid()
+        {
+            // Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .Build();
+
+            var page1 = new PageBuilder()
+                .WithPageSlug("test-page")
+                .WithElement(element)
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithName("test-name")
+                .WithPage(page1)
+                .Build();
+
+            // Act
+            var result = _validator.Validate(schema);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Empty(result.Messages);
+        }
+
+        [Fact]
+        public void Validate_Should_Return_Success_WhenSumary_Element_WithSections_IsValid()
+        {
+            // Arrange
+            var section = new Section
+            {
+                Title = "section title",
+                Pages = new List<string>
+                {
+                   "page-one",
+                   "page-two"
+                }
+            };
+
+            var sectionTwo = new Section
+            {
+                Title = "section title two",
+                Pages = new List<string>
+                {
+                   "page-three"
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .withSummarySection(section)
+                .withSummarySection(sectionTwo)
+                .Build();
+
+            var page1 = new PageBuilder()
+                .WithPageSlug("page-one")
+                .WithElement(element)
+                .Build();
+
+            var page2 = new PageBuilder()
+                .WithPageSlug("page-two")
+                .WithElement(element)
+                .Build();
+
+            var page3 = new PageBuilder()
+                .WithPageSlug("page-three")
+                .WithElement(element)
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithName("test-name")
+                .WithPage(page1)
+                .WithPage(page2)
+                .WithPage(page3)
+                .Build();
+
+            // Act
+            var result = _validator.Validate(schema);
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Empty(result.Messages);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Allow designs to split up the summary into sections via a new property called `Sections`

Refactored Summary RenderAsync to use razor view render to bring inline with other elements.

[Wiki entry](https://github.com/smbc-digital/form-builder/wiki/Summary)


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary