### PR TITLE
refactor(H1 Title): Allow (optional) to be added to Title

### DIFF
--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Threading.Tasks;
 using form_builder.Configuration;
 using form_builder.Constants;
+using form_builder.Enum;
 using form_builder.Extensions;
 using form_builder.Helpers.ActionsHelpers;
 using form_builder.Helpers.ElementHelpers;
@@ -63,8 +64,10 @@ namespace form_builder.Helpers.PageHelpers
             var formModel = new FormBuilderViewModel();
 
             if (page.PageSlug.ToLower() != "success" && !page.HideTitle)
+            {
                 formModel.RawHTML += await _viewRender
-                    .RenderAsync("H1", new Element { Properties = new BaseProperty { Text = page.GetPageTitle() } });
+                    .RenderAsync("H1", new Element { Properties = new BaseProperty { Text = page.GetPageTitle(), Optional = page.DisplayOptionalInTitle } });
+            }   
 
             foreach (var element in page.Elements)
             {

--- a/src/Models/Page.cs
+++ b/src/Models/Page.cs
@@ -25,6 +25,8 @@ namespace form_builder.Models
 
         public bool DisplayBreadCrumbs { get; set; }
 
+        public bool DisplayOptionalInTitle { get; set; } = false;
+
         public List<IElement> Elements { get; set; }
 
         public List<Behaviour> Behaviours { get; set; }

--- a/src/Views/Shared/HtmlElements/Headings/H1.cshtml
+++ b/src/Views/Shared/HtmlElements/Headings/H1.cshtml
@@ -14,4 +14,9 @@
             break;
     }
 }
-<h1 class="@cssClass">@Model.Properties.Text</h1>
+<h1 class="@cssClass">@Model.Properties.Text
+    @if (Model.Properties.Optional)
+    {
+        <span class="smbc-body">(optional)</span>
+    }
+</h1>


### PR DESCRIPTION
### Description
For elements which require '(optional)' to be displayed in the H1 Title when HideTitle is false
- Add Property to Page 'DisplayOptionalInTitle' - defaults to false
- In PageHelper GenerateHtml, H1 Property Optional will be set using the Page.DisplayOptionalInTitle
- In H1.cshtml '(optional)' will be added if Property.Optional is true

### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary