### PR TITLE
fix(Summary): Added call to reduce answers before building Summary

### DIFF
--- a/src/Builders/SummaryAnswerBuilder.cs
+++ b/src/Builders/SummaryAnswerBuilder.cs
@@ -31,8 +31,11 @@ namespace form_builder.Builders.Document
             return _data;
         }
 
-        public void AddBlankLine()
+        public void AddBlankLine(string answer)
         {
+            if (string.IsNullOrWhiteSpace(answer))
+                return;
+            
             _data.Add(string.Empty);
         }
     }

--- a/src/Builders/SummaryAnswerBuilder.cs
+++ b/src/Builders/SummaryAnswerBuilder.cs
@@ -31,11 +31,8 @@ namespace form_builder.Builders.Document
             return _data;
         }
 
-        public void AddBlankLine(string answer)
+        public void AddBlankLine()
         {
-            if (string.IsNullOrWhiteSpace(answer))
-                return;
-            
             _data.Add(string.Empty);
         }
     }

--- a/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
+++ b/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using form_builder.Builders.Document;
-using form_builder.Enum;
+using form_builder.Extensions;
 using form_builder.Mappers;
 using form_builder.Models;
 
@@ -15,21 +15,25 @@ namespace form_builder.Helpers.DocumentCreation
         public List<string> GenerateQuestionAndAnswersList(FormAnswers formAnswers, FormSchema formSchema)
         {
             var summaryBuilder = new SummaryAnswerBuilder();
+            var reducedAnswers = FormAnswersExtensions.GetReducedAnswers(formAnswers, formSchema);
 
-            formSchema.Pages.ForEach(page =>
+            foreach (var page in formSchema.Pages.ToList())
             {
                 var formSchemaQuestions = page.ValidatableElements
                     .Where(_ => _ != null)
                     .ToList();
+
+                if (!formSchemaQuestions.Any() || !reducedAnswers.Where(p => p.PageSlug == page.PageSlug).Select(p => p).Any())
+                    continue;
 
                 formSchemaQuestions.ForEach(question =>
                 {
                     var answer = _elementMapper.GetAnswerStringValue(question, formAnswers);
                     summaryBuilder.Add(question.GetLabelText(page.Title), answer, question.Type);
 
-                    summaryBuilder.AddBlankLine();
+                    summaryBuilder.AddBlankLine(answer);
                 });
-            });
+            }
 
             return summaryBuilder.Build();
         }

--- a/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
+++ b/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
@@ -31,7 +31,7 @@ namespace form_builder.Helpers.DocumentCreation
                     var answer = _elementMapper.GetAnswerStringValue(question, formAnswers);
                     summaryBuilder.Add(question.GetLabelText(page.Title), answer, question.Type);
 
-                    summaryBuilder.AddBlankLine(answer);
+                    summaryBuilder.AddBlankLine();
                 });
             }
 


### PR DESCRIPTION
### Description
Answers summary was not reducing answers before building the summary of preivous answers, Which meant it could include answers from paths the user has taken which was not part of the final journey. 

Changes:
- Call GetReducedAnswers before creating summary


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary