### PR TITLE
chore(TextArea): Amended Textarea rows property

### DIFF
--- a/src/Models/Elements/Textarea.cs
+++ b/src/Models/Elements/Textarea.cs
@@ -40,11 +40,9 @@ namespace form_builder.Models.Elements
                 { "name", Properties.QuestionId },
                 { "id", Properties.QuestionId },
                 { "value", Properties.Value},
-                { "spellcheck", Properties.Spellcheck.ToString().ToLower() }
+                { "spellcheck", Properties.Spellcheck.ToString().ToLower() },
+                { "rows", Properties.MaxLength > 500 ? "15" : "5" }
             };
-
-            if (Properties.MaxLength >= 200)
-                properties.Add("rows", Properties.MaxLength > 500 ? "15" : "5");
 
             if (!DisplayAriaDescribedby)
                 return properties;

--- a/tests/unit-tests/UnitTests/Models/ElementTests.cs
+++ b/tests/unit-tests/UnitTests/Models/ElementTests.cs
@@ -104,57 +104,6 @@ namespace form_builder_tests.UnitTests.Models
             Assert.True(result.ContainsValue(length));
         }
 
-        [Theory]
-        [InlineData(200, "5")]
-        [InlineData(500, "5")]
-        [InlineData(501, "15")]
-        [InlineData(2000, "15")]
-        public void GenerateElementProperties_ShouldReturnCorrectRowsSize_When_MaxLengthSupllied(int length, string expectedValue)
-        {
-            // Arrange
-            var questionId = "test-question-id";
-            var value = "test-value";
-
-            var element = new ElementBuilder()
-                .WithType(EElementType.Textarea)
-                .WithQuestionId(questionId)
-                .WithValue(value)
-                .WithMaxLength(length)
-                .Build();
-
-            // Act
-            var result = element.GenerateElementProperties();
-
-            // Assert
-            Assert.NotEmpty(result);
-            Assert.True(result.ContainsKey("rows"));
-            Assert.True(result.ContainsValue(expectedValue));
-        }
-
-        [Theory]
-        [InlineData(50)]
-        [InlineData(199)]
-        public void GenerateElementProperties_ShouldReturn_NoRowsSize_When_MaxLengthSupllied_Below200(int length)
-        {
-            // Arrange
-            var questionId = "test-question-id";
-            var value = "test-value";
-
-            var element = new ElementBuilder()
-                .WithType(EElementType.Textarea)
-                .WithQuestionId(questionId)
-                .WithValue(value)
-                .WithMaxLength(length)
-                .Build();
-
-            // Act
-            var result = element.GenerateElementProperties();
-
-            // Assert
-            Assert.NotEmpty(result);
-            Assert.False(result.ContainsKey("rows"));
-        }
-
         [Fact]
         public void GenerateElementProperties_ShouldReturnCorrectRowsSize_When_UsingDefaultMaxLength()
         {

--- a/tests/unit-tests/UnitTests/Models/Elements/TextAreaTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/TextAreaTests.cs
@@ -17,13 +17,10 @@ namespace form_builder_tests.UnitTests.Models.Elements
         public void GenerateElementProperties_ShouldReturnCorrectRowsSize_When_MaxLengthSupllied(int length, string expectedValue)
         {
             // Arrange
-            var questionId = "test-question-id";
-            var value = "test-value";
-
             var element = new ElementBuilder()
                 .WithType(EElementType.Textarea)
-                .WithQuestionId(questionId)
-                .WithValue(value)
+                .WithQuestionId("test-question-id")
+                .WithValue("test-value")
                 .WithMaxLength(length)
                 .Build();
 
@@ -37,16 +34,13 @@ namespace form_builder_tests.UnitTests.Models.Elements
         }
 
         [Fact]
-        public void GenerateElementProperties_ShouldReturn_DefaultRow_WhenMaxLength_NotSupplied()
+        public void GenerateElementProperties_ShouldReturn_DefaultRows_Value_WhenMaxLength_NotSupplied()
         {
             // Arrange
-            var questionId = "test-question-id";
-            var value = "test-value";
-
             var element = new ElementBuilder()
                 .WithType(EElementType.Textarea)
-                .WithQuestionId(questionId)
-                .WithValue(value)
+                .WithQuestionId("test-question-id")
+                .WithValue("test-value")
                 .Build();
 
             // Act

--- a/tests/unit-tests/UnitTests/Models/Elements/TextAreaTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/TextAreaTests.cs
@@ -1,0 +1,62 @@
+using form_builder.Builders;
+using form_builder.Enum;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.Models.Elements
+{
+    public class TextAreaTests
+    {
+        
+        [Theory]
+        [InlineData(50, "5")]
+        [InlineData(200, "5")]
+        [InlineData(500, "5")]
+        [InlineData(501, "15")]
+        [InlineData(2000, "15")]
+        [InlineData(4000, "15")]
+        public void GenerateElementProperties_ShouldReturnCorrectRowsSize_When_MaxLengthSupllied(int length, string expectedValue)
+        {
+            // Arrange
+            var questionId = "test-question-id";
+            var value = "test-value";
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textarea)
+                .WithQuestionId(questionId)
+                .WithValue(value)
+                .WithMaxLength(length)
+                .Build();
+
+            // Act
+            var result = element.GenerateElementProperties();
+
+            // Assert
+            Assert.NotEmpty(result);
+            Assert.True(result.ContainsKey("rows"));
+            Assert.True(result.ContainsValue(expectedValue));
+        }
+
+        [Fact]
+        public void GenerateElementProperties_ShouldReturn_DefaultRow_WhenMaxLength_NotSupplied()
+        {
+            // Arrange
+            var questionId = "test-question-id";
+            var value = "test-value";
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textarea)
+                .WithQuestionId(questionId)
+                .WithValue(value)
+                .Build();
+
+            // Act
+            var result = element.GenerateElementProperties();
+
+            // Assert
+            Assert.NotEmpty(result);
+            Assert.True(result.ContainsKey("rows"));
+            Assert.True(result.ContainsValue("5"));
+        }
+
+    }
+}


### PR DESCRIPTION

### Description
If you provided a maxlenght of below 200 the textarea would not add the rows property correctly, and would look like a textbox. The logic has been changed so that it will now always be rows: 5 and rows:15 if the maxlength is greater than 500.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary