### PR TITLE
External data mapping

### DIFF
--- a/src/Models/Properties/ActionProperties/RetrieveExternalDataActionProperty.cs
+++ b/src/Models/Properties/ActionProperties/RetrieveExternalDataActionProperty.cs
@@ -6,6 +6,8 @@ namespace form_builder.Models.Properties.ActionProperties
     {
         public string TargetQuestionId { get; set; }
 
+        public bool IncludeInFormSubmission { get; set; }
+
         public List<PageActionSlug> PageActionSlugs { get; set; }
 
     }

--- a/src/Services/RetrieveExternalDataService/RetrieveExternalDataService.cs
+++ b/src/Services/RetrieveExternalDataService/RetrieveExternalDataService.cs
@@ -89,9 +89,15 @@ namespace form_builder.Services.RetrieveExternalDataService
 
                 answers.Add(answer);
 
-                mappingData.FormAnswers.AdditionalFormData.Add(answer.QuestionId, answer.Response);
+                if (action.Properties.IncludeInFormSubmission)
+                {
+                    if (mappingData.FormAnswers.AdditionalFormData.TryGetValue(answer.QuestionId, out object _))
+                        mappingData.FormAnswers.AdditionalFormData.Remove(answer.QuestionId);
+
+                    mappingData.FormAnswers.AdditionalFormData.Add(answer.QuestionId, answer.Response);
+                }
             }
-            
+
             mappingData.FormAnswers.Pages.FirstOrDefault(_ => _.PageSlug.ToLower().Equals(mappingData.FormAnswers.Path.ToLower())).Answers.AddRange(answers);
 
             await _distributedCache.SetStringAsync(sessionGuid, JsonConvert.SerializeObject(mappingData.FormAnswers), CancellationToken.None);

--- a/src/Services/RetrieveExternalDataService/RetrieveExternalDataService.cs
+++ b/src/Services/RetrieveExternalDataService/RetrieveExternalDataService.cs
@@ -81,13 +81,17 @@ namespace form_builder.Services.RetrieveExternalDataService
                 if (string.IsNullOrWhiteSpace(content))
                     throw new ApplicationException($"RetrieveExternalDataService::Process, Gateway {entity.Url} responded with empty reference");
 
-                answers.Add(new Answers
+                var answer = new Answers
                 {
                     QuestionId = action.Properties.TargetQuestionId,
                     Response = JsonConvert.DeserializeObject<string>(content)
-                });
-            }
+                };
 
+                answers.Add(answer);
+
+                mappingData.FormAnswers.AdditionalFormData.Add(answer.QuestionId, answer.Response);
+            }
+            
             mappingData.FormAnswers.Pages.FirstOrDefault(_ => _.PageSlug.ToLower().Equals(mappingData.FormAnswers.Path.ToLower())).Answers.AddRange(answers);
 
             await _distributedCache.SetStringAsync(sessionGuid, JsonConvert.SerializeObject(mappingData.FormAnswers), CancellationToken.None);

--- a/tests/unit-tests/UnitTests/Services/RetrieveExternalDataServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/RetrieveExternalDataServiceTests.cs
@@ -98,6 +98,57 @@ namespace form_builder_tests.UnitTests.Services
         }
 
         [Fact]
+        public async Task Process_ShouldNot_AddDataToAdditionalFormData_ByDefault()
+        {
+            // Arrange
+            var action = new ActionBuilder()
+               .WithActionType(EActionType.RetrieveExternalData)
+               .WithPageActionSlug(new PageActionSlug
+               {
+                   URL = "www.test.com",
+                   AuthToken = string.Empty,
+                   Environment = "local"
+               })
+               .WithTargetQuestionId("targetId")
+               .Build();
+
+            var actions = new List<IAction> { action };
+
+            // Act
+            await _service.Process(actions, new FormSchema(), "test");
+
+            // Assert
+            Assert.Empty(_mappingEntity.FormAnswers.AdditionalFormData);
+            Assert.False(_mappingEntity.FormAnswers.AdditionalFormData.ContainsKey("targetId"));
+        }
+
+        [Fact]
+        public async Task Process_Should_AddDataToAdditionalFormData_If_IncludeInFormSubmission()
+        {
+            // Arrange
+            var action = new ActionBuilder()
+               .WithActionType(EActionType.RetrieveExternalData)
+               .WithPageActionSlug(new PageActionSlug
+               {
+                   URL = "www.test.com",
+                   AuthToken = string.Empty,
+                   Environment = "local"
+               })
+               .WithTargetQuestionId("targetId")
+               .Build();
+
+            action.Properties.IncludeInFormSubmission = true;
+            var actions = new List<IAction> { action };
+
+            // Act
+            await _service.Process(actions, new FormSchema(), "test");
+
+            // Assert
+            Assert.Single(_mappingEntity.FormAnswers.AdditionalFormData);
+            Assert.True(_mappingEntity.FormAnswers.AdditionalFormData.ContainsKey("targetId"));
+        }
+
+        [Fact]
         public async Task Process_Should_NotCallGatewayToUpdateHeader_IfNoAuthTokenProvided()
         {
             // Arrange


### PR DESCRIPTION
### Description
Added (bool)IncludeInFormSubmission property to BaseProperties of IAction for RetrieveExternalDataActionProperty.cs

This will be handled in RetrieveExternalDataService.cs line: 92

If true, we save the (QuestionId)key-value pair to FormAnswers.AdditionalFormData

If duplicate keys exist, we remove and re-add the value ( This may come in if a user backs up on the form journey )

AdditionalFormData already get's resolved in the Mapping Service Create post Data, so the values that are retrieved externally are now within the submission post data object

Add unit tests

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary