### PR TITLE
chore(Availability): Updated returned view when form is disabled, Added some additional checks around deserialisation

### DIFF
--- a/src/Services/BookingService/BookingService.cs
+++ b/src/Services/BookingService/BookingService.cs
@@ -162,8 +162,6 @@ namespace form_builder.Services.BookingService
             if (currentPage is null)
                 throw new ApplicationException($"Requested path '{path}' object could not be found for form '{form}'");
 
-            var guid = _sessionHelper.GetSessionGuid();
-
             if (!viewModel.ContainsKey(BookingConstants.BOOKING_MONTH_REQUEST))
                 throw new ApplicationException("BookingService::ProcessMonthRequest, request for appointment did not contain requested month");
 
@@ -183,8 +181,17 @@ namespace form_builder.Services.BookingService
             if (requestedMonth < currentDate)
                 throw new ApplicationException("BookingService::ProcessMonthRequest, Invalid request for appointment search, Start date provided is before today");
 
-            var bookingInformationCacheKey = $"{bookingElement.Properties.QuestionId}{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var guid = _sessionHelper.GetSessionGuid();
+
+            if (string.IsNullOrEmpty(guid))
+                throw new ApplicationException("BookingService::ProcessMonthRequest Session has expired");
+
             var cachedAnswers = _distributedCache.GetString(guid);
+
+            if(cachedAnswers is null)
+                throw new ApplicationException("BookingService::ProcessMonthRequest, Session has expired");
+
+            var bookingInformationCacheKey = $"{bookingElement.Properties.QuestionId}{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
             var convertedAnswers = JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
             var appointmentType = bookingElement.Properties.AppointmentTypes

--- a/src/Services/BookingService/BookingService.cs
+++ b/src/Services/BookingService/BookingService.cs
@@ -189,7 +189,7 @@ namespace form_builder.Services.BookingService
             var cachedAnswers = _distributedCache.GetString(guid);
 
             if(cachedAnswers is null)
-                throw new ApplicationException("BookingService::ProcessMonthRequest, Session has expired");
+                throw new ApplicationException("BookingService::ProcessMonthRequest, Session data is null");
 
             var bookingInformationCacheKey = $"{bookingElement.Properties.QuestionId}{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
             var convertedAnswers = JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);

--- a/src/Services/MappingService/MappingService.cs
+++ b/src/Services/MappingService/MappingService.cs
@@ -90,7 +90,16 @@ namespace form_builder.Services.MappingService
         private async Task<(FormAnswers convertedAnswers, FormSchema baseForm)> GetFormAnswers(string form, string sessionGuid)
         {
             var baseForm = await _schemaFactory.Build(form);
-            var convertedAnswers = JsonConvert.DeserializeObject<FormAnswers>(_distributedCache.GetString(sessionGuid));
+
+            if (string.IsNullOrEmpty(sessionGuid))
+                throw new ApplicationException("MappingService::GetFormAnswers Session has expired");
+
+            var sessionData = _distributedCache.GetString(sessionGuid);
+
+            if(sessionData is null)
+                throw new ApplicationException("MappingService::GetFormAnswers, Session data is null");
+
+            var convertedAnswers = JsonConvert.DeserializeObject<FormAnswers>(sessionData);
             convertedAnswers.Pages = convertedAnswers.GetReducedAnswers(baseForm);
             convertedAnswers.FormName = form;
 

--- a/src/Services/PageService/PageService.cs
+++ b/src/Services/PageService/PageService.cs
@@ -27,6 +27,7 @@ using form_builder.ViewModels;
 using form_builder.Workflows.ActionsWorkflow;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
@@ -52,6 +53,7 @@ namespace form_builder.Services.PageService
         private readonly IPageFactory _pageContentFactory;
         private readonly IIncomingDataHelper _incomingDataHelper;
         private readonly IActionsWorkflow _actionsWorkflow;
+        private readonly ILogger<IPageService> _logger;
 
         public PageService(
             IEnumerable<IElementValidator> validators,
@@ -71,7 +73,8 @@ namespace form_builder.Services.PageService
             IMappingService mappingService,
             IPayService payService,
             IIncomingDataHelper incomingDataHelper,
-            IActionsWorkflow actionsWorkflow)
+            IActionsWorkflow actionsWorkflow,
+            ILogger<IPageService> logger)
         {
             _validators = validators;
             _pageHelper = pageHelper;
@@ -91,6 +94,7 @@ namespace form_builder.Services.PageService
             _mappingService = mappingService;
             _incomingDataHelper = incomingDataHelper;
             _actionsWorkflow = actionsWorkflow;
+            _logger = logger;
         }
 
         public async Task<ProcessPageEntity> ProcessPage(string form, string path, string subPath, IQueryCollection queryParamters)
@@ -112,7 +116,10 @@ namespace form_builder.Services.PageService
                 return null;
 
             if (!baseForm.IsAvailable(_environment.EnvironmentName))
-                throw new ApplicationException($"Form: {form} is not available in this Environment: {_environment.EnvironmentName.ToS3EnvPrefix()}");
+            {
+                _logger.LogWarning($"Form: {form} is not available in this Environment: {_environment.EnvironmentName.ToS3EnvPrefix()}");
+                return null;
+            }
 
             var formData = _distributedCache.GetString(sessionGuid);
 


### PR DESCRIPTION
### Description
Currently when a form is disabled in an enviroment the user will be shown an error page, This has been changed so the 404 page is now displayed also included is some additional checks before deserialising an object within Booking and mapping service to remove a log for `Value cannot be null. (Parameter 'value')`

Old behaviour:
![image](https://user-images.githubusercontent.com/35955528/116680928-3393ff80-a9a4-11eb-94af-e3d864cb7a82.png)

New Behaviour:
![image](https://user-images.githubusercontent.com/35955528/116680982-40185800-a9a4-11eb-84cd-3b06033e0554.png)


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary