### PR TITLE
fix(HasDuplicateQuestonIdsCheck): add support for checking nested elements as well

### DIFF
--- a/src/Validators/IntegrityChecks/Form/HasDuplicateQuestionIdsCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/HasDuplicateQuestionIdsCheck.cs
@@ -17,6 +17,14 @@ namespace form_builder.Validators.IntegrityChecks.Form
                 foreach (var element in page.ValidatableElements)
                 {
                     questionIds.Add(element.Properties.QuestionId);
+
+                    if (element.Properties.Elements is not null && element.Properties.Elements.Count > 0)
+                    {
+                        foreach (var nestedElement in element.Properties.Elements)
+                        {
+                            questionIds.Add(nestedElement.Properties.QuestionId);
+                        }
+                    }
                 }
             }
 

--- a/tests/unit-tests/UnitTests/Validators/IntegrityChecks/Form/HasDuplicateQuestionIdsCheckTests.cs
+++ b/tests/unit-tests/UnitTests/Validators/IntegrityChecks/Form/HasDuplicateQuestionIdsCheckTests.cs
@@ -56,6 +56,52 @@ namespace form_builder_tests.UnitTests.Validators.IntegrityChecks.Form
         }
 
         [Fact]
+        public void HasDuplicateQuestionIDsCheck_IsNotValid_IfDuplicateNestedQuestionIDsInJSON()
+        {
+            // Arrange
+            var element1 = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("texbox1")
+                .WithLabel("First name")
+                .Build();
+
+            var element2 = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("texbox2")
+                .WithLabel("Middle name")
+                .Build();
+
+            var element3 = new ElementBuilder()
+                .WithType(EElementType.AddAnother)
+                .WithQuestionId("addAnother")
+                .WithNestedElement(element1)
+                .Build();
+
+            var page1 = new PageBuilder()
+                .WithElement(element1)
+                .WithElement(element2)
+                .Build();
+
+            var page2 = new PageBuilder()
+                .WithElement(element3)
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithPage(page1)
+                .WithPage(page2)
+                .WithName("test-name")
+                .Build();
+
+            // Act
+            HasDuplicateQuestionIdsCheck check = new();
+            var result = check.Validate(schema);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Collection<string>(result.Messages, message => Assert.StartsWith(IntegrityChecksConstants.FAILURE, message));
+        }
+
+        [Fact]
         public void HasDuplicateQuestionIDsCheck_IsValid_IfNoDuplicateQuestionIDsInJSON()
         {
             // Arrange


### PR DESCRIPTION
### Description
Add loop around any nested elements to the duplicateId check


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary