### PR TITLE
fix(Layout): Remove media print due to chrome issue resolving icon

### DIFF
--- a/src/Views/Shared/Error/_ErrorLayout.cshtml
+++ b/src/Views/Shared/Error/_ErrorLayout.cshtml
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#006666">
-    <link rel="shortcut icon" type="image/png" href="~/assets/images/favicon-sg.png" media="print" />
+    <link rel="shortcut icon" type="image/png" href="~/assets/images/favicon-sg.png" />
     <title>@ViewData["PageTitle"] @ViewData["Title"] - Stockport Council</title>
     <link href="https://design-system.stockport.gov.uk/int/1/smbc-frontend.min.css" rel="stylesheet" />
     <partial name="TagManagerHead" />

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -13,7 +13,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#006666">
-    <link rel="shortcut icon" type="image/png" href="~/assets/images/favicon-sg.png" media="print" />
+    <link rel="shortcut icon" type="image/png" href="~/assets/images/favicon-sg.png" />
     <title>@ViewData["PageTitle"] - @ViewData["Title"] - Stockport Council</title>
     <link href="https://design-system.stockport.gov.uk/int/1/smbc-frontend.min.css" rel="stylesheet" />
     <partial name="TagManagerHead" />


### PR DESCRIPTION
### Description
Removed media="print" from fav icon, causing issue with chrome browsers requesting /favicon.ico


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary