### PR TITLE
fix: remove check on answers to finish form reduction, change logic t…

### DIFF
--- a/src/Extensions/FormAnswersExtensions.cs
+++ b/src/Extensions/FormAnswersExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using form_builder.Constants;
 using form_builder.Enum;
@@ -14,7 +13,7 @@ namespace form_builder.Extensions
                 answer.Pages,
                 answer.Pages.SelectMany(_ => _.Answers).ToDictionary(x => x.QuestionId, x => x.Response),
                 schema.Pages,
-                !String.IsNullOrEmpty(answer.Path) && answer.Path.Equals(FileUploadConstants.DOCUMENT_UPLOAD_URL_PATH) ? answer.Path : schema.FirstPageSlug,
+                !string.IsNullOrEmpty(answer.Path) && answer.Path.Equals(FileUploadConstants.DOCUMENT_UPLOAD_URL_PATH) ? answer.Path : schema.FirstPageSlug,
                 new List<PageAnswers>());
 
         private static List<PageAnswers> RecursivelyReduceAnswers(
@@ -24,26 +23,24 @@ namespace form_builder.Extensions
             string currentPageSlug,
             List<PageAnswers> reducedAnswers)
         {
-            var page = new Page();
             var currentAnswer = answers.Find(_ => _.PageSlug.Equals(currentPageSlug));
-            if (currentAnswer == null)
-                return reducedAnswers;
 
             var currentSchema = schema.FindAll(_ => _.PageSlug.Equals(currentPageSlug));
-            if (currentSchema == null)
+            if (!currentSchema.Any())
                 return reducedAnswers;
 
-            page = currentSchema.Count > 1
-                ? currentSchema.FirstOrDefault(page => page.CheckPageMeetsConditions(answersDictionary))
+            var page = currentSchema.Count > 1
+                ? currentSchema.FirstOrDefault(currentPage => currentPage.CheckPageMeetsConditions(answersDictionary))
                 : currentSchema.FirstOrDefault();
 
-            if (page == null)
+            if (page is null)
                 return reducedAnswers;
 
-            reducedAnswers.Add(currentAnswer);
+            if (currentAnswer is not null)
+                reducedAnswers.Add(currentAnswer);
 
             var behaviour = page.GetNextPage(answersDictionary);
-            if (behaviour.BehaviourType != EBehaviourType.GoToPage)
+            if (behaviour is null || behaviour.BehaviourType != EBehaviourType.GoToPage)
                 return reducedAnswers;
 
             return RecursivelyReduceAnswers(answers, answersDictionary, schema, behaviour.PageSlug, reducedAnswers);

--- a/src/Models/Page.cs
+++ b/src/Models/Page.cs
@@ -116,6 +116,9 @@ namespace form_builder.Models
         {
             var conditionValidator = new ConditionValidator();
 
+            if (Behaviours.Count == 0)
+                return null;
+
             if (Behaviours.Count == 1)
                 return Behaviours.FirstOrDefault();
 


### PR DESCRIPTION
…o look for end of form pages

### Description
We were previously checking if a page didn't have answers to finish our reduction of form answers, this has now been changed to wait for the final page of the form, e.g. a behaviour that isn't GoToPage.

This means we can have fully optional pages within forms and still have all answers reduced at the end.

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary