### PR TITLE
chore(refactor): and standardise

### DIFF
--- a/src/Attributes/ValidateReCaptchaAttribute.cs
+++ b/src/Attributes/ValidateReCaptchaAttribute.cs
@@ -27,7 +27,7 @@ namespace form_builder.Attributes
         public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
             var formData = (IDictionary<string, string[]>)context.ActionArguments["formData"];
-            if (context.ActionArguments["path"].Equals(FileUploadConstants.DOCUMENT_UPLOAD_URL_PATH) && formData != null && formData.ContainsKey("Submit"))
+            if (context.ActionArguments["path"].Equals(FileUploadConstants.DOCUMENT_UPLOAD_URL_PATH) && formData is not null && formData.ContainsKey("Submit"))
             {
                 await DoReCaptchaValidation(context);
             }
@@ -71,7 +71,7 @@ namespace form_builder.Attributes
 
             var response = await _gateway.PostAsync(_configuration.ApiVerificationEndpoint, request, false);
 
-            if (response.Content == null)
+            if (response.Content is null)
             {
                 AddModelError(context, "Unable To Read Response From Server");
                 _logger.LogWarning("ValidateReCaptchaAttribute:: ValidateReCaptcha:: Unable To Read Response From Server");

--- a/src/Builders/AvailabilityDayResponseBuilder.cs
+++ b/src/Builders/AvailabilityDayResponseBuilder.cs
@@ -6,7 +6,7 @@ namespace form_builder.Builders
 {
     public class AvailabilityDayResponseBuilder
     {
-        private List<AvailabilityDayResponse> _response = new List<AvailabilityDayResponse>();
+        private List<AvailabilityDayResponse> _response = new();
 
         public List<AvailabilityDayResponse> Build() => _response;
 

--- a/src/Builders/ElementBuilder.cs
+++ b/src/Builders/ElementBuilder.cs
@@ -14,13 +14,13 @@ namespace form_builder.Builders
         private EElementType _type = EElementType.H1;
         private string _lookup = string.Empty;
 
-        private BaseProperty _property = new BaseProperty();
+        private BaseProperty _property = new();
 
         public Element Build()
         {
             var elementType = typeof(IElement).GetTypeInfo().Assembly
                 .GetTypes()
-                .FirstOrDefault(type => type.Name == _type.ToString());
+                .FirstOrDefault(type => type.Name.Equals( _type.ToString()));
 
             var element = (Element)Activator.CreateInstance(elementType);
 
@@ -218,7 +218,7 @@ namespace form_builder.Builders
 
         public ElementBuilder WithAppointmentType(AppointmentType value)
         {
-            if (_property.AppointmentTypes == null)
+            if (_property.AppointmentTypes is null)
                 _property.AppointmentTypes = new List<AppointmentType>();
 
             _property.AppointmentTypes.Add(value);
@@ -284,7 +284,7 @@ namespace form_builder.Builders
 
         public ElementBuilder WithAcceptedMimeType(string type)
         {
-            if (_property.AllowedFileTypes == null)
+            if (_property.AllowedFileTypes is null)
                 _property.AllowedFileTypes = new List<string>();
 
             _property.AllowedFileTypes.Add(type);

--- a/src/Builders/SummaryAnswerBuilder.cs
+++ b/src/Builders/SummaryAnswerBuilder.cs
@@ -14,7 +14,7 @@ namespace form_builder.Builders.Document
             if (string.IsNullOrWhiteSpace(answer))
                 return;
 
-            if (type == EElementType.FileUpload || type == EElementType.MultipleFileUpload)
+            if (type.Equals(EElementType.FileUpload) || type.Equals(EElementType.MultipleFileUpload))
                 _filesData.Add($"{question}: {answer}");
             else
                 _data.Add($"{question}: {answer}");

--- a/src/Builders/SummaryDictionaryBuilder.cs
+++ b/src/Builders/SummaryDictionaryBuilder.cs
@@ -15,7 +15,7 @@ namespace form_builder.Builders
             if (string.IsNullOrWhiteSpace(answer))
                 return;
 
-            if (type == EElementType.FileUpload || type == EElementType.MultipleFileUpload)
+            if (type.Equals(EElementType.FileUpload) || type.Equals(EElementType.MultipleFileUpload))
                 _filesData.Add($"{question}: {answer}");
             else
                 _data.Add(question, answer);

--- a/src/Conditions/DateComparator.cs
+++ b/src/Conditions/DateComparator.cs
@@ -10,7 +10,7 @@ namespace form_builder.Conditions
         public static bool DateIsBefore(Condition condition, Dictionary<string, dynamic> viewModel)
         {
             var dateComparison = DateTime.Today;
-            if (condition.ComparisonDate.ToLower() != "today")
+            if (!condition.ComparisonDate.Equals("today", StringComparison.OrdinalIgnoreCase))
             {
                 dateComparison = DateTime.Parse(condition.ComparisonDate);
             }
@@ -25,10 +25,8 @@ namespace form_builder.Conditions
         public static bool DateIsAfter(Condition condition, Dictionary<string, dynamic> viewModel)
         {
             var dateComparison = DateTime.Today;
-            if (condition.ComparisonDate.ToLower() != "today")
-            {
+            if (!condition.ComparisonDate.Equals("today", StringComparison.OrdinalIgnoreCase))
                 dateComparison = DateTime.Parse(condition.ComparisonDate);
-            }
 
             var isAfter = !string.IsNullOrEmpty(condition.ComparisonValue) ? int.Parse(condition.ComparisonValue) : condition.IsAfter.Value;
             var newComparisonDate = GetComparisonDate(dateComparison, condition.Unit, isAfter);
@@ -40,16 +38,14 @@ namespace form_builder.Conditions
         public static bool DateIsEqual(Condition condition, Dictionary<string, dynamic> viewModel)
         {
             var dateComparison = DateTime.Today;
-            if (condition.ComparisonDate.ToLower() != "today")
-            {
+            if (!condition.ComparisonDate.Equals("today", StringComparison.OrdinalIgnoreCase))
                 dateComparison = DateTime.Parse(condition.ComparisonDate);
-            }
 
             var isEqualTo = !string.IsNullOrEmpty(condition.ComparisonValue) ? int.Parse(condition.ComparisonValue) : condition.IsBefore.Value;
             var newComparisonDate = GetComparisonDate(dateComparison, condition.Unit, isEqualTo);
             var dateValue = GetDateValue(condition.QuestionId, viewModel);
 
-            return DateTime.Compare(dateValue, newComparisonDate) == 0;
+            return DateTime.Compare(dateValue, newComparisonDate).Equals(0);
         }
 
         private static DateTime GetComparisonDate(DateTime dateComparison, EDateUnit unit, int isAfter)

--- a/src/Conditions/FileUploadComparator.cs
+++ b/src/Conditions/FileUploadComparator.cs
@@ -10,7 +10,7 @@ namespace form_builder.Conditions
         {
             var questionId = $"{condition.QuestionId}{FileUploadConstants.SUFFIX}";
 
-            return viewModel.ContainsKey(questionId) && (viewModel[questionId] == null) == bool.Parse(condition.ComparisonValue);
+            return viewModel.ContainsKey(questionId) && (viewModel[questionId] is null).Equals(bool.Parse(condition.ComparisonValue));
         }
     }
 }

--- a/src/Conditions/StringComparator.cs
+++ b/src/Conditions/StringComparator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using form_builder.Models;
 
 namespace form_builder.Conditions
@@ -7,31 +8,30 @@ namespace form_builder.Conditions
     {
         public static bool IsEqualTo(Condition condition, Dictionary<string, dynamic> viewModel)
         {
-            var val = !string.IsNullOrEmpty(condition.ComparisonValue) ? condition.ComparisonValue.ToLower() : condition.EqualTo.ToLower();
+            var val = !string.IsNullOrEmpty(condition.ComparisonValue) ? condition.ComparisonValue : condition.EqualTo;
 
-            return viewModel.ContainsKey(condition.QuestionId) &&
-                   (string)viewModel[condition.QuestionId].ToLower() == val;
+            return viewModel.ContainsKey(condition.QuestionId) && (bool)viewModel[condition.QuestionId].Equals(val, StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool IsNullOrEmpty(Condition condition, Dictionary<string, dynamic> viewModel)
         {
             var val = !string.IsNullOrEmpty(condition.ComparisonValue) ? bool.Parse(condition.ComparisonValue) : condition.IsNullOrEmpty;
 
-            return viewModel.ContainsKey(condition.QuestionId) && string.IsNullOrEmpty((string)viewModel[condition.QuestionId]) == val;
+            return viewModel.ContainsKey(condition.QuestionId) && (bool)viewModel[condition.QuestionId].Equals(val, StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool Contains(Condition condition, Dictionary<string, dynamic> viewModel)
         {
-            var val = !string.IsNullOrEmpty(condition.ComparisonValue) ? condition.ComparisonValue.ToLower() : condition.CheckboxContains.ToLower();
+            var val = !string.IsNullOrEmpty(condition.ComparisonValue) ? condition.ComparisonValue : condition.CheckboxContains;
 
-            return viewModel.ContainsKey(condition.QuestionId) && viewModel[condition.QuestionId].ToLower().Contains(val);
+            return viewModel.ContainsKey(condition.QuestionId) && viewModel[condition.QuestionId].Contains(val, StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool EndsWith(Condition condition, Dictionary<string, dynamic> viewModel)
         {
-            var val = !string.IsNullOrEmpty(condition.ComparisonValue) ? condition.ComparisonValue.ToLower() : condition.CheckboxContains.ToLower();
+            var val = !string.IsNullOrEmpty(condition.ComparisonValue) ? condition.ComparisonValue : condition.CheckboxContains;
 
-            return viewModel.ContainsKey(condition.QuestionId) && viewModel[condition.QuestionId].ToLower().EndsWith(val);
+            return viewModel.ContainsKey(condition.QuestionId) && viewModel[condition.QuestionId].EndsWith(val, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Conditions/StringComparator.cs
+++ b/src/Conditions/StringComparator.cs
@@ -15,9 +15,9 @@ namespace form_builder.Conditions
 
         public static bool IsNullOrEmpty(Condition condition, Dictionary<string, dynamic> viewModel)
         {
-            var val = !string.IsNullOrEmpty(condition.ComparisonValue) ? bool.Parse(condition.ComparisonValue) : condition.IsNullOrEmpty;
+            bool val = !string.IsNullOrEmpty(condition.ComparisonValue) ? bool.Parse(condition.ComparisonValue) : (bool)condition.IsNullOrEmpty;
 
-            return viewModel.ContainsKey(condition.QuestionId) && (bool)viewModel[condition.QuestionId].Equals(val, StringComparison.OrdinalIgnoreCase);
+            return viewModel.ContainsKey(condition.QuestionId) && string.IsNullOrEmpty((string)viewModel[condition.QuestionId]).Equals(val);
         }
 
         public static bool Contains(Condition condition, Dictionary<string, dynamic> viewModel)

--- a/src/Constants/SystemConstants.cs
+++ b/src/Constants/SystemConstants.cs
@@ -4,7 +4,7 @@ namespace form_builder.Constants
 {
     public class SystemConstants
     {
-        public static readonly List<string> AcceptedMimeTypes = new List<string>() { ".png", ".jpg", ".jpeg", ".pdf", ".docx", ".doc", ".odt" };
+        public static readonly List<string> AcceptedMimeTypes = new() { ".png", ".jpg", ".jpeg", ".pdf", ".docx", ".doc", ".odt" };
 
         public static readonly int DefaultMaxFileSize = 10485760;
 

--- a/src/ContentFactory/PageFactory/PageFactory.cs
+++ b/src/ContentFactory/PageFactory/PageFactory.cs
@@ -31,11 +31,11 @@ namespace form_builder.ContentFactory.PageFactory
 
         public async Task<FormBuilderViewModel> Build(Page page, Dictionary<string, dynamic> viewModel, FormSchema baseForm, string sessionGuid, FormAnswers formAnswers = null, List<object> results = null)
         {
-            if (formAnswers == null)
+            if (formAnswers is null)
             {
                 var cachedAnswers = _distributedCache.GetString(sessionGuid);
 
-                formAnswers = cachedAnswers == null
+                formAnswers = cachedAnswers is null
                     ? new FormAnswers { Pages = new List<PageAnswers>(), FormName = baseForm.BaseURL }
                     : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
             }

--- a/src/ContentFactory/SuccessPageFactory/SuccessPageFactory.cs
+++ b/src/ContentFactory/SuccessPageFactory/SuccessPageFactory.cs
@@ -39,13 +39,13 @@ namespace form_builder.ContentFactory.SuccessPageFactory
             _distributedCache.Remove(sessionGuid);
             _sessionHelper.RemoveSessionGuid();
 
-            if (page == null && behaviourType == EBehaviourType.SubmitAndPay)
+            if (page is null && behaviourType.Equals(EBehaviourType.SubmitAndPay))
             {
                 page = GenerateGenericPaymentPage();
                 baseForm.Pages.Add(page);
             }
 
-            if (page == null)
+            if (page is null)
             {
                 return new SuccessPageEntity
                 {
@@ -187,7 +187,7 @@ namespace form_builder.ContentFactory.SuccessPageFactory
                 LeadingParagraph = "We've received your cancellation request",
                 Title = "Success",
                 HideTitle = true,
-                DisplayBreadCrumbs = baseForm.BreadCrumbs != null && baseForm.BreadCrumbs.Any()
+                DisplayBreadCrumbs = baseForm.BreadCrumbs is not null && baseForm.BreadCrumbs.Any()
             };
         }
     }

--- a/src/Controllers/Home/HomeController.cs
+++ b/src/Controllers/Home/HomeController.cs
@@ -6,7 +6,6 @@ using form_builder.Attributes;
 using form_builder.Builders;
 using form_builder.Enum;
 using form_builder.Extensions;
-using form_builder.Helpers.PageHelpers;
 using form_builder.Models;
 using form_builder.Services.FileUploadService;
 using form_builder.Services.PageService;
@@ -51,7 +50,7 @@ namespace form_builder.Controllers
         [Route("/")]
         public IActionResult Home()
         {
-            if (_hostingEnvironment.EnvironmentName.ToLower().Equals("prod"))
+            if (_hostingEnvironment.EnvironmentName.Equals("prod", StringComparison.OrdinalIgnoreCase))
                 return Redirect("https://www.stockport.gov.uk");
 
             return RedirectToAction("Index", "Error");
@@ -69,7 +68,7 @@ namespace form_builder.Controllers
             var queryParamters = Request.Query;
             var response = await _pageService.ProcessPage(form, path, subPath, queryParamters);
 
-            if (response == null)
+            if (response is null)
                 return RedirectToAction("NotFound", "Error");
 
             if (response.ShouldRedirect)
@@ -100,7 +99,7 @@ namespace form_builder.Controllers
         {
             var viewModel = formData.ToNormaliseDictionary(subPath);
 
-            if (fileUpload != null && fileUpload.Any())
+            if (fileUpload is not null && fileUpload.Any())
                 viewModel = _fileUploadService.AddFiles(viewModel, fileUpload);
 
             var currentPageResult = await _pageService.ProcessRequest(form, path, viewModel, fileUpload, ModelState.IsValid);
@@ -114,7 +113,7 @@ namespace form_builder.Controllers
                 return View(currentPageResult.ViewName, currentPageResult.ViewModel);
 
             if (currentPageResult.Page.HasPageActionsPostValues)
-                await _actionsWorkflow.Process(currentPageResult.Page.PageActions.Where(_ => _.Properties.HttpActionType == EHttpActionType.Post).ToList(), null, form);
+                await _actionsWorkflow.Process(currentPageResult.Page.PageActions.Where(_ => _.Properties.HttpActionType.Equals(EHttpActionType.Post)).ToList(), null, form);
 
             var behaviour = _pageService.GetBehaviour(currentPageResult);
 

--- a/src/Extensions/BookingExtensions.cs
+++ b/src/Extensions/BookingExtensions.cs
@@ -5,8 +5,8 @@ namespace form_builder.Extensions
 {
     public static class BookingExtensions
     {
-        public static bool IsEmpty(this Booking value) => value.Id == Guid.Empty
-            && value.Date == DateTime.MinValue
-            && value.StartTime == DateTime.MinValue;
+        public static bool IsEmpty(this Booking value) => value.Id.Equals(Guid.Empty)
+            && value.Date.Equals(DateTime.MinValue)
+            && value.StartTime.Equals(DateTime.MinValue);
     }
 }

--- a/src/Extensions/DictionaryExtensions.cs
+++ b/src/Extensions/DictionaryExtensions.cs
@@ -17,7 +17,7 @@ namespace form_builder.Extensions
                 if (item.Key.EndsWith(FileUploadConstants.SUFFIX))
                     continue;
 
-                if (item.Value.Length == 1)
+                if (item.Value.Length.Equals(1))
                 {
                     if (item.Key.EndsWith(AddressConstants.SELECT_SUFFIX) && !string.IsNullOrEmpty(item.Value[0]))
                     {

--- a/src/Extensions/ElementExtensions.cs
+++ b/src/Extensions/ElementExtensions.cs
@@ -21,12 +21,12 @@ namespace form_builder.Extensions
             {
                 foreach (Option option in element.Properties.Options)
                 {
-                    KeyValuePair<string, dynamic> optionValue = viewModel.FirstOrDefault(value => value.Key == element.Properties.QuestionId && (element.Type.Equals(EElementType.Checkbox) ? value.Value.Contains(option.Value) : value.Value == option.Value));
-                    if (option.ConditionalElementId != null && optionValue.Key == null)
+                    KeyValuePair<string, dynamic> optionValue = viewModel.FirstOrDefault(value => value.Key.Equals(element.Properties.QuestionId) && (element.Type.Equals(EElementType.Checkbox) ? value.Value.Contains(option.Value) : value.Value.Equals(option.Value)));
+                    if (option.ConditionalElementId is not null && optionValue.Key is null)
                     {
                         viewModel.Remove(option.ConditionalElementId);
-                        listOfElements.Remove(listOfElements.FirstOrDefault(_ => _.Properties.QuestionId == option.ConditionalElementId));
-                        listOfConditionalElements.Remove(listOfElements.FirstOrDefault(_ => _.Properties.QuestionId == option.ConditionalElementId));
+                        listOfElements.Remove(listOfElements.FirstOrDefault(_ => _.Properties.QuestionId.Equals(option.ConditionalElementId)));
+                        listOfConditionalElements.Remove(listOfElements.FirstOrDefault(_ => _.Properties.QuestionId.Equals(option.ConditionalElementId)));
                     }
                 }
             }
@@ -34,8 +34,8 @@ namespace form_builder.Extensions
             foreach (Element element in listOfConditionalElements)
             {
                 if (listOfElementsWhichMayContainConditionalElements.Any(_ =>
-                    _.Properties.Options != null && !_.Properties.Options.Any(_ =>
-                        _.ConditionalElementId  != null && _.ConditionalElementId.Equals(element.Properties.QuestionId))))
+                    _.Properties.Options is not null && !_.Properties.Options.Any(_ =>
+                        _.ConditionalElementId  is not null && _.ConditionalElementId.Equals(element.Properties.QuestionId))))
                 {
                     if (listOfElements.Contains(element))
                     {

--- a/src/Extensions/EnumerableExtensions.cs
+++ b/src/Extensions/EnumerableExtensions.cs
@@ -21,25 +21,25 @@ namespace form_builder.Extensions
             value.Single(_ => _.ProviderName.Equals(providerName, StringComparison.OrdinalIgnoreCase));
 
         public static IAddressProvider Get(this IEnumerable<IAddressProvider> value, string providerName) =>
-            value.Single(_ => _.ProviderName == providerName);
+            value.Single(_ => _.ProviderName.Equals(providerName));
 
         public static IBookingProvider Get(this IEnumerable<IBookingProvider> value, string providerName) =>
-            value.Single(_ => _.ProviderName == providerName);
+            value.Single(_ => _.ProviderName.Equals(providerName));
 
         public static IOrganisationProvider Get(this IEnumerable<IOrganisationProvider> value, string providerName) =>
-            value.Single(_ => _.ProviderName == providerName);
+            value.Single(_ => _.ProviderName.Equals(providerName));
 
         public static IStreetProvider Get(this IEnumerable<IStreetProvider> value, string providerName) =>
-            value.Single(_ => _.ProviderName == providerName);
+            value.Single(_ => _.ProviderName.Equals(providerName));
 
         public static IFormatter Get(this IEnumerable<IFormatter> value, string formatterrName) =>
-            value.Single(_ => _.FormatterName == formatterrName);
+            value.Single(_ => _.FormatterName.Equals(formatterrName));
 
         public static ISubmitProvider Get(this IEnumerable<ISubmitProvider> value, string providerName) =>
-            value.Single(_ => _.ProviderName == providerName);
+            value.Single(_ => _.ProviderName.Equals(providerName));
 
         public static ITemplatedEmailProvider Get(this IEnumerable<ITemplatedEmailProvider> value, string providerName) =>
-           value.Single(_ => _.ProviderName == providerName);
+           value.Single(_ => _.ProviderName.Equals(providerName));
 
         public static IEnabledForProvider Get(this IEnumerable<IEnabledForProvider> value, EEnabledFor providerName) =>
            value.Single(_ => _.Type.Equals(providerName));

--- a/src/Extensions/FormAnswersExtensions.cs
+++ b/src/Extensions/FormAnswersExtensions.cs
@@ -26,24 +26,24 @@ namespace form_builder.Extensions
         {
             var page = new Page();
             var currentAnswer = answers.Find(_ => _.PageSlug.Equals(currentPageSlug));
-            if (currentAnswer == null)
+            if (currentAnswer is null)
                 return reducedAnswers;
 
             var currentSchema = schema.FindAll(_ => _.PageSlug.Equals(currentPageSlug));
-            if (currentSchema == null)
+            if (currentSchema is null)
                 return reducedAnswers;
 
             page = currentSchema.Count > 1
                 ? currentSchema.FirstOrDefault(page => page.CheckPageMeetsConditions(answersDictionary))
                 : currentSchema.FirstOrDefault();
 
-            if (page == null)
+            if (page is null)
                 return reducedAnswers;
 
             reducedAnswers.Add(currentAnswer);
 
             var behaviour = page.GetNextPage(answersDictionary);
-            if (behaviour.BehaviourType != EBehaviourType.GoToPage)
+            if (!behaviour.BehaviourType.Equals(EBehaviourType.GoToPage))
                 return reducedAnswers;
 
             return RecursivelyReduceAnswers(answers, answersDictionary, schema, behaviour.PageSlug, reducedAnswers);

--- a/src/Extensions/ListExtension.cs
+++ b/src/Extensions/ListExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using form_builder.Models;
 
@@ -14,6 +15,6 @@ namespace form_builder.Extensions
                   : value.First().ToUpper();
         }
 
-        public static AppointmentType GetAppointmentTypeForEnvironment(this List<AppointmentType> value, string environment) => value.First(_ => _.Environment.ToLower().Equals(environment.ToLower()));
+        public static AppointmentType GetAppointmentTypeForEnvironment(this List<AppointmentType> value, string environment) => value.First(_ => _.Environment.Equals(environment, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/Extensions/ViewModelExtensions.cs
+++ b/src/Extensions/ViewModelExtensions.cs
@@ -7,17 +7,17 @@ namespace form_builder.Extensions
     {
         public static bool IsAutomatic(this Dictionary<string, dynamic> dictionary)
             => dictionary.ContainsKey(LookUpConstants.SubPathViewModelKey)
-            && dictionary[LookUpConstants.SubPathViewModelKey] == LookUpConstants.Automatic;
+            && dictionary[LookUpConstants.SubPathViewModelKey].Equals(LookUpConstants.Automatic);
 
         public static bool IsManual(this Dictionary<string, dynamic> dictionary)
             => dictionary.ContainsKey(LookUpConstants.SubPathViewModelKey)
-            && dictionary[LookUpConstants.SubPathViewModelKey] == LookUpConstants.Manual;
+            && dictionary[LookUpConstants.SubPathViewModelKey].Equals(LookUpConstants.Manual);
 
         public static bool IsInitial(this Dictionary<string, dynamic> dictionary)
             => !(dictionary.IsAutomatic() || dictionary.IsManual());
 
         public static bool IsCheckYourBooking(this Dictionary<string, dynamic> dictionary)
             => dictionary.ContainsKey(LookUpConstants.SubPathViewModelKey)
-            && dictionary[LookUpConstants.SubPathViewModelKey] == BookingConstants.CHECK_YOUR_BOOKING;
+            && dictionary[LookUpConstants.SubPathViewModelKey].Equals(BookingConstants.CHECK_YOUR_BOOKING);
     }
 }

--- a/src/Factories/Schema/SchemaFactory.cs
+++ b/src/Factories/Schema/SchemaFactory.cs
@@ -60,7 +60,7 @@ namespace form_builder.Factories.Schema
             {
                 string data = _distributedCache.GetString($"{ESchemaType.FormJson.ToESchemaTypePrefix(_configuration["ApplicationVersion"])}{formKey}");
 
-                if (data != null)
+                if (data is not null)
                 {
                     formSchema = JsonConvert.DeserializeObject<FormSchema>(data);
                     foreach (var page in formSchema.Pages)

--- a/src/Factories/Transform/ReusableElements/ReusableElementSchemaTransformFactory.cs
+++ b/src/Factories/Transform/ReusableElements/ReusableElementSchemaTransformFactory.cs
@@ -37,16 +37,16 @@ namespace form_builder.Factories.Transform.ReusableElements
             {
                 var page = formSchema.Pages[i];
                 page.Elements
-                    .Where(_ => _.Type == EElementType.Reusable)
+                    .Where(_ => _.Type.Equals(EElementType.Reusable))
                     .ToList()
                     .ForEach(_ => substitutions.Add(CreateSubstitutionRecord(i, page.Elements.IndexOf(_), null, _)));
 
                 for (int j = 0; j < page.Elements.Count; j++)
                 {
-                    if (page.Elements[j].Properties.Elements != null && page.Elements[j].Properties.Elements.Count > 0)
+                    if (page.Elements[j].Properties.Elements is not null && page.Elements[j].Properties.Elements.Count > 0)
                     {
                         page.Elements[j].Properties.Elements
-                            .Where(_ => _.Type == EElementType.Reusable)
+                            .Where(_ => _.Type.Equals(EElementType.Reusable))
                             .ToList()
                             .ForEach(_ => substitutions.Add(CreateSubstitutionRecord(i, page.Elements.IndexOf(page.Elements[j]), page.Elements[j].Properties.Elements.IndexOf(_), _)));
                     }
@@ -76,7 +76,7 @@ namespace form_builder.Factories.Transform.ReusableElements
 
             var substituteElement = await _reusableElementTransformDataProvider.Get(reusableElement.ElementRef);
 
-            if (substituteElement == null)
+            if (substituteElement is null)
                 throw new Exception($"ReusableElementSchemaTransformFactory::CreateSubstituteRecord, No substitute element could be created for question {reusableElement.Properties.QuestionId}");
 
             substituteElement.Properties.QuestionId = reusableElement.Properties.QuestionId;
@@ -87,7 +87,7 @@ namespace form_builder.Factories.Transform.ReusableElements
             if (reusableElement.Properties.Optional)
                 substituteElement.Properties.Optional = true;
 
-            if (reusableElement.Properties.MaxLength != 200)
+            if (!reusableElement.Properties.MaxLength.Equals(200))
                 substituteElement.Properties.MaxLength = reusableElement.Properties.MaxLength;
 
             if (!string.IsNullOrEmpty(reusableElement.Properties.Hint))

--- a/src/Factories/Transform/UserSchema/DynamicLookupPageTransformFactory.cs
+++ b/src/Factories/Transform/UserSchema/DynamicLookupPageTransformFactory.cs
@@ -57,7 +57,7 @@ namespace form_builder.Factories.Transform.UserSchema
                 .SingleOrDefault(x => x.EnvironmentName
                 .Equals(_environment.EnvironmentName, StringComparison.OrdinalIgnoreCase));
 
-            if (submitDetails == null)
+            if (submitDetails is null)
                 throw new Exception("DynamicLookupPageTransformFactory::AddDynamicOptions, No Environment specific details found");
 
             var session = _sessionHelper.GetSessionGuid();
@@ -73,10 +73,10 @@ namespace form_builder.Factories.Transform.UserSchema
                 var lookupProvider = _lookupProviders.Get(submitDetails.Provider);
                 List<Option> lookupOptions = new();
 
-                if (convertedAnswers != null)
+                if (convertedAnswers is not null)
                 {
                     var lookUpCacheResults = convertedAnswers.FormData.SingleOrDefault(x => x.Key.Equals(request.Url, StringComparison.OrdinalIgnoreCase));
-                    if (!string.IsNullOrEmpty(lookUpCacheResults.Key) && lookUpCacheResults.Value != null)
+                    if (!string.IsNullOrEmpty(lookUpCacheResults.Key) && lookUpCacheResults.Value is not null)
                     {
                         lookupOptions = JsonConvert.DeserializeObject<List<Option>>(JsonConvert.SerializeObject(lookUpCacheResults.Value));
                     }

--- a/src/Helpers/ActionsHelpers/ActionHelper.cs
+++ b/src/Helpers/ActionsHelpers/ActionHelper.cs
@@ -60,7 +60,7 @@ namespace form_builder.Helpers.ActionsHelpers
                             .SelectMany(_ => _.Answers)
                             .FirstOrDefault(_ => _.QuestionId.Equals(questionKey));
 
-                    if (question != null)
+                    if (question is not null)
                     {
                         var answer = question.Response as string;
 
@@ -94,7 +94,7 @@ namespace form_builder.Helpers.ActionsHelpers
 
             emailList.AddRange(action.Properties.To.Split(",").Where(_ => !TagRegex.IsMatch(_)));
 
-            return emailList.Where(_ => _ != null).Aggregate((current, email) => current + "," + email);
+            return emailList.Where(_ => _ is not null).Aggregate((current, email) => current + "," + email);
         }
 
         private string Replace(Match match, string current, FormAnswers formAnswers)
@@ -114,7 +114,7 @@ namespace form_builder.Helpers.ActionsHelpers
         {
             var splitTargets = targetMapping.Split(".");
 
-            if (splitTargets.Length == 1)
+            if (splitTargets.Length.Equals(1))
                 return (dynamic)answer.Response;
 
             var subObject = new Answers { Response = (dynamic)answer.Response[splitTargets[1]] };

--- a/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
+++ b/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
@@ -20,10 +20,10 @@ namespace form_builder.Helpers.DocumentCreation
             foreach (var page in formSchema.Pages.ToList())
             {
                 var formSchemaQuestions = page.ValidatableElements
-                    .Where(_ => _ != null)
+                    .Where(_ => _ is not null)
                     .ToList();
 
-                if (!formSchemaQuestions.Any() || !reducedAnswers.Where(p => p.PageSlug == page.PageSlug).Select(p => p).Any())
+                if (!formSchemaQuestions.Any() || !reducedAnswers.Where(p => p.PageSlug.Equals(page.PageSlug)).Select(p => p).Any())
                     continue;
 
                 formSchemaQuestions.ForEach(question =>

--- a/src/Helpers/ElementHelpers/ElementHelper.cs
+++ b/src/Helpers/ElementHelpers/ElementHelper.cs
@@ -59,10 +59,10 @@ namespace form_builder.Helpers.ElementHelpers
             {
                 var storedValue = answers.Pages?.SelectMany(_ => _.Answers);
 
-                if (storedValue != null)
+                if (storedValue is not null)
                 {
-                    var value = storedValue.FirstOrDefault(_ => _.QuestionId == $"{questionId}{suffix}");
-                    return value != null ? (T)value.Response : defaultValue;
+                    var value = storedValue.FirstOrDefault(_ => _.QuestionId.Equals($"{questionId}{suffix}"));
+                    return value is not null ? (T)value.Response : defaultValue;
                 }
                 return defaultValue;
             }
@@ -104,7 +104,7 @@ namespace form_builder.Helpers.ElementHelpers
 
         public bool CheckForRadioOptions(Element element)
         {
-            if (element.Properties.Options == null || element.Properties.Options.Count <= 1)
+            if (element.Properties.Options is null || element.Properties.Options.Count <= 1)
                 throw new Exception("A radio element requires two or more options to be present.");
 
             return true;
@@ -112,7 +112,7 @@ namespace form_builder.Helpers.ElementHelpers
 
         public bool CheckForSelectOptions(Element element)
         {
-            if (element.Properties.Options == null || element.Properties.Options.Count <= 1)
+            if (element.Properties.Options is null || element.Properties.Options.Count <= 1)
                 throw new Exception("A select element requires two or more options to be present.");
 
             return true;
@@ -120,7 +120,7 @@ namespace form_builder.Helpers.ElementHelpers
 
         public bool CheckForCheckBoxListValues(Element element)
         {
-            if (element.Properties.Options == null || element.Properties.Options.Count < 1)
+            if (element.Properties.Options is null || element.Properties.Options.Count < 1)
                 throw new Exception("A checkbox list requires one or more options to be present.");
 
             return true;
@@ -138,7 +138,7 @@ namespace form_builder.Helpers.ElementHelpers
         {
             foreach (var option in element.Properties.Options)
             {
-                if (option.Value == element.Properties.Value)
+                if (option.Value.Equals(element.Properties.Value))
                 {
                     option.Selected = true;
                 }
@@ -153,7 +153,7 @@ namespace form_builder.Helpers.ElementHelpers
         {
             foreach (var option in element.Properties.Options)
             {
-                if (option.Value == element.Properties.Value)
+                if (option.Value.Equals(element.Properties.Value))
                 {
                     option.Checked = true;
                 }
@@ -166,9 +166,9 @@ namespace form_builder.Helpers.ElementHelpers
 
         public bool CheckForProvider(Element element)
         {
-            if (string.IsNullOrEmpty(element.Properties.StreetProvider) && element.Type == EElementType.Street
-                  || string.IsNullOrEmpty(element.Properties.AddressProvider) && element.Type == EElementType.Address
-                  || string.IsNullOrEmpty(element.Properties.OrganisationProvider) && element.Type == EElementType.Organisation)
+            if (string.IsNullOrEmpty(element.Properties.StreetProvider) && element.Type.Equals(EElementType.Street)
+                  || string.IsNullOrEmpty(element.Properties.AddressProvider) && element.Type.Equals(EElementType.Address)
+                  || string.IsNullOrEmpty(element.Properties.OrganisationProvider) && element.Type.Equals(EElementType.Organisation))
                 throw new Exception($"A {element.Type} Provider must be present.");
 
             return true;
@@ -206,10 +206,10 @@ namespace form_builder.Helpers.ElementHelpers
             {
                 var formSchemaQuestions = new List<IElement>();
 
-                if (page.Elements.Any(_ => _.Type == EElementType.AddAnother))
+                if (page.Elements.Any(_ => _.Type.Equals(EElementType.AddAnother)))
                 {
-                    var listOfPageSummary = new List<PageSummary>();
-                    var addAnotherElement = page.Elements.FirstOrDefault(_ => _.Type == EElementType.AddAnother);
+                    List<PageSummary> listOfPageSummary = new();
+                    var addAnotherElement = page.Elements.FirstOrDefault(_ => _.Type.Equals(EElementType.AddAnother));
                     var currentIncrement = GetAddAnotherNumberOfFieldsets(addAnotherElement, formAnswers);
                     for (var i = 1; i <= currentIncrement; i++)
                     {
@@ -236,10 +236,10 @@ namespace form_builder.Helpers.ElementHelpers
                 };
 
                 formSchemaQuestions = page.ValidatableElements
-                .Where(_ => _ != null)
+                .Where(_ => _ is not null)
                 .ToList();
 
-                if (!formSchemaQuestions.Any() || !reducedAnswers.Where(p => p.PageSlug == page.PageSlug).Select(p => p).Any())
+                if (!formSchemaQuestions.Any() || !reducedAnswers.Where(p => p.PageSlug.Equals(page.PageSlug)).Select(p => p).Any())
                     continue;
 
                 pageSummary.Answers = GenerateSummaryAnswers(formSchemaQuestions, page, formAnswers, true);
@@ -263,7 +263,7 @@ namespace form_builder.Helpers.ElementHelpers
 
             foreach (var element in formSchemaQuestions)
             {
-                if (element.Type == EElementType.AddAnother || (element.Properties.IsDynamicallyGeneratedElement && ignoreDynamicallyGeneratedElements))
+                if (element.Type.Equals(EElementType.AddAnother) || (element.Properties.IsDynamicallyGeneratedElement && ignoreDynamicallyGeneratedElements))
                     continue;
 
                 var answer = _elementMapper.GetAnswerStringValue(element, formAnswers);

--- a/src/Helpers/IncomingDataHelper/IncomingDataHelper.cs
+++ b/src/Helpers/IncomingDataHelper/IncomingDataHelper.cs
@@ -59,7 +59,7 @@ namespace form_builder.Helpers.IncomingDataHelper
         {
             var splitTargets = targetMapping.Split(".");
 
-            if (splitTargets.Length == 1)
+            if (splitTargets.Length.Equals(1))
             {
                 obj.Add(splitTargets[0], value);
                 return obj;

--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -64,7 +64,7 @@ namespace form_builder.Helpers.PageHelpers
         {
             var formModel = new FormBuilderViewModel();
 
-            if (page.PageSlug.ToLower() != "success" && !page.HideTitle)
+            if (!page.PageSlug.Equals("success", StringComparison.OrdinalIgnoreCase) && !page.HideTitle)
             {
                 formModel.RawHTML += await _viewRender
                     .RenderAsync("H1", new Element { Properties = new BaseProperty { Text = page.GetPageTitle(), Optional = page.DisplayOptionalInTitle } });
@@ -103,7 +103,7 @@ namespace form_builder.Helpers.PageHelpers
                 {
                     var splitQuestionId = item.Key.Split(':');
                     var currentQuestionIncrement = int.Parse(splitQuestionId[1]);
-                    if (currentQuestionIncrement == incrementToRemove)
+                    if (currentQuestionIncrement.Equals(incrementToRemove))
                     {
                         answersToRemove.Add(item.Key, item.Value);
                     }
@@ -151,13 +151,13 @@ namespace form_builder.Helpers.PageHelpers
             if (!string.IsNullOrEmpty(formData))
                 convertedAnswers = JsonConvert.DeserializeObject<FormAnswers>(formData);
 
-            if (convertedAnswers.Pages != null && convertedAnswers.Pages.Any(_ => _.PageSlug == viewModel["Path"].ToLower()))
+            if (convertedAnswers.Pages is not null && convertedAnswers.Pages.Any(_ => _.PageSlug.Equals(viewModel["Path"], StringComparison.OrdinalIgnoreCase)))
             {
-                currentPageAnswers = convertedAnswers.Pages.Where(_ => _.PageSlug == viewModel["Path"].ToLower()).ToList().FirstOrDefault();
-                convertedAnswers.Pages = convertedAnswers.Pages.Where(_ => _.PageSlug != viewModel["Path"].ToLower()).ToList();
+                currentPageAnswers = convertedAnswers.Pages.Where(_ => _.PageSlug.Equals(viewModel["Path"], StringComparison.OrdinalIgnoreCase)).ToList().FirstOrDefault();
+                convertedAnswers.Pages = convertedAnswers.Pages.Where(_ => !_.PageSlug.Equals(viewModel["Path"], StringComparison.OrdinalIgnoreCase)).ToList();
             }
 
-            var answers = new List<Answers>();
+            List<Answers> answers = new();
 
             foreach (var item in viewModel)
             {
@@ -165,10 +165,10 @@ namespace form_builder.Helpers.PageHelpers
                     answers.Add(new Answers { QuestionId = item.Key, Response = item.Value });
             }
 
-            if ((files == null || !files.Any()) && currentPageAnswers.Answers != null && currentPageAnswers.Answers.Any() && isPageValid && appendMultipleFileUploadParts)
+            if ((files is null || !files.Any()) && currentPageAnswers.Answers is not null && currentPageAnswers.Answers.Any() && isPageValid && appendMultipleFileUploadParts)
                 answers = currentPageAnswers.Answers;
 
-            if (files != null && files.Any() && isPageValid)
+            if (files is not null && files.Any() && isPageValid)
                 answers = SaveFormFileAnswers(answers, files, appendMultipleFileUploadParts, currentPageAnswers);
 
             convertedAnswers.Pages?.Add(new PageAnswers
@@ -263,11 +263,11 @@ namespace form_builder.Helpers.PageHelpers
                 if (isMultipleFileUploadElementType)
                 {
                     var data = currentAnswersForFileUpload.Answers?.FirstOrDefault(_ => _.QuestionId.Equals(file.Key))?.Response;
-                    if (data != null)
+                    if (data is not null)
                     {
                         List<FileUploadModel> response = JsonConvert.DeserializeObject<List<FileUploadModel>>(data.ToString());
                         fileUploadModel.AddRange(response);
-                        filsToAdd = filsToAdd.Where(_ => !response.Any(x => WebUtility.HtmlEncode(_.UntrustedOriginalFileName) == x.TrustedOriginalFileName)).ToList();
+                        filsToAdd = filsToAdd.Where(_ => !response.Any(x => WebUtility.HtmlEncode(_.UntrustedOriginalFileName).Equals(x.TrustedOriginalFileName))).ToList();
                     }
                 }
 
@@ -293,10 +293,10 @@ namespace form_builder.Helpers.PageHelpers
                     FileSize = _.Length
                 }).ToList());
 
-                if (answers.Exists(_ => _.QuestionId == file.Key))
+                if (answers.Exists(_ => _.QuestionId.Equals(file.Key)))
                 {
-                    var fileUploadAnswer = answers.FirstOrDefault(_ => _.QuestionId == file.Key);
-                    if (fileUploadAnswer != null)
+                    var fileUploadAnswer = answers.FirstOrDefault(_ => _.QuestionId.Equals(file.Key));
+                    if (fileUploadAnswer is not null)
                         fileUploadAnswer.Response = fileUploadModel;
                 }
                 else

--- a/src/Helpers/ViewRender/ViewRender.cs
+++ b/src/Helpers/ViewRender/ViewRender.cs
@@ -56,7 +56,7 @@ namespace form_builder.Helpers.ViewRender
                     output,
                     new HtmlHelperOptions());
 
-                if (viewData != null)
+                if (viewData is not null)
                     foreach (var item in viewData)
                         viewContext.ViewData.Add(item.Key, item.Value);
 

--- a/src/ModelBinders/CustomFormFileModelBinder.cs
+++ b/src/ModelBinders/CustomFormFileModelBinder.cs
@@ -12,11 +12,11 @@ namespace form_builder.ModelBinders
     {
         public async Task BindModelAsync(ModelBindingContext bindingContext)
         {
-            if (bindingContext == null) throw new ArgumentNullException(nameof(bindingContext));
+            if (bindingContext is null) throw new ArgumentNullException(nameof(bindingContext));
 
             var formFiles = bindingContext.ActionContext?.HttpContext?.Request?.Form?.Files;
 
-            if (formFiles == null || !formFiles.Any())
+            if (formFiles is null || !formFiles.Any())
                 return;
 
             var list = new List<CustomFormFile>();

--- a/src/ModelBinders/Providers/FormFileModelBinderProvider.cs
+++ b/src/ModelBinders/Providers/FormFileModelBinderProvider.cs
@@ -10,10 +10,10 @@ namespace form_builder.ModelBinders.Providers
     {
         public IModelBinder GetBinder(ModelBinderProviderContext context)
         {
-            if (context == null)
+            if (context is null)
                 throw new ArgumentNullException(nameof(context));
 
-            if (context.Metadata.ModelType == typeof(CustomFormFile))
+            if (context.Metadata.ModelType.Equals(typeof(CustomFormFile)))
                 return new BinderTypeModelBinder(typeof(CustomFormFileModelBinder));
 
             return typeof(IEnumerable<CustomFormFile>).IsAssignableFrom(context.Metadata.ModelType) ? new BinderTypeModelBinder(typeof(CustomFormFileModelBinder)) : null;

--- a/src/Models/Condition.cs
+++ b/src/Models/Condition.cs
@@ -11,11 +11,11 @@ namespace form_builder.Models
         {
             get
             {
-                if (_condition != ECondition.Undefined)
+                if (!_condition.Equals(ECondition.Undefined))
                     return _condition;
 
                 //Backwards compatibility stuff
-                if (IsNullOrEmpty != null)
+                if (IsNullOrEmpty is not null)
                     return ECondition.IsNullOrEmpty;
 
                 if (!string.IsNullOrEmpty(EqualTo))

--- a/src/Models/Elements/AddAnother.cs
+++ b/src/Models/Elements/AddAnother.cs
@@ -9,10 +9,7 @@ namespace form_builder.Models.Elements
 {
     public class AddAnother : Element
     {
-        public AddAnother()
-        {
-            Type = EElementType.AddAnother;
-        }
+        public AddAnother() => Type = EElementType.AddAnother;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/Address.cs
+++ b/src/Models/Elements/Address.cs
@@ -14,6 +14,8 @@ namespace form_builder.Models.Elements
 {
     public class Address : Element
     {
+        public Address() => Type = EElementType.Address;
+
         public List<SelectListItem> Items { get; set; }
 
         public string ReturnURL { get; set; }
@@ -47,12 +49,6 @@ namespace form_builder.Models.Elements
 
         public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{GetIsOptionalLabelText()}";
         
-
-        public Address()
-        {
-            Type = EElementType.Address;
-        }
-
         public override async Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
             string guid,
@@ -86,14 +82,14 @@ namespace form_builder.Models.Elements
                         : $"{environment.EnvironmentName.ToReturnUrlPrefix()}/v2/{formSchema.BaseURL}/{page.PageSlug}/manual";
 
                     var selectedAddress = elementHelper.CurrentValue(Properties.QuestionId, viewModel, formAnswers, AddressConstants.SELECT_SUFFIX);
-                    var searchSuffix = results?.Count == 1 ? "address found" : "addresses found";
+                    var searchSuffix = (bool)(results?.Count.Equals(1)) ? "address found" : "addresses found";
                     Items = new List<SelectListItem> { new SelectListItem($"{results.Count} {searchSuffix}", string.Empty) };
 
                     results.ForEach((objectResult) =>
                     {
                         AddressSearchResult searchResult;
 
-                        if ((objectResult as JObject) != null)
+                        if ((objectResult as JObject) is not null)
                             searchResult = (objectResult as JObject).ToObject<AddressSearchResult>();
                         else
                             searchResult = objectResult as AddressSearchResult;

--- a/src/Models/Elements/AddressManual.cs
+++ b/src/Models/Elements/AddressManual.cs
@@ -14,6 +14,8 @@ namespace form_builder.Models.Elements
 {
     public class AddressManual : Element
     {
+        public AddressManual() => Type = EElementType.AddressManual;
+
         private string[] ErrorMessages
         {
             get
@@ -28,7 +30,7 @@ namespace form_builder.Models.Elements
 
         public bool IsLine1Valid => string.IsNullOrEmpty(Line1ValidationMessage);
 
-        public ErrorViewModel Line1ValidationModel => new ErrorViewModel
+        public ErrorViewModel Line1ValidationModel => new()
         {
             Id = GetCustomErrorId(AddressManualConstants.ADDRESS_LINE_1),
             IsValid = IsLine1Valid,
@@ -39,7 +41,7 @@ namespace form_builder.Models.Elements
 
         public bool IsTownValid => string.IsNullOrEmpty(TownValidationMessage);
 
-        public ErrorViewModel TownValidationModel => new ErrorViewModel
+        public ErrorViewModel TownValidationModel => new()
         {
             Id = GetCustomErrorId(AddressManualConstants.TOWN),
             IsValid = IsTownValid,
@@ -62,10 +64,6 @@ namespace form_builder.Models.Elements
         };
 
         public string ReturnURL { get; set; }
-        public AddressManual()
-        {
-            Type = EElementType.AddressManual;
-        }
 
         public AddressManual(ValidationResult validation)
         {
@@ -129,7 +127,7 @@ namespace form_builder.Models.Elements
         {
             SetAddressProperties(elementHelper, formAnswers, page.PageSlug, guid, viewModel);
 
-            if (results != null && results.Count == 0)
+            if (results is not null && results.Count.Equals(0))
                 Properties.DisplayNoResultsIAG = true;
 
             ReturnURL = environment.EnvironmentName.Equals("local") || environment.EnvironmentName.Equals("uitest")

--- a/src/Models/Elements/Booking.cs
+++ b/src/Models/Elements/Booking.cs
@@ -33,7 +33,7 @@ namespace form_builder.Models.Elements
         public DateTime CurrentSelectedMonth { get; set; }
         public DateTime FirstAvailableMonth { get; set; }
         public string AppointmentTypeFullDayIAG => $"You can select a date but you cannot select a time. We’ll be with you between {AppointmentStartTime.ToTimeFormat()} and {AppointmentEndTime.ToTimeFormat()}.";
-        public bool DisplayNextAvailableAppointmentIAG => FirstAvailableMonth.Date > DateTime.Now.Date && CurrentSelectedMonth.Month == FirstAvailableMonth.Month && CurrentSelectedMonth.Year == FirstAvailableMonth.Year;
+        public bool DisplayNextAvailableAppointmentIAG => FirstAvailableMonth.Date > DateTime.Now.Date && CurrentSelectedMonth.Month.Equals(FirstAvailableMonth.Month) && CurrentSelectedMonth.Year.Equals(FirstAvailableMonth.Year);
         public string InsetText => SetInsetText();
         public bool DisplayInsetText => InsetText.Length > 0;
         public string CurrentSelectedMonthText => $"{CurrentSelectedMonth:MMMMM yyyy}";
@@ -138,7 +138,7 @@ namespace form_builder.Models.Elements
             {
                 var day = new DateTime(CurrentSelectedMonth.Year, CurrentSelectedMonth.Month, i + 1);
                 var containsDay = Appointments.FirstOrDefault(_ => _.Date.Equals(day));
-                dates.Add(new CalendarDay { Date = day, IsDisabled = containsDay == null, Checked = containsDay != null && Properties.Value.Equals(day.Date.ToString()) });
+                dates.Add(new CalendarDay { Date = day, IsDisabled = containsDay is null, Checked = containsDay is not null && Properties.Value.Equals(day.Date.ToString()) });
             }
 
             for (int i = dates.Count + 1; i < 43; i++)
@@ -194,7 +194,7 @@ namespace form_builder.Models.Elements
         {
             var selectedAppointment = Appointments.FirstOrDefault(_ => _.Date.ToString().Equals(Properties.Value));
 
-            if (selectedAppointment == null)
+            if (selectedAppointment is null)
                 throw new ApplicationException("Booking::GetSelectedAppointment, Unable to find selected appointment while attempting to generate check your booking view");
 
             AppointmentStartTime = DateTime.Parse(StartAppointmentTime);

--- a/src/Models/Elements/Button.cs
+++ b/src/Models/Elements/Button.cs
@@ -12,10 +12,7 @@ namespace form_builder.Models.Elements
 {
     public class Button : Element
     {
-        public Button()
-        {
-            Type = EElementType.Button;
-        }
+        public Button() => Type = EElementType.Button;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
@@ -37,12 +34,12 @@ namespace form_builder.Models.Elements
 
         private bool CheckForBehaviour(List<Behaviour> behaviour)
         {
-            return behaviour.Any(_ => _.BehaviourType == EBehaviourType.SubmitForm || _.BehaviourType == EBehaviourType.SubmitAndPay);
+            return behaviour.Any(_ => _.BehaviourType.Equals(EBehaviourType.SubmitForm) || _.BehaviourType.Equals(EBehaviourType.SubmitAndPay));
         }
 
         private bool CheckForLookups(List<IElement> element, Dictionary<string, dynamic> viewModel)
         {
-            var containsLookupElement = element.Any(_ => _.Type == EElementType.Address || _.Type == EElementType.Street || _.Type == EElementType.Organisation);
+            var containsLookupElement = element.Any(_ => _.Type.Equals(EElementType.Address) || _.Type.Equals(EElementType.Street) || _.Type.Equals(EElementType.Organisation));
 
             if (containsLookupElement && !viewModel.IsInitial())
                 return false;
@@ -57,24 +54,24 @@ namespace form_builder.Models.Elements
 
         private string GetButtonText(List<IElement> element, Dictionary<string, dynamic> viewModel, Page page)
         {
-            if (element.Any(_ => _.Type == EElementType.Address) && viewModel.IsInitial())
+            if (element.Any(_ => _.Type.Equals(EElementType.Address)) && viewModel.IsInitial())
                 return ButtonConstants.ADDRESS_SEARCH_TEXT;
 
-            if (element.Any(_ => _.Type == EElementType.Street) && viewModel.IsInitial())
+            if (element.Any(_ => _.Type.Equals(EElementType.Street)) && viewModel.IsInitial())
                 return ButtonConstants.STREET_SEARCH_TEXT;
 
-            if (element.Any(_ => _.Type == EElementType.Organisation) && viewModel.IsInitial())
+            if (element.Any(_ => _.Type.Equals(EElementType.Organisation)) && viewModel.IsInitial())
                 return ButtonConstants.ORG_SEARCH_TEXT;
 
-            if (element.Any(_ => _.Type == EElementType.Booking))
+            if (element.Any(_ => _.Type.Equals(EElementType.Booking)))
             {
-                var bookingElement = element.FirstOrDefault(_ => _.Type == EElementType.Booking);
+                var bookingElement = element.FirstOrDefault(_ => _.Type.Equals(EElementType.Booking));
 
                 if (bookingElement.Properties.CheckYourBooking && !viewModel.IsCheckYourBooking())
                     return string.IsNullOrEmpty(Properties.Text) ? ButtonConstants.NEXTSTEP_TEXT : Properties.Text;
             }
 
-            if (page.Behaviours.Any(_ => _.BehaviourType == EBehaviourType.SubmitForm || _.BehaviourType == EBehaviourType.SubmitAndPay))
+            if (page.Behaviours.Any(_ => _.BehaviourType.Equals(EBehaviourType.SubmitForm) || _.BehaviourType.Equals(EBehaviourType.SubmitAndPay)))
                 return string.IsNullOrEmpty(Properties.Text) ? ButtonConstants.SUBMIT_TEXT : Properties.Text;
 
             return string.IsNullOrEmpty(Properties.Text) ? ButtonConstants.NEXTSTEP_TEXT : Properties.Text;

--- a/src/Models/Elements/Checkbox.cs
+++ b/src/Models/Elements/Checkbox.cs
@@ -9,10 +9,7 @@ namespace form_builder.Models.Elements
 {
     public class Checkbox : Element
     {
-        public Checkbox()
-        {
-            Type = EElementType.Checkbox;
-        }
+        public Checkbox() => Type = EElementType.Checkbox;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/DateInput.cs
+++ b/src/Models/Elements/DateInput.cs
@@ -11,10 +11,7 @@ namespace form_builder.Models.Elements
 {
     public class DateInput : Element
     {
-        public DateInput()
-        {
-            Type = EElementType.DateInput;
-        }
+        public DateInput() => Type = EElementType.DateInput;
 
         public static string DAY_EXTENSION => "-day";
         public static string MONTH_EXTENSION => "-month";
@@ -83,9 +80,9 @@ namespace form_builder.Models.Elements
         public static DateTime? GetDate(FormAnswers answers, string key)
         {
             IEnumerable<Answers> flattenedAnswers = answers.AllAnswers;
-            string year = flattenedAnswers.Single(answer => answer.QuestionId == $"{key}{DateInput.YEAR_EXTENSION}").Response; 
-            string month = flattenedAnswers.Single(answer => answer.QuestionId == $"{key}{DateInput.MONTH_EXTENSION}").Response;
-            string day = flattenedAnswers.Single(answer => answer.QuestionId == $"{key}{DateInput.DAY_EXTENSION}").Response;
+            string year = flattenedAnswers.Single(answer => answer.QuestionId.Equals($"{key}{DateInput.YEAR_EXTENSION}")).Response; 
+            string month = flattenedAnswers.Single(answer => answer.QuestionId.Equals($"{key}{DateInput.MONTH_EXTENSION}")).Response;
+            string day = flattenedAnswers.Single(answer => answer.QuestionId.Equals($"{key}{DateInput.DAY_EXTENSION}")).Response;
             
             return new DateTime(Convert.ToInt32(year), Convert.ToInt32(month), Convert.ToInt32(day));
         }

--- a/src/Models/Elements/DatePicker.cs
+++ b/src/Models/Elements/DatePicker.cs
@@ -13,10 +13,7 @@ namespace form_builder.Models.Elements
     {
         public const string PLACEHOLDER_DATE_FORMAT = "dd/mm/yyyy";
 
-        public DatePicker()
-        {
-            Type = EElementType.DatePicker;
-        }
+        public DatePicker() => Type = EElementType.DatePicker;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
@@ -80,9 +77,9 @@ namespace form_builder.Models.Elements
         public static DateTime? GetDate(FormAnswers answers, string key)
         {
             IEnumerable<Answers> response = answers.AllAnswers;
-            Answers answer = response.SingleOrDefault(_ => _.QuestionId == key);
+            Answers answer = response.SingleOrDefault(_ => _.QuestionId.Equals(key));
 
-            if (answer == null || string.IsNullOrEmpty(answer.Response))
+            if (answer is null || string.IsNullOrEmpty(answer.Response))
                 return null;
 
             if (!DateTime.TryParse(answer.Response, out DateTime dateValue))

--- a/src/Models/Elements/Declaration.cs
+++ b/src/Models/Elements/Declaration.cs
@@ -9,10 +9,7 @@ namespace form_builder.Models.Elements
 {
     public class Declaration : Element
     {
-        public Declaration()
-        {
-            Type = EElementType.Declaration;
-        }
+        public Declaration() => Type = EElementType.Declaration;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/DocumentDownload.cs
+++ b/src/Models/Elements/DocumentDownload.cs
@@ -5,9 +5,6 @@ namespace form_builder.Models.Elements
     public class DocumentDownload : Element
     {
 
-        public DocumentDownload()
-        {
-            Type = EElementType.DocumentDownload;
-        }
+        public DocumentDownload() => Type = EElementType.DocumentDownload;
     }
 }

--- a/src/Models/Elements/DocumentUpload.cs
+++ b/src/Models/Elements/DocumentUpload.cs
@@ -10,10 +10,7 @@ namespace form_builder.Models.Elements
 {
     public class DocumentUpload : Element
     {
-        public DocumentUpload()
-        {
-            Type = EElementType.DocumentUpload;
-        }
+        public DocumentUpload() => Type = EElementType.DocumentUpload;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/Element.cs
+++ b/src/Models/Elements/Element.cs
@@ -13,10 +13,7 @@ namespace form_builder.Models.Elements
     {
         protected ValidationResult validationResult;
 
-        public Element()
-        {
-            validationResult = new ValidationResult();
-        }
+        public Element() => validationResult = new ValidationResult();
 
         public EElementType Type { get; set; }
 

--- a/src/Models/Elements/Fieldset.cs
+++ b/src/Models/Elements/Fieldset.cs
@@ -9,10 +9,7 @@ namespace form_builder.Models.Elements
 {
     public class Fieldset : Element
     {
-        public Fieldset()
-        {
-            Type = EElementType.Fieldset;
-        }
+        public Fieldset() => Type = EElementType.Fieldset;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/FileUpload.cs
+++ b/src/Models/Elements/FileUpload.cs
@@ -10,10 +10,7 @@ namespace form_builder.Models.Elements
 {
     public class FileUpload : Element
     {
-        public FileUpload()
-        {
-            Type = EElementType.FileUpload;
-        }
+        public FileUpload() => Type = EElementType.FileUpload;
 
         public override string QuestionId => $"{base.QuestionId}{FileUploadConstants.SUFFIX}";
 

--- a/src/Models/Elements/H1.cs
+++ b/src/Models/Elements/H1.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class H1 : Element
     {
-        public H1()
-        {
-            Type = EElementType.H1;
-        }
+        public H1() => Type = EElementType.H1;
     }
 }

--- a/src/Models/Elements/H2.cs
+++ b/src/Models/Elements/H2.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class H2 : Element
     {
-        public H2()
-        {
-            Type = EElementType.H2;
-        }
+        public H2() => Type = EElementType.H2;
     }
 }

--- a/src/Models/Elements/H3.cs
+++ b/src/Models/Elements/H3.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class H3 : Element
     {
-        public H3()
-        {
-            Type = EElementType.H3;
-        }
+        public H3() => Type = EElementType.H3;
     }
 }

--- a/src/Models/Elements/H4.cs
+++ b/src/Models/Elements/H4.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class H4 : Element
     {
-        public H4()
-        {
-            Type = EElementType.H4;
-        }
+        public H4() => Type = EElementType.H4;
     }
 }

--- a/src/Models/Elements/H5.cs
+++ b/src/Models/Elements/H5.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class H5 : Element
     {
-        public H5()
-        {
-            Type = EElementType.H5;
-        }
+        public H5() => Type = EElementType.H5;
     }
 }

--- a/src/Models/Elements/H6.cs
+++ b/src/Models/Elements/H6.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class H6 : Element
     {
-        public H6()
-        {
-            Type = EElementType.H6;
-        }
+        public H6() => Type = EElementType.H6;
     }
 }

--- a/src/Models/Elements/HR.cs
+++ b/src/Models/Elements/HR.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class HR : Element
     {
-        public HR()
-        {
-            Type = EElementType.HR;
-        }
+        public HR() => Type = EElementType.HR;
     }
 }

--- a/src/Models/Elements/Img.cs
+++ b/src/Models/Elements/Img.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class Img : Element
     {
-        public Img()
-        {
-            Type = EElementType.Img;
-        }
+        public Img() => Type = EElementType.Img;
     }
 }

--- a/src/Models/Elements/InlineAlert.cs
+++ b/src/Models/Elements/InlineAlert.cs
@@ -9,10 +9,7 @@ namespace form_builder.Models.Elements
 {
     public class InlineAlert : Element
     {
-        public InlineAlert()
-        {
-            Type = EElementType.InlineAlert;
-        }
+        public InlineAlert() => Type = EElementType.InlineAlert;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/Legend.cs
+++ b/src/Models/Elements/Legend.cs
@@ -9,10 +9,7 @@ namespace form_builder.Models.Elements
 {
     public class Legend : Element
     {
-        public Legend()
-        {
-            Type = EElementType.Legend;
-        }
+        public Legend() => Type = EElementType.Legend;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/Link.cs
+++ b/src/Models/Elements/Link.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class Link : Element
     {
-        public Link()
-        {
-            Type = EElementType.Link;
-        }
+        public Link() => Type = EElementType.Link;
     }
 }

--- a/src/Models/Elements/Map.cs
+++ b/src/Models/Elements/Map.cs
@@ -14,10 +14,7 @@ namespace form_builder.Models.Elements
 
         public string VendorJSFIle => $"{Properties.Source}/vendor-latest.js";
 
-        public Map()
-        {
-            Type = EElementType.Map;
-        }
+        public Map() => Type = EElementType.Map;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/MultipleFileUpload.cs
+++ b/src/Models/Elements/MultipleFileUpload.cs
@@ -14,14 +14,11 @@ namespace form_builder.Models.Elements
 {
     public class MultipleFileUpload : Element
     {
-        public MultipleFileUpload()
-        {
-            Type = EElementType.MultipleFileUpload;
-        }
+        public MultipleFileUpload() => Type = EElementType.MultipleFileUpload;
 
         public string AllowFileTypeText { get { return Properties.AllowedFileTypes?.ToReadableFileType("and") ?? SystemConstants.AcceptedMimeTypes.ToReadableFileType("and"); } }
-        public string MaxFileSizeText { get { return $"{(Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes == 0 ? SystemConstants.DefaultMaxFileSize.ToReadableMaxFileSize() : Properties.MaxFileSize)}MB"; } }
-        public string MaxCombinedFileSizeText { get { return $"{(Properties.MaxCombinedFileSize == 0 ? SystemConstants.DefaultMaxCombinedFileSize.ToReadableMaxFileSize() : Properties.MaxCombinedFileSize)}MB"; } }
+        public string MaxFileSizeText { get { return $"{(Properties.MaxFileSize * (SystemConstants.OneMBInBinaryBytes.Equals(0) ? SystemConstants.DefaultMaxFileSize.ToReadableMaxFileSize() : Properties.MaxFileSize))}MB"; } }
+        public string MaxCombinedFileSizeText { get { return $"{(Properties.MaxCombinedFileSize.Equals(0) ? SystemConstants.DefaultMaxCombinedFileSize.ToReadableMaxFileSize() : Properties.MaxCombinedFileSize)}MB"; } }
         public override string QuestionId => $"{base.QuestionId}{FileUploadConstants.SUFFIX}";
         public List<string> CurrentFilesUploaded { get; set; } = new List<string>();
         public int MaxFileSize => Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes > 0 && Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes < SystemConstants.DefaultMaxFileSize ? Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes : SystemConstants.DefaultMaxFileSize;
@@ -65,7 +62,7 @@ namespace form_builder.Models.Elements
             SubmitButtonText = SetSubmitButtonText(page);
             IsModelStateValid = !viewModel.ContainsKey("modelStateInvalid");
 
-            if (currentAnswer != null)
+            if (currentAnswer is not null)
             {
                 List<FileUploadModel> response = JsonConvert.DeserializeObject<List<FileUploadModel>>(currentAnswer.ToString());
                 CurrentFilesUploaded = response.Select(_ => _.TrustedOriginalFileName).ToList();
@@ -81,7 +78,7 @@ namespace form_builder.Models.Elements
 
         private string SetSubmitButtonText(Page page)
         {
-            if (page.Behaviours.Any(_ => _.BehaviourType == EBehaviourType.SubmitForm || _.BehaviourType == EBehaviourType.SubmitAndPay))
+            if (page.Behaviours.Any(_ => _.BehaviourType.Equals(EBehaviourType.SubmitForm) || _.BehaviourType.Equals(EBehaviourType.SubmitAndPay)))
                 return string.IsNullOrEmpty(Properties.PageSubmitButtonLabel) ? ButtonConstants.SUBMIT_TEXT : Properties.PageSubmitButtonLabel;
 
             return string.IsNullOrEmpty(Properties.PageSubmitButtonLabel) ? ButtonConstants.NEXTSTEP_TEXT : Properties.PageSubmitButtonLabel;

--- a/src/Models/Elements/OL.cs
+++ b/src/Models/Elements/OL.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class OL : Element
     {
-        public OL()
-        {
-            Type = EElementType.OL;
-        }
+        public OL() => Type = EElementType.OL;
     }
 }

--- a/src/Models/Elements/Organisation.cs
+++ b/src/Models/Elements/Organisation.cs
@@ -45,10 +45,7 @@ namespace form_builder.Models.Elements
 
         public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{GetIsOptionalLabelText()}";
 
-        public Organisation()
-        {
-            Type = EElementType.Organisation;
-        }
+        public Organisation() => Type = EElementType.Organisation;
 
         public override async Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
@@ -79,7 +76,7 @@ namespace form_builder.Models.Elements
                     {
                         OrganisationSearchResult searchResult;
 
-                        if (objectResult as JObject != null)
+                        if (objectResult as JObject is not null)
                             searchResult = (objectResult as JObject).ToObject<OrganisationSearchResult>();
                         else
                             searchResult = objectResult as OrganisationSearchResult;

--- a/src/Models/Elements/P.cs
+++ b/src/Models/Elements/P.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class P : Element
     {
-        public P()
-        {
-            Type = EElementType.P;
-        }
+        public P() => Type = EElementType.P;
     }
 }

--- a/src/Models/Elements/Radio.cs
+++ b/src/Models/Elements/Radio.cs
@@ -9,10 +9,8 @@ namespace form_builder.Models.Elements
 {
     public class Radio : Element
     {
-        public Radio()
-        {
-            Type = EElementType.Radio;
-        }
+        public Radio() => Type = EElementType.Radio;
+
         public async override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
             string guid,

--- a/src/Models/Elements/Reusable.cs
+++ b/src/Models/Elements/Reusable.cs
@@ -5,9 +5,6 @@ namespace form_builder.Models.Elements
     public class Reusable : Element
     {
         public string ElementRef { get; set; } = string.Empty;
-        public Reusable()
-        {
-            Type = EElementType.Reusable;
-        }
+        public Reusable() => Type = EElementType.Reusable;
     }
 }

--- a/src/Models/Elements/Select.cs
+++ b/src/Models/Elements/Select.cs
@@ -9,10 +9,8 @@ namespace form_builder.Models.Elements
 {
     public class Select : Element
     {
-        public Select()
-        {
-            Type = EElementType.Select;
-        }
+        public Select() => Type = EElementType.Select;
+
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
             string guid,

--- a/src/Models/Elements/Span.cs
+++ b/src/Models/Elements/Span.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class Span : Element
     {
-        public Span()
-        {
-            Type = EElementType.Span;
-        }
+        public Span() => Type = EElementType.Span;
     }
 }

--- a/src/Models/Elements/Street.cs
+++ b/src/Models/Elements/Street.cs
@@ -72,7 +72,7 @@ namespace form_builder.Models.Elements
                         : $"{environment.EnvironmentName.ToReturnUrlPrefix()}/v2/{formSchema.BaseURL}/{page.PageSlug}";
 
                     var selectedStreet = elementHelper.CurrentValue(Properties.QuestionId, viewModel, formAnswers, StreetConstants.SELECT_SUFFIX);
-                    var searchSuffix = (bool)(results?.Count.Equals(1)) ? "street found" : "streets found";
+                    var searchSuffix = results?.Count == 1 ? "street found" : "streets found";
                     Items = new List<SelectListItem> { new SelectListItem($"{results?.Count} {searchSuffix}", string.Empty) };
 
                     results?.ForEach((objectResult) =>

--- a/src/Models/Elements/Street.cs
+++ b/src/Models/Elements/Street.cs
@@ -14,6 +14,8 @@ namespace form_builder.Models.Elements
 {
     public class Street : Element
     {
+        public Street() => Type = EElementType.Street;
+
         public List<SelectListItem> Items { get; set; }
 
         public string ReturnURL { get; set; }
@@ -45,11 +47,6 @@ namespace form_builder.Models.Elements
 
         public override string GetLabelText(string pageTitle) => $"{(string.IsNullOrEmpty(Properties.SummaryLabel) ? pageTitle : Properties.SummaryLabel)}{GetIsOptionalLabelText()}";
 
-        public Street()
-        {
-            Type = EElementType.Street;
-        }
-
         public override async Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
             string guid,
@@ -75,14 +72,14 @@ namespace form_builder.Models.Elements
                         : $"{environment.EnvironmentName.ToReturnUrlPrefix()}/v2/{formSchema.BaseURL}/{page.PageSlug}";
 
                     var selectedStreet = elementHelper.CurrentValue(Properties.QuestionId, viewModel, formAnswers, StreetConstants.SELECT_SUFFIX);
-                    var searchSuffix = results?.Count == 1 ? "street found" : "streets found";
+                    var searchSuffix = (bool)(results?.Count.Equals(1)) ? "street found" : "streets found";
                     Items = new List<SelectListItem> { new SelectListItem($"{results?.Count} {searchSuffix}", string.Empty) };
 
                     results?.ForEach((objectResult) =>
                     {
                         AddressSearchResult searchResult;
 
-                        if (objectResult as JObject != null)
+                        if (objectResult as JObject is not null)
                             searchResult = (objectResult as JObject).ToObject<AddressSearchResult>();
                         else
                             searchResult = objectResult as AddressSearchResult;

--- a/src/Models/Elements/Summary.cs
+++ b/src/Models/Elements/Summary.cs
@@ -12,10 +12,7 @@ namespace form_builder.Models.Elements
 {
     public class Summary : Element
     {
-        public Summary()
-        {
-            Type = EElementType.Summary;
-        }
+        public Summary() => Type = EElementType.Summary;
 
         public override async Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
@@ -30,7 +27,7 @@ namespace form_builder.Models.Elements
             List<PageSummary> pages = await elementHelper.GenerateQuestionAndAnswersList(guid, formSchema);
             var summaryViewModel = new SummarySectionsViewModel();
 
-            if (formSchema.Pages.Any(_ => _.Elements.Any(_ => _.Type == EElementType.AddAnother)) && !Properties.HasSummarySectionsDefined)
+            if (formSchema.Pages.Any(_ => _.Elements.Any(_ => _.Type.Equals(EElementType.AddAnother))) && !Properties.HasSummarySectionsDefined)
             {
                 summaryViewModel = AutoGenerateSummarySectionsViewModel(formSchema, formAnswers, pages, elementHelper);
 
@@ -66,12 +63,12 @@ namespace form_builder.Models.Elements
             var temporarySlugGroup = new List<string>();
             foreach (var schemaPage in formSchema.Pages)
             {
-                if (schemaPage.Elements.Any(_ => _.Type == EElementType.AddAnother))
+                if (schemaPage.Elements.Any(_ => _.Type.Equals(EElementType.AddAnother)))
                 {
                     temporarySlugGroup.Add(schemaPage.PageSlug);
                     groupedPageSlugs.Add(temporarySlugGroup);
                     temporarySlugGroup = new List<string>();
-                    groupedPageSlugs.Add(new List<string> { $"{schemaPage.PageSlug}-{schemaPage.Elements.FirstOrDefault(_ => _.Type == EElementType.AddAnother).Properties.QuestionId}" });
+                    groupedPageSlugs.Add(new List<string> { $"{schemaPage.PageSlug}-{schemaPage.Elements.FirstOrDefault(_ => _.Type.Equals(EElementType.AddAnother)).Properties.QuestionId}" });
                 }
                 else
                 {
@@ -90,8 +87,8 @@ namespace form_builder.Models.Elements
             }
 
             List<IElement> addAnotherElements = formSchema.Pages
-                .Where(_ => _.Elements.Any(_ => _.Type == EElementType.AddAnother))
-                .SelectMany(_ => _.Elements.Where(_ => _.Type == EElementType.AddAnother)).ToList();
+                .Where(_ => _.Elements.Any(_ => _.Type.Equals(EElementType.AddAnother)))
+                .SelectMany(_ => _.Elements.Where(_ => _.Type.Equals(EElementType.AddAnother))).ToList();
 
             foreach (var element in addAnotherElements)
             {
@@ -129,9 +126,9 @@ namespace form_builder.Models.Elements
 
         private SummarySectionsViewModel GenerateDefinedSummarySectionViewModel(FormSchema formSchema, FormAnswers formAnswers, IEnumerable<PageSummary> pages, IElementHelper elementHelper)
         {
-            if (formSchema.Pages.Any(_ => _.Elements.Any(_ => _.Type == EElementType.AddAnother)))
+            if (formSchema.Pages.Any(_ => _.Elements.Any(_ => _.Type.Equals(EElementType.AddAnother))))
             {
-                var newSections = new List<Section>();
+                List<Section> newSections = new();
 
                 foreach (Section section in Properties.Sections)
                 {
@@ -140,9 +137,9 @@ namespace form_builder.Models.Elements
                         newSections.Add(section);
 
                         Page schemaPageForSection = formSchema.Pages.FirstOrDefault(_ => _.PageSlug.Equals(sectionPage));
-                        if (schemaPageForSection is not null && schemaPageForSection.Elements.Any(_ => _.Type == EElementType.AddAnother))
+                        if (schemaPageForSection is not null && schemaPageForSection.Elements.Any(_ => _.Type.Equals(EElementType.AddAnother)))
                         {
-                            IElement addAnotherElement = schemaPageForSection.Elements.FirstOrDefault(_ => _.Type == EElementType.AddAnother);
+                            IElement addAnotherElement = schemaPageForSection.Elements.FirstOrDefault(_ => _.Type.Equals(EElementType.AddAnother));
                             int currentIncrement = elementHelper.GetAddAnotherNumberOfFieldsets(addAnotherElement, formAnswers);
 
                             for (var i = 1; i <= currentIncrement; i++)

--- a/src/Models/Elements/Textarea.cs
+++ b/src/Models/Elements/Textarea.cs
@@ -10,10 +10,7 @@ namespace form_builder.Models.Elements
     public class Textarea : Element
     {
         public bool DisplayCharacterCount => Properties.DisplayCharacterCount;
-        public Textarea()
-        {
-            Type = EElementType.Textarea;
-        }
+        public Textarea() => Type = EElementType.Textarea;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/Textbox.cs
+++ b/src/Models/Elements/Textbox.cs
@@ -46,7 +46,7 @@ namespace form_builder.Models.Elements
                 properties.Add("min", Properties.Min);
             }
 
-            if ((bool)Properties.Telephone)
+            if (Properties.Telephone.GetValueOrDefault())
                 properties["autocomplete"] = "tel";
 
             if (DisplayAriaDescribedby)

--- a/src/Models/Elements/Textbox.cs
+++ b/src/Models/Elements/Textbox.cs
@@ -9,10 +9,7 @@ namespace form_builder.Models.Elements
 {
     public class Textbox : Element
     {
-        public Textbox()
-        {
-            Type = EElementType.Textbox;
-        }
+        public Textbox() => Type = EElementType.Textbox;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
@@ -49,7 +46,7 @@ namespace form_builder.Models.Elements
                 properties.Add("min", Properties.Min);
             }
 
-            if (Properties.Telephone == true)
+            if ((bool)Properties.Telephone)
                 properties["autocomplete"] = "tel";
 
             if (DisplayAriaDescribedby)

--- a/src/Models/Elements/TimeInput.cs
+++ b/src/Models/Elements/TimeInput.cs
@@ -10,10 +10,7 @@ namespace form_builder.Models.Elements
 {
     public class TimeInput : Element
     {
-        public TimeInput()
-        {
-            Type = EElementType.TimeInput;
-        }
+        public TimeInput() => Type = EElementType.TimeInput;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/Elements/UL.cs
+++ b/src/Models/Elements/UL.cs
@@ -4,9 +4,6 @@ namespace form_builder.Models.Elements
 {
     public class UL : Element
     {
-        public UL()
-        {
-            Type = EElementType.UL;
-        }
+        public UL() => Type = EElementType.UL;
     }
 }

--- a/src/Models/Elements/UploadedFilesSummary.cs
+++ b/src/Models/Elements/UploadedFilesSummary.cs
@@ -13,10 +13,7 @@ namespace form_builder.Models.Elements
 {
     public class UploadedFilesSummary : Element
     {
-        public UploadedFilesSummary()
-        {
-            Type = EElementType.UploadedFilesSummary;
-        }
+        public UploadedFilesSummary() => Type = EElementType.UploadedFilesSummary;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,
@@ -36,7 +33,7 @@ namespace form_builder.Models.Elements
                 {
                     var model = elementHelper.CurrentValue<JArray>(questionId, viewModel, formAnswers, FileUploadConstants.SUFFIX);
 
-                    if (model != null && model.Any())
+                    if (model is not null && model.Any())
                     {
                         List<FileUploadModel> response = JsonConvert.DeserializeObject<List<FileUploadModel>>(model.ToString());
                         Properties.ListItems.AddRange(response.Select(_ => _.TrustedOriginalFileName));

--- a/src/Models/Elements/Warning.cs
+++ b/src/Models/Elements/Warning.cs
@@ -9,10 +9,7 @@ namespace form_builder.Models.Elements
 {
     public class Warning : Element
     {
-        public Warning()
-        {
-            Type = EElementType.InlineAlert;
-        }
+        public Warning() => Type = EElementType.InlineAlert;
 
         public override Task<string> RenderAsync(IViewRender viewRender,
             IElementHelper elementHelper,

--- a/src/Models/FormAnswers.cs
+++ b/src/Models/FormAnswers.cs
@@ -33,7 +33,7 @@ namespace form_builder.Models
         public IEnumerable<Answers> AllAnswers {
             get 
             {
-                if (this.Pages == null)
+                if (this.Pages is null)
                     return Enumerable.Empty<Answers>();
 
                 if (!this.Pages.SelectMany(_ => _.Answers).Any())

--- a/src/Models/FormSchema.cs
+++ b/src/Models/FormSchema.cs
@@ -40,7 +40,7 @@ namespace form_builder.Models
 
         public bool DocumentDownload { get; set; }
 
-        public bool HasDocumentUpload => Pages.Any(_ => _.PageSlug == FileUploadConstants.DOCUMENT_UPLOAD_URL_PATH);
+        public bool HasDocumentUpload => Pages.Any(_ => _.PageSlug.Equals(FileUploadConstants.DOCUMENT_UPLOAD_URL_PATH));
 
         public List<EDocumentType> DocumentType { get; set; }
 
@@ -53,9 +53,9 @@ namespace form_builder.Models
         {
             try
             {
-                var pages = Pages.Where(_ => _.PageSlug.ToLower().Trim() == path.ToLower().Trim()).OrderByDescending(_ => _.RenderConditions.Count).ToList();
+                var pages = Pages.Where(_ => _.PageSlug.Trim().Equals(path.Trim(), StringComparison.OrdinalIgnoreCase)).OrderByDescending(_ => _.RenderConditions.Count).ToList();
 
-                if (pages.Count == 1)
+                if (pages.Count.Equals(1))
                     return pages.First();
 
                 var page = pageHelper.GetPageWithMatchingRenderConditions(pages);
@@ -70,7 +70,7 @@ namespace form_builder.Models
 
         public IElement GetElement(string questionId) => 
             Pages.SelectMany(_ => _.Elements)
-                .SingleOrDefault(_ => _.Properties.QuestionId == questionId);
+                .SingleOrDefault(_ => _.Properties.QuestionId.Equals(questionId));
 
     }
 }

--- a/src/Models/FormSchema.cs
+++ b/src/Models/FormSchema.cs
@@ -23,9 +23,9 @@ namespace form_builder.Models
         public string FeedbackForm { get; set; }
 
         public string FeedbackPhase { get; set; }
-        
+
         public bool GenerateReferenceNumber { get; set; }
-        
+
         public string GeneratedReferenceNumberMapping { get; set; }
 
         public string ReferencePrefix { get; set; }
@@ -68,9 +68,9 @@ namespace form_builder.Models
             }
         }
 
-        public IElement GetElement(string questionId) => 
+        public IElement GetElement(string questionId) =>
             Pages.SelectMany(_ => _.Elements)
-                .SingleOrDefault(_ => _.Properties.QuestionId.Equals(questionId));
-
+            .Where(_ => _.Properties.QuestionId is not null)
+            .SingleOrDefault(_ => _.Properties.QuestionId.Equals(questionId));
     }
 }

--- a/src/Models/Page.cs
+++ b/src/Models/Page.cs
@@ -47,16 +47,16 @@ namespace form_builder.Models
         [JsonIgnore] public bool IsValid => !InvalidElements.Any();
 
         public bool HasIncomingValues => IncomingValues.Any();
-        public bool HasIncomingGetValues => IncomingValues.Any(_ => _.HttpActionType == EHttpActionType.Get);
-        public bool HasIncomingPostValues => IncomingValues.Any(_ => _.HttpActionType == EHttpActionType.Post);
+        public bool HasIncomingGetValues => IncomingValues.Any(_ => _.HttpActionType.Equals(EHttpActionType.Get));
+        public bool HasIncomingPostValues => IncomingValues.Any(_ => _.HttpActionType.Equals(EHttpActionType.Post));
 
         public List<IAction> PageActions { get; set; } = new List<IAction>();
 
         public bool HasPageActions => PageActions.Any();
 
         public bool HasIncomingAction => PageActions.Any();
-        public bool HasPageActionsGetValues => PageActions.Any(_ => _.Properties.HttpActionType == EHttpActionType.Get);
-        public bool HasPageActionsPostValues => PageActions.Any(_ => _.Properties.HttpActionType == EHttpActionType.Post);
+        public bool HasPageActionsGetValues => PageActions.Any(_ => _.Properties.HttpActionType.Equals(EHttpActionType.Get));
+        public bool HasPageActionsPostValues => PageActions.Any(_ => _.Properties.HttpActionType.Equals(EHttpActionType.Post));
 
         public bool HasDynamicLookupElements => Elements.Any(_ => !string.IsNullOrEmpty(_.Lookup) && _.Lookup.Equals(LookUpConstants.Dynamic));
 
@@ -80,32 +80,32 @@ namespace form_builder.Models
         }
 
         public IEnumerable<IElement> ValidatableElements => Elements.Where(element =>
-                element.Type == EElementType.AddAnother ||
-                element.Type == EElementType.Address ||
-                element.Type == EElementType.AddressManual ||
-                element.Type == EElementType.Booking ||
-                element.Type == EElementType.Checkbox ||
-                element.Type == EElementType.DatePicker ||
-                element.Type == EElementType.DateInput ||
-                element.Type == EElementType.Declaration ||
-                element.Type == EElementType.FileUpload ||
-                element.Type == EElementType.Radio ||
-                element.Type == EElementType.Select ||
-                element.Type == EElementType.Street ||
-                element.Type == EElementType.Textarea ||
-                element.Type == EElementType.Textbox ||
-                element.Type == EElementType.TimeInput ||
-                element.Type == EElementType.Map ||
-                element.Type == EElementType.MultipleFileUpload ||
-                element.Type == EElementType.Organisation
+                element.Type.Equals(EElementType.AddAnother) ||
+                element.Type.Equals(EElementType.Address) ||
+                element.Type.Equals(EElementType.AddressManual) ||
+                element.Type.Equals(EElementType.Booking) ||
+                element.Type.Equals(EElementType.Checkbox) ||
+                element.Type.Equals(EElementType.DatePicker) ||
+                element.Type.Equals(EElementType.DateInput) ||
+                element.Type.Equals(EElementType.Declaration) ||
+                element.Type.Equals(EElementType.FileUpload) ||
+                element.Type.Equals(EElementType.Radio) ||
+                element.Type.Equals(EElementType.Select) ||
+                element.Type.Equals(EElementType.Street) ||
+                element.Type.Equals(EElementType.Textarea) ||
+                element.Type.Equals(EElementType.Textbox) ||
+                element.Type.Equals(EElementType.TimeInput) ||
+                element.Type.Equals(EElementType.Map) ||
+                element.Type.Equals(EElementType.MultipleFileUpload) ||
+                element.Type.Equals(EElementType.Organisation)
         );
 
         public IEnumerable<IElement> ValidatableElementsConditional => Elements.Where(element =>
-            element.Type == EElementType.Textarea ||
-            element.Type == EElementType.Select ||
-            element.Type == EElementType.Textbox ||
-            element.Type == EElementType.DateInput ||
-            element.Type == EElementType.TimeInput
+            element.Type.Equals(EElementType.Textarea) ||
+            element.Type.Equals(EElementType.Select) ||
+            element.Type.Equals(EElementType.Textbox) ||
+            element.Type.Equals(EElementType.DateInput) ||
+            element.Type.Equals(EElementType.TimeInput)
         );
 
         public void Validate(Dictionary<string, dynamic> viewModel, IEnumerable<IElementValidator> validators, FormSchema baseForm)
@@ -121,7 +121,7 @@ namespace form_builder.Models
         {
             var conditionValidator = new ConditionValidator();
 
-            if (Behaviours.Count == 1)
+            if (Behaviours.Count.Equals(1))
                 return Behaviours.FirstOrDefault();
 
             foreach (var behaviour in Behaviours.OrderByDescending(_ => _.Conditions.Count))
@@ -141,7 +141,7 @@ namespace form_builder.Models
             }
 
             var conditionValuesForDebug = Behaviours.OrderByDescending(_ => _.Conditions.Count)
-                .Where(_ => _.Conditions != null)
+                .Where(_ => _.Conditions is not null)
                 .SelectMany(_ => _.Conditions)
                 .Where(_ => !string.IsNullOrEmpty(_.QuestionId))
                 .Select(_ => _.QuestionId)
@@ -156,16 +156,16 @@ namespace form_builder.Models
         {
             var conditionValidator = new ConditionValidator();
 
-            return RenderConditions.Count == 0 ||
+            return RenderConditions.Count.Equals(0) ||
                    RenderConditions.All(condition => conditionValidator.IsValid(condition, answers));
         }
 
         public SubmitSlug GetSubmitFormEndpoint(FormAnswers formAnswers, string environment)
         {
-            var submitBehaviour = new SubmitSlug();
+            SubmitSlug submitBehaviour = new();
 
             var pageSubmitBehaviours = GetBehavioursByType(EBehaviourType.SubmitForm);
-            if (pageSubmitBehaviours.Count == 0)
+            if (pageSubmitBehaviours.Count.Equals(0))
                 pageSubmitBehaviours = GetBehavioursByType(EBehaviourType.SubmitAndPay);
 
             if (Behaviours.Count > 1)
@@ -180,11 +180,11 @@ namespace form_builder.Models
 
                 submitBehaviour = foundSubmitBehaviour.SubmitSlugs
                     .ToList()
-                    .FirstOrDefault(x => x.Environment.ToLower().Equals(environment.ToLower()));
+                    .FirstOrDefault(x => x.Environment.Equals(environment, StringComparison.OrdinalIgnoreCase));
             }
             else
             {
-                if (pageSubmitBehaviours.FirstOrDefault()?.SubmitSlugs.Count == 0)
+                if ((bool)pageSubmitBehaviours.FirstOrDefault()?.SubmitSlugs.Count.Equals(0))
                 {
                     submitBehaviour.URL = pageSubmitBehaviours.FirstOrDefault()?.PageSlug;
                 }
@@ -192,7 +192,7 @@ namespace form_builder.Models
                 {
                     var behaviour = pageSubmitBehaviours
                         .SelectMany(x => x.SubmitSlugs)
-                        .FirstOrDefault(x => x.Environment.ToLower().Equals(environment.ToLower()));
+                        .FirstOrDefault(x => x.Environment.Equals(environment, StringComparison.OrdinalIgnoreCase));
 
                     submitBehaviour = behaviour ?? throw new NullReferenceException("Page model::GetSubmitFormEndpoint, No Url supplied for submit form");
                 }
@@ -204,7 +204,7 @@ namespace form_builder.Models
                 : submitBehaviour;
         }
 
-        private List<Behaviour> GetBehavioursByType(EBehaviourType type) => Behaviours.Where(_ => _.BehaviourType == type).ToList();
+        private List<Behaviour> GetBehavioursByType(EBehaviourType type) => Behaviours.Where(_ => _.BehaviourType.Equals(type)).ToList();
 
         public string GetPageTitle() => Elements.Any() && HideTitle ? Elements.First().Properties.Label : Title;
     }

--- a/src/Models/Page.cs
+++ b/src/Models/Page.cs
@@ -184,7 +184,7 @@ namespace form_builder.Models
             }
             else
             {
-                if ((bool)pageSubmitBehaviours.FirstOrDefault()?.SubmitSlugs.Count.Equals(0))
+                if (pageSubmitBehaviours.FirstOrDefault()?.SubmitSlugs.Count == 0)
                 {
                     submitBehaviour.URL = pageSubmitBehaviours.FirstOrDefault()?.PageSlug;
                 }

--- a/src/Providers/FormAnswersProvider.cs
+++ b/src/Providers/FormAnswersProvider.cs
@@ -21,7 +21,7 @@ namespace form_builder.Providers
         {
             string sessionGuid = _sessionHelper.GetSessionGuid();
             string cachedAnswers = _distributedCache.GetString(sessionGuid);
-            return cachedAnswers == null
+            return cachedAnswers is null
                 ? new FormAnswers { Pages = new List<PageAnswers>() }
                 : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);    
         }

--- a/src/Providers/PaymentProvider/CivicaPayProvider.cs
+++ b/src/Providers/PaymentProvider/CivicaPayProvider.cs
@@ -66,7 +66,7 @@ namespace form_builder.Providers.PaymentProvider
 
             var civicaResponse = await _civicaPayGateway.CreateImmediateBasketAsync(basket);
 
-            if (civicaResponse.StatusCode != HttpStatusCode.OK)
+            if (!civicaResponse.IsSuccessStatusCode)
                 throw new Exception($"CivicaPayProvider::GeneratePaymentUrl, CivicaPay gateway response with a non ok status code {civicaResponse.StatusCode}, HttpResponse: {JsonConvert.SerializeObject(civicaResponse)}");
 
             return _civicaPayGateway.GetPaymentUrl(civicaResponse.ResponseContent.BasketReference, civicaResponse.ResponseContent.BasketToken, reference);
@@ -74,10 +74,10 @@ namespace form_builder.Providers.PaymentProvider
 
         public void VerifyPaymentResponse(string responseCode)
         {
-            if (responseCode == "00022" || responseCode == "00023" || responseCode == "00001")
+            if (responseCode.Equals("00022") || responseCode.Equals("00023") || responseCode.Equals("00001"))
                 throw new PaymentDeclinedException($"CivicaPayProvider::Declined payment with response code: {responseCode}");
 
-            if (responseCode != "00000")
+            if (!responseCode.Equals("00000"))
                 throw new PaymentFailureException($"CivicaPayProvider::Payment failed with response code: {responseCode}");
         }
     }

--- a/src/Providers/PaymentProvider/CivicaPayProvider.cs
+++ b/src/Providers/PaymentProvider/CivicaPayProvider.cs
@@ -37,7 +37,7 @@ namespace form_builder.Providers.PaymentProvider
             if (string.IsNullOrEmpty(reference))
                 throw new PaymentFailureException("CivicaPayProvider::No valid reference");
 
-            var basket = new CreateImmediateBasketRequest
+            CreateImmediateBasketRequest basket = new()
             {
                 CallingAppIdentifier = "Basket",
                 CustomerID = _paymentConfig.CustomerId,

--- a/src/Providers/SchemaProvider/S3FileSchemaProvider.cs
+++ b/src/Providers/SchemaProvider/S3FileSchemaProvider.cs
@@ -113,7 +113,7 @@ namespace form_builder.Providers.SchemaProvider
             else
                 indexSchema = JsonConvert.DeserializeObject<List<string>>(cachedIndexSchema);
 
-            return indexSchema.Any(_ => _.ToLower().Equals($"{schemaName.ToLower()}.json"));
+            return indexSchema.Any(_ => _.Equals($"{schemaName}.json", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Services/AddAnotherService/AddAnotherService.cs
+++ b/src/Services/AddAnotherService/AddAnotherService.cs
@@ -34,7 +34,7 @@ namespace form_builder.Services.AddAnotherService
             bool addEmptyFieldset = viewModel.Keys.Any(_ => _.Equals(AddAnotherConstants.AddAnotherButtonKey));
 
             FormAnswers convertedFormAnswers = _pageHelper.GetSavedAnswers(guid);
-            var maximumFieldsets = dynamicCurrentPage.Elements.FirstOrDefault(_ => _.Type == EElementType.AddAnother).Properties.MaximumFieldsets;
+            var maximumFieldsets = dynamicCurrentPage.Elements.FirstOrDefault(_ => _.Type.Equals(EElementType.AddAnother)).Properties.MaximumFieldsets;
 
             if (dynamicCurrentPage.IsValid  || !string.IsNullOrEmpty(removeKey))
             {

--- a/src/Services/AddressService/AddressService.cs
+++ b/src/Services/AddressService/AddressService.cs
@@ -67,7 +67,7 @@ namespace form_builder.Services.AddressService
             {
                 var cachedAnswers = _distributedCache.GetString(guid);
 
-                var convertedAnswers = cachedAnswers == null
+                var convertedAnswers = cachedAnswers is null
                     ? new FormAnswers { Pages = new List<PageAnswers>() }
                     : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
@@ -97,17 +97,17 @@ namespace form_builder.Services.AddressService
         {
             var cachedAnswers = _distributedCache.GetString(guid);
 
-            var convertedAnswers = cachedAnswers == null
+            var convertedAnswers = cachedAnswers is null
                 ? new FormAnswers { Pages = new List<PageAnswers>() }
                 : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
-            var addressElement = currentPage.Elements.FirstOrDefault(_ => _.Type == EElementType.Address);
+            var addressElement = currentPage.Elements.FirstOrDefault(_ => _.Type.Equals(EElementType.Address));
 
             var postcode = (string)convertedAnswers
                         .Pages
-                        .FirstOrDefault(_ => _.PageSlug == path)
+                        .FirstOrDefault(_ => _.PageSlug.Equals(path))
                         .Answers
-                        .FirstOrDefault(_ => _.QuestionId == $"{addressElement.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}")
+                        .FirstOrDefault(_ => _.QuestionId.Equals($"{addressElement.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}"))
                         .Response;
 
             var address = (string)viewModel[$"{addressElement.Properties.QuestionId}{AddressConstants.SELECT_SUFFIX}"];
@@ -160,11 +160,11 @@ namespace form_builder.Services.AddressService
         {
             var cachedAnswers = _distributedCache.GetString(guid);
 
-            var convertedAnswers = cachedAnswers == null
+            var convertedAnswers = cachedAnswers is null
                 ? new FormAnswers { Pages = new List<PageAnswers>() }
                 : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
-            var addressElement = currentPage.Elements.Where(_ => _.Type == EElementType.Address).FirstOrDefault();
+            var addressElement = currentPage.Elements.FirstOrDefault(_ => _.Type.Equals(EElementType.Address));
 
             if (!currentPage.IsValid)
             {
@@ -190,10 +190,10 @@ namespace form_builder.Services.AddressService
 
             var foundPostCode = convertedAnswers
                 .Pages.FirstOrDefault(_ => _.PageSlug.Equals(path))?
-                .Answers?.FirstOrDefault(_ => _.QuestionId == $"{addressElement.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}")?
+                .Answers?.FirstOrDefault(_ => _.QuestionId.Equals($"{addressElement.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}"))?
                 .Response;
 
-            var addressResults = new List<object>();
+            List<object> addressResults = new();
             if (postcode.Equals(foundPostCode))
             {
                 addressResults = (convertedAnswers.FormData[$"{path}{LookUpConstants.SearchResultsKeyPostFix}"] as IEnumerable<object>).ToList();

--- a/src/Services/BookingService/BookingService.cs
+++ b/src/Services/BookingService/BookingService.cs
@@ -172,7 +172,7 @@ namespace form_builder.Services.BookingService
                 .First(element => element.Type.
                     Equals(EElementType.Booking));
 
-            if (requestedMonth.Month == currentDate.Month && requestedMonth.Year == currentDate.Year)
+            if (requestedMonth.Month.Equals(currentDate.Month) && requestedMonth.Year.Equals(currentDate.Year))
                 requestedMonth = currentDate;
 
             if (requestedMonth > new DateTime(currentDate.Year, currentDate.Month, 1).AddMonths(bookingElement.Properties.SearchPeriod))

--- a/src/Services/DocumentService/DocumentSummaryService.cs
+++ b/src/Services/DocumentService/DocumentSummaryService.cs
@@ -17,7 +17,7 @@ namespace form_builder.Services.DocumentService
         public DocumentSummaryService(IDocumentCreationHelper documentCreationHelper, IEnumerable<IDocumentCreation> providers)
         {
             _textfileProvider = providers
-                                    .Where(_ => _.DocumentType == EDocumentType.Txt)
+                                    .Where(_ => _.DocumentType.Equals(EDocumentType.Txt))
                                     .OrderByDescending(_ => _.Priority)
                                     .FirstOrDefault();
 

--- a/src/Services/FileUploadService/FileUploadService.cs
+++ b/src/Services/FileUploadService/FileUploadService.cs
@@ -40,7 +40,7 @@ namespace form_builder.Services.FileUploadService
 
         public Dictionary<string, dynamic> AddFiles(Dictionary<string, dynamic> viewModel, IEnumerable<CustomFormFile> fileUpload)
         {
-            fileUpload.Where(_ => _ != null)
+            fileUpload.Where(_ => _ is not null)
                 .ToList()
                 .GroupBy(_ => _.QuestionId)
                 .ToList()
@@ -79,7 +79,7 @@ namespace form_builder.Services.FileUploadService
         {
             var cachedAnswers = _distributedCache.GetString(sessionGuid);
 
-            var convertedAnswers = cachedAnswers == null
+            var convertedAnswers = cachedAnswers is null
                 ? new FormAnswers { Pages = new List<PageAnswers>() }
                 : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
@@ -130,7 +130,7 @@ namespace form_builder.Services.FileUploadService
                 };
             }
 
-            if (currentPage.IsValid && viewModel.ContainsKey(ButtonConstants.SUBMIT) && (files == null || !files.Any()) && modelStateIsValid)
+            if (currentPage.IsValid && viewModel.ContainsKey(ButtonConstants.SUBMIT) && (files is null || !files.Any()) && modelStateIsValid)
             {
                 if (currentPage.Elements.Where(_ => _.Type.Equals(EElementType.MultipleFileUpload)).Any(_ => _.Properties.Optional))
                     _pageHelper.SaveAnswers(viewModel, guid, baseForm.BaseURL, files, currentPage.IsValid, true);
@@ -141,7 +141,7 @@ namespace form_builder.Services.FileUploadService
                 };
             }
 
-            if (!viewModel.ContainsKey(ButtonConstants.SUBMIT) && (files == null || !files.Any()))
+            if (!viewModel.ContainsKey(ButtonConstants.SUBMIT) && (files is null || !files.Any()))
             {
                 return new ProcessRequestEntity
                 {
@@ -155,7 +155,7 @@ namespace form_builder.Services.FileUploadService
                 };
             }
 
-            if (files != null && files.Any())
+            if (files is not null && files.Any())
                 _pageHelper.SaveAnswers(viewModel, guid, baseForm.BaseURL, files, currentPage.IsValid, true);
 
             if (viewModel.ContainsKey(ButtonConstants.SUBMIT) && modelStateIsValid)

--- a/src/Services/FormAvailabilityService/FormAvailabilityService.cs
+++ b/src/Services/FormAvailabilityService/FormAvailabilityService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using form_builder.Extensions;
@@ -17,12 +18,12 @@ namespace form_builder.Services.FormAvailabilityService
 
         public bool IsAvailable(List<EnvironmentAvailability> availability, string environment)
         {
-            var environmentAvailability = availability.SingleOrDefault(_ => _.Environment.ToLower().Equals(environment.ToLower()));
+            var environmentAvailability = availability.SingleOrDefault(_ => _.Environment.Equals(environment, StringComparison.OrdinalIgnoreCase));
 
             if(environmentAvailability is not null && environmentAvailability.EnabledFor is not null && environmentAvailability.EnabledFor.Any())
                 return environmentAvailability.EnabledFor.All(_ => _enabledFor.Get(_.Type).IsAvailable(_));
 
-            return environmentAvailability == null || environmentAvailability.IsAvailable;
+            return environmentAvailability is null || environmentAvailability.IsAvailable;
         }
     }
 }

--- a/src/Services/MappingService/MappingService.cs
+++ b/src/Services/MappingService/MappingService.cs
@@ -108,7 +108,7 @@ namespace form_builder.Services.MappingService
 
             convertedAnswers.FormName = form;
 
-            if (convertedAnswers.Pages == null || !convertedAnswers.Pages.Any())
+            if (convertedAnswers.Pages is null || !convertedAnswers.Pages.Any())
             {
                 var deviceInformation = $"Device Type: {_detectionService.Device.Type}, Browser Name/Version: {_detectionService.Browser.Name}/{_detectionService.Browser.Version}, Platform Name: {_detectionService.Platform.Name}, Engine Name: {_detectionService.Engine.Name}, Crawler: {_detectionService.Crawler.IsCrawler}/{_detectionService.Crawler.Name}";
                 _logger.LogWarning($"MappingService::GetFormAnswers, Reduced Answers returned empty or null list, Creating submit data but no answers collected. Form {form}, Session {sessionGuid}, {deviceInformation}");
@@ -139,8 +139,8 @@ namespace form_builder.Services.MappingService
             var data = new ExpandoObject() as IDictionary<string, dynamic>;
             formSchema.Pages.SelectMany(_ => _.ValidatableElements)
                 .Where(x => !string.IsNullOrEmpty(x.Properties.TargetMapping)
-                            && x.Properties.TargetMapping.ToLower().StartsWith("customer.")
-                            && !x.Properties.TargetMapping.ToLower().Equals("customer.address"))
+                            && x.Properties.TargetMapping.StartsWith("customer.", StringComparison.OrdinalIgnoreCase)
+                            && !x.Properties.TargetMapping.Equals("customer.address", StringComparison.OrdinalIgnoreCase))
                 .ToList()
                 .ForEach(_ => data = RecursiveCheckAndCreate(string.IsNullOrEmpty(_.Properties.TargetMapping) ? _.Properties.QuestionId : _.Properties.TargetMapping, _, formAnswers, data));
 
@@ -155,7 +155,7 @@ namespace form_builder.Services.MappingService
 
             var addressElement = formSchema.Pages.SelectMany(_ => _.Elements)
                 .FirstOrDefault(_ =>
-                    _.Properties.QuestionId != null &&
+                    _.Properties.QuestionId is not null &&
                     _.Properties.QuestionId.Contains(bookingElement.Properties.CustomerAddressId));
             customer.Address = _elementMapper.GetAnswerStringValue(addressElement, formAnswers);
 
@@ -183,16 +183,16 @@ namespace form_builder.Services.MappingService
             if (element.Properties.IsDynamicallyGeneratedElement)
                 return obj;
 
-            if (splitTargets.Length == 1)
+            if (splitTargets.Length.Equals(1))
             {
-                if (element.Type == EElementType.FileUpload || element.Type == EElementType.MultipleFileUpload)
+                if (element.Type.Equals(EElementType.FileUpload) || element.Type.Equals(EElementType.MultipleFileUpload))
                     return CheckAndCreateForFileUpload(splitTargets[0], element, formAnswers, obj);
 
-                if (element.Type == EElementType.AddAnother)
+                if (element.Type.Equals(EElementType.AddAnother))
                     return CheckAndCreateForAddAnother(splitTargets[0], element, formAnswers, obj);
 
                 object answerValue = _elementMapper.GetAnswerValue(element, formAnswers);
-                if (answerValue != null && obj.TryGetValue(splitTargets[0], out var objectValue))
+                if (answerValue is not null && obj.TryGetValue(splitTargets[0], out var objectValue))
                 {
                     var combinedValue = $"{objectValue} {answerValue}";
                     obj.Remove(splitTargets[0]);
@@ -200,7 +200,7 @@ namespace form_builder.Services.MappingService
                     return obj;
                 }
 
-                if (answerValue != null)
+                if (answerValue is not null)
                     obj.Add(splitTargets[0], answerValue);
 
                 return obj;
@@ -253,7 +253,7 @@ namespace form_builder.Services.MappingService
             if (obj.TryGetValue(target, out objectValue))
             {
                 var files = (List<File>)objectValue;
-                if (value != null)
+                if (value is not null)
                 {
                     obj.Remove(target);
                     files.AddRange((List<File>)value);
@@ -264,7 +264,7 @@ namespace form_builder.Services.MappingService
             }
             else
             {
-                if (value != null)
+                if (value is not null)
                 {
                     obj.Add(target, (List<File>)value);
                 }

--- a/src/Services/OrganisationService/OrganisationService.cs
+++ b/src/Services/OrganisationService/OrganisationService.cs
@@ -53,16 +53,16 @@ namespace form_builder.Services.OrganisationService
             string path)
         {
             var cachedAnswers = _distributedCache.GetString(guid);
-            var organisationElement = currentPage.Elements.Where(_ => _.Type == EElementType.Organisation).FirstOrDefault();
-            var convertedAnswers = cachedAnswers == null
+            var organisationElement = currentPage.Elements.FirstOrDefault(_ => _.Type.Equals(EElementType.Organisation));
+            var convertedAnswers = cachedAnswers is null
                         ? new FormAnswers { Pages = new List<PageAnswers>() }
                         : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
             var organisation = (string)convertedAnswers
                 .Pages
-                .FirstOrDefault(_ => _.PageSlug == path)
+                .FirstOrDefault(_ => _.PageSlug.Equals(path))
                 .Answers
-                .FirstOrDefault(_ => _.QuestionId == $"{organisationElement.Properties.QuestionId}")
+                .FirstOrDefault(_ => _.QuestionId.Equals($"{organisationElement.Properties.QuestionId}"))
                 .Response;
 
             if (currentPage.IsValid && organisationElement.Properties.Optional && string.IsNullOrEmpty(organisation))
@@ -103,9 +103,9 @@ namespace form_builder.Services.OrganisationService
             string path)
         {
             var cachedAnswers = _distributedCache.GetString(guid);
-            var organisationElement = currentPage.Elements.Where(_ => _.Type == EElementType.Organisation).FirstOrDefault();
+            var organisationElement = currentPage.Elements.FirstOrDefault(_ => _.Type.Equals(EElementType.Organisation));
 
-            var convertedAnswers = cachedAnswers == null
+            var convertedAnswers = cachedAnswers is null
                         ? new FormAnswers { Pages = new List<PageAnswers>() }
                         : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
@@ -139,7 +139,7 @@ namespace form_builder.Services.OrganisationService
 
             var foundOrganisationSearchTerm = convertedAnswers
                 .Pages.FirstOrDefault(_ => _.PageSlug.Equals(path))?
-                .Answers?.FirstOrDefault(_ => _.QuestionId == organisationElement.Properties.QuestionId)?
+                .Answers?.FirstOrDefault(_ => _.QuestionId.Equals(organisationElement.Properties.QuestionId))?
                 .Response;
 
             List<object> searchResults;

--- a/src/Services/PageService/PageService.cs
+++ b/src/Services/PageService/PageService.cs
@@ -9,7 +9,6 @@ using form_builder.ContentFactory.SuccessPageFactory;
 using form_builder.Enum;
 using form_builder.Extensions;
 using form_builder.Factories.Schema;
-using form_builder.Helpers.ElementHelpers;
 using form_builder.Helpers.IncomingDataHelper;
 using form_builder.Helpers.PageHelpers;
 using form_builder.Helpers.Session;
@@ -121,7 +120,7 @@ namespace form_builder.Services.PageService
 
             var baseForm = await _schemaFactory.Build(form);
 
-            if (baseForm == null)
+            if (baseForm is null)
                 return null;
 
             if (!_formAvailabilityServics.IsAvailable(baseForm.EnvironmentAvailabilities, _environment.EnvironmentName))
@@ -130,31 +129,23 @@ namespace form_builder.Services.PageService
                 return null;
             }
 
+            if (string.IsNullOrEmpty(path))
+                return new ProcessPageEntity { ShouldRedirect = true, TargetPage = baseForm.FirstPageSlug };
+
             var formData = _distributedCache.GetString(sessionGuid);
 
-            if (formData == null && path != baseForm.FirstPageSlug && (!baseForm.HasDocumentUpload || path != FileUploadConstants.DOCUMENT_UPLOAD_URL_PATH))
-                return new ProcessPageEntity
-                {
-                    ShouldRedirect = true,
-                    TargetPage = baseForm.FirstPageSlug
-                };
+            if (string.IsNullOrEmpty(formData) && !path.Equals(baseForm.FirstPageSlug) && (!baseForm.HasDocumentUpload || !path.Equals(FileUploadConstants.DOCUMENT_UPLOAD_URL_PATH)))
+                return new ProcessPageEntity { ShouldRedirect = true, TargetPage = baseForm.FirstPageSlug };
 
-            if (string.IsNullOrEmpty(path))
-                return new ProcessPageEntity
-                {
-                    ShouldRedirect = true,
-                    TargetPage = baseForm.FirstPageSlug
-                };
-
-            if (formData != null && path == baseForm.FirstPageSlug)
+            if (!string.IsNullOrEmpty(formData) && path.Equals(baseForm.FirstPageSlug))
             {
                 var convertedFormData = JsonConvert.DeserializeObject<FormAnswers>(formData);
-                if (form.ToLower() != convertedFormData.FormName.ToLower())
+                if (!form.Equals(convertedFormData.FormName, StringComparison.OrdinalIgnoreCase))
                     _distributedCache.Remove(sessionGuid);
             }
 
             var page = baseForm.GetPage(_pageHelper, path);
-            if (page == null)
+            if (page is null)
                 throw new ApplicationException($"Requested path '{path}' object could not be found for form '{form}'");
 
             List<object> searchResults = null;
@@ -162,6 +153,7 @@ namespace form_builder.Services.PageService
 
             if (!string.IsNullOrEmpty(formData))
                 convertedAnswers = JsonConvert.DeserializeObject<FormAnswers>(formData);
+
             if (subPath.Equals(LookUpConstants.Automatic) || subPath.Equals(LookUpConstants.Manual))
             {
                 if (convertedAnswers.FormData.ContainsKey($"{path}{LookUpConstants.SearchResultsKeyPostFix}"))
@@ -195,10 +187,7 @@ namespace form_builder.Services.PageService
 
             var viewModel = await GetViewModel(page, baseForm, path, sessionGuid, subPath, searchResults);
 
-            return new ProcessPageEntity
-            {
-                ViewModel = viewModel
-            };
+            return new ProcessPageEntity { ViewModel = viewModel };
         }
 
         public async Task<ProcessRequestEntity> ProcessRequest(
@@ -217,10 +206,10 @@ namespace form_builder.Services.PageService
 
             var sessionGuid = _sessionHelper.GetSessionGuid();
 
-            if (sessionGuid == null)
+            if (sessionGuid is null)
                 throw new NullReferenceException($"Session guid null.");
 
-            if (currentPage == null)
+            if (currentPage is null)
                 throw new NullReferenceException($"Current page '{path}' object could not be found.");
 
             if (currentPage.HasIncomingPostValues)
@@ -228,22 +217,22 @@ namespace form_builder.Services.PageService
 
             currentPage.Validate(viewModel, _validators, baseForm);
 
-            if (currentPage.Elements.Any(_ => _.Type == EElementType.AddAnother))
+            if (currentPage.Elements.Any(_ => _.Type.Equals(EElementType.AddAnother)))
                 return await _addAnotherService.ProcessAddAnother(viewModel, currentPage, baseForm, sessionGuid, path);
 
-            if (currentPage.Elements.Any(_ => _.Type == EElementType.Address))
+            if (currentPage.Elements.Any(_ => _.Type.Equals(EElementType.Address)))
                 return await _addressService.ProcessAddress(viewModel, currentPage, baseForm, sessionGuid, path);
 
-            if (currentPage.Elements.Any(_ => _.Type == EElementType.Street))
+            if (currentPage.Elements.Any(_ => _.Type.Equals(EElementType.Street)))
                 return await _streetService.ProcessStreet(viewModel, currentPage, baseForm, sessionGuid, path);
 
-            if (currentPage.Elements.Any(_ => _.Type == EElementType.Organisation))
+            if (currentPage.Elements.Any(_ => _.Type.Equals(EElementType.Organisation)))
                 return await _organisationService.ProcessOrganisation(viewModel, currentPage, baseForm, sessionGuid, path);
 
-            if (currentPage.Elements.Any(_ => _.Type == EElementType.MultipleFileUpload))
+            if (currentPage.Elements.Any(_ => _.Type.Equals(EElementType.MultipleFileUpload)))
                 return await _fileUploadService.ProcessFile(viewModel, currentPage, baseForm, sessionGuid, path, files, modelStateIsValid);
 
-            if (currentPage.Elements.Any(_ => _.Type == EElementType.Booking))
+            if (currentPage.Elements.Any(_ => _.Type.Equals(EElementType.Booking)))
                 return await _bookingService.ProcessBooking(viewModel, currentPage, baseForm, sessionGuid, path);
 
             _pageHelper.SaveAnswers(viewModel, sessionGuid, baseForm.BaseURL, files, currentPage.IsValid);
@@ -252,17 +241,10 @@ namespace form_builder.Services.PageService
             {
                 var formModel = await _pageContentFactory.Build(currentPage, viewModel, baseForm, sessionGuid);
 
-                return new ProcessRequestEntity
-                {
-                    Page = currentPage,
-                    ViewModel = formModel
-                };
+                return new ProcessRequestEntity { Page = currentPage, ViewModel = formModel };
             }
 
-            return new ProcessRequestEntity
-            {
-                Page = currentPage
-            };
+            return new ProcessRequestEntity { Page = currentPage };
         }
 
         public async Task<FormBuilderViewModel> GetViewModel(Page page, FormSchema baseForm, string path, string sessionGuid, string subPath, List<object> results)
@@ -301,26 +283,26 @@ namespace form_builder.Services.PageService
 
             var formData = _distributedCache.GetString(sessionGuid);
 
-            if (formData == null)
+            if (formData is null)
                 throw new ApplicationException("PageService::FinalisePageJourney: Session data is null");
 
             var formAnswers = JsonConvert.DeserializeObject<FormAnswers>(formData);
 
             var formFileUploadElements = baseForm.Pages.SelectMany(_ => _.Elements)
-                .Where(_ => _.Type == EElementType.FileUpload || _.Type == EElementType.MultipleFileUpload)
+                .Where(_ => _.Type.Equals(EElementType.FileUpload) || _.Type.Equals(EElementType.MultipleFileUpload))
                 .ToList();
 
             if (formFileUploadElements.Any())
                 formFileUploadElements.ForEach(fileElement =>
                 {
-                    var formFileAnswerData = formAnswers.Pages.SelectMany(_ => _.Answers).FirstOrDefault(_ => _.QuestionId == $"{fileElement.Properties.QuestionId}{FileUploadConstants.SUFFIX}")?.Response ?? string.Empty;
+                    var formFileAnswerData = formAnswers.Pages.SelectMany(_ => _.Answers).FirstOrDefault(_ => _.QuestionId.Equals($"{fileElement.Properties.QuestionId}{FileUploadConstants.SUFFIX}"))?.Response ?? string.Empty;
                     List<FileUploadModel> convertedFileUploadAnswer = JsonConvert.DeserializeObject<List<FileUploadModel>>(formFileAnswerData.ToString());
 
                     var fileStorageType = _configuration["FileStorageProvider:Type"];
-                    
+
                     var fileStorageProvider = _fileStorageProviders.Get(fileStorageType);
 
-                    if (convertedFileUploadAnswer != null && convertedFileUploadAnswer.Any())
+                    if (convertedFileUploadAnswer is not null && convertedFileUploadAnswer.Any())
                     {
                         convertedFileUploadAnswer.ForEach((_) =>
                         {

--- a/src/Services/PayService/PayService.cs
+++ b/src/Services/PayService/PayService.cs
@@ -63,7 +63,7 @@ namespace form_builder.Services.PayService
         {
             var sessionGuid = _sessionHelper.GetSessionGuid();
             var mappingEntity = await _mappingService.Map(sessionGuid, form);
-            if (mappingEntity == null)
+            if (mappingEntity is null)
                 throw new Exception($"PayService:: No mapping entity found for {form}");
 
             var currentPage = mappingEntity.BaseForm.GetPage(_pageHelper, mappingEntity.FormAnswers.Path);
@@ -107,13 +107,13 @@ namespace form_builder.Services.PayService
         {
             var sessionGuid = _sessionHelper.GetSessionGuid();
             var mappingEntity = await _mappingService.Map(sessionGuid, form);
-            if (mappingEntity == null)
+            if (mappingEntity is null)
                 throw new Exception($"PayService:: No mapping entity found for {form}");
 
             var paymentConfig = await _paymentConfigProvider.Get<List<PaymentInformation>>();
-            var formPaymentConfig = paymentConfig.FirstOrDefault(_ => _.FormName == form);
+            var formPaymentConfig = paymentConfig.FirstOrDefault(_ => _.FormName.Equals(form));
 
-            if (formPaymentConfig == null)
+            if (formPaymentConfig is null)
                 throw new Exception($"PayService:: No payment information found for {form}");
 
             if (string.IsNullOrEmpty(formPaymentConfig.Settings.Amount))
@@ -128,7 +128,7 @@ namespace form_builder.Services.PayService
             {
                 var postUrl = formPaymentConfig.Settings.CalculationSlug;
 
-                if (postUrl.URL == null || postUrl.AuthToken == null)
+                if (postUrl.URL is null || postUrl.AuthToken is null)
                     throw new Exception($"PayService::CalculateAmountAsync, slug for {_hostingEnvironment.EnvironmentName} not found or incomplete");
 
                 _gateway.ChangeAuthenticationHeader(postUrl.AuthToken);
@@ -137,7 +137,7 @@ namespace form_builder.Services.PayService
                 if (!response.IsSuccessStatusCode)
                     throw new Exception($"PayService::CalculateAmountAsync, Gateway returned unsuccessful status code {response.StatusCode}, Response: {Newtonsoft.Json.JsonConvert.SerializeObject(response)}");
 
-                if (response.Content == null)
+                if (response.Content is null)
                     throw new ApplicationException($"PayService::CalculateAmountAsync, Gateway {postUrl.URL} responded with null content");
 
                 var content = await response.Content.ReadAsStringAsync();
@@ -155,9 +155,9 @@ namespace form_builder.Services.PayService
 
         private IPaymentProvider GetFormPaymentProvider(PaymentInformation paymentInfo)
         {
-            var paymentProvider = _paymentProviders.FirstOrDefault(_ => _.ProviderName == paymentInfo.PaymentProvider);
+            var paymentProvider = _paymentProviders.FirstOrDefault(_ => _.ProviderName.Equals(paymentInfo.PaymentProvider));
 
-            if (paymentProvider == null)
+            if (paymentProvider is null)
                 throw new Exception($"PayService::GetFormPaymentProvider, No payment provider configured for {paymentInfo.PaymentProvider}");
 
             return paymentProvider;

--- a/src/Services/RetrieveExternalDataService/RetrieveExternalDataService.cs
+++ b/src/Services/RetrieveExternalDataService/RetrieveExternalDataService.cs
@@ -52,9 +52,9 @@ namespace form_builder.Services.RetrieveExternalDataService
             {
                 var response = new HttpResponseMessage();
                 var submitSlug = action.Properties.PageActionSlugs.FirstOrDefault(_ =>
-                    _.Environment.ToLower().Equals(_environment.EnvironmentName.ToS3EnvPrefix().ToLower()));
+                    _.Environment.Equals(_environment.EnvironmentName.ToS3EnvPrefix(), StringComparison.OrdinalIgnoreCase));
 
-                if (submitSlug == null)
+                if (submitSlug is null)
                     throw new ApplicationException("RetrieveExternalDataService::Process, there is no PageActionSlug defined for this environment");
 
                 var entity = _actionHelper.GenerateUrl(submitSlug.URL, mappingData.FormAnswers);
@@ -74,7 +74,7 @@ namespace form_builder.Services.RetrieveExternalDataService
                 if (!response.IsSuccessStatusCode)
                     throw new ApplicationException($"RetrieveExternalDataService::Process, http request to {entity.Url} returned an unsuccessful status code, Response: {JsonConvert.SerializeObject(response)}");
 
-                if (response.Content == null)
+                if (response.Content is null)
                     throw new ApplicationException($"RetrieveExternalDataService::Process, response content from {entity.Url} is null.");
 
                 var content = await response.Content.ReadAsStringAsync();
@@ -98,7 +98,7 @@ namespace form_builder.Services.RetrieveExternalDataService
                 }
             }
 
-            mappingData.FormAnswers.Pages.FirstOrDefault(_ => _.PageSlug.ToLower().Equals(mappingData.FormAnswers.Path.ToLower())).Answers.AddRange(answers);
+            mappingData.FormAnswers.Pages.FirstOrDefault(_ => _.PageSlug.Equals(mappingData.FormAnswers.Path, StringComparison.OrdinalIgnoreCase)).Answers.AddRange(answers);
 
             await _distributedCache.SetStringAsync(sessionGuid, JsonConvert.SerializeObject(mappingData.FormAnswers), CancellationToken.None);
         }

--- a/src/Services/StreetService/StreetService.cs
+++ b/src/Services/StreetService/StreetService.cs
@@ -57,16 +57,16 @@ namespace form_builder.Services.StreetService
             string path)
         {
             var cachedAnswers = _distributedCache.GetString(guid);
-            var streetElement = currentPage.Elements.Where(_ => _.Type == EElementType.Street).FirstOrDefault();
-            var convertedAnswers = cachedAnswers == null
+            var streetElement = currentPage.Elements.Where(_ => _.Type.Equals(EElementType.Street)).FirstOrDefault();
+            var convertedAnswers = cachedAnswers is null
                         ? new FormAnswers { Pages = new List<PageAnswers>() }
                         : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
             var street = (string)convertedAnswers
                 .Pages
-                .FirstOrDefault(_ => _.PageSlug == path)
+                .FirstOrDefault(_ => _.PageSlug.Equals(path))
                 .Answers
-                .FirstOrDefault(_ => _.QuestionId == $"{streetElement.Properties.QuestionId}")
+                .FirstOrDefault(_ => _.QuestionId.Equals($"{streetElement.Properties.QuestionId}"))
                 .Response;
 
             if (currentPage.IsValid && streetElement.Properties.Optional && string.IsNullOrEmpty(street))
@@ -107,9 +107,9 @@ namespace form_builder.Services.StreetService
             string path)
         {
             var cachedAnswers = _distributedCache.GetString(guid);
-            var streetElement = currentPage.Elements.Where(_ => _.Type == EElementType.Street).FirstOrDefault();
+            var streetElement = currentPage.Elements.Where(_ => _.Type.Equals(EElementType.Street)).FirstOrDefault();
 
-            var convertedAnswers = cachedAnswers == null
+            var convertedAnswers = cachedAnswers is null
                         ? new FormAnswers { Pages = new List<PageAnswers>() }
                         : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
@@ -137,7 +137,7 @@ namespace form_builder.Services.StreetService
 
             var foundStreet = convertedAnswers
                 .Pages.FirstOrDefault(_ => _.PageSlug.Equals(path))?
-                .Answers?.FirstOrDefault(_ => _.QuestionId == streetElement.Properties.QuestionId)?
+                .Answers?.FirstOrDefault(_ => _.QuestionId.Equals(streetElement.Properties.QuestionId))?
                 .Response;
 
             List<object> searchResults;

--- a/src/Services/SubmitService/SubmitService.cs
+++ b/src/Services/SubmitService/SubmitService.cs
@@ -105,7 +105,7 @@ namespace form_builder.Services.SubmitService
             if (!response.IsSuccessStatusCode)
                 throw new ApplicationException($"SubmitService::ProcessSubmission, An exception has occurred while attempting to call {submitSlug.URL}, Gateway responded with {response.StatusCode} status code, Message: {JsonConvert.SerializeObject(response)}");
             
-            if (!baseForm.GenerateReferenceNumber && response.Content != null)
+            if (!baseForm.GenerateReferenceNumber && response.Content is not null)
             {
                 var content = await response.Content.ReadAsStringAsync() ?? string.Empty;
                 reference = JsonConvert.DeserializeObject<string>(content);
@@ -147,7 +147,7 @@ namespace form_builder.Services.SubmitService
                 throw new ApplicationException($"SubmitService::PaymentSubmission, An exception has occurred while attempting to call {postUrl.URL}, Gateway responded with {response.StatusCode} status code, Message: {JsonConvert.SerializeObject(response)}");
             }
 
-            if (response.Content != null)
+            if (response.Content is not null)
             {
                 var content = await response.Content.ReadAsStringAsync();
 

--- a/src/Services/ValidateService/ValidateService.cs
+++ b/src/Services/ValidateService/ValidateService.cs
@@ -50,9 +50,9 @@ namespace form_builder.Services.ValidateService
             {
                 var response = new HttpResponseMessage();
                 var submitSlug = action.Properties.PageActionSlugs.FirstOrDefault(_ =>
-                    _.Environment.ToLower().Equals(_environment.EnvironmentName.ToS3EnvPrefix().ToLower()));
+                    _.Environment.Equals(_environment.EnvironmentName.ToS3EnvPrefix(), StringComparison.OrdinalIgnoreCase));
 
-                if (submitSlug == null)
+                if (submitSlug is null)
                     throw new ApplicationException("ValidateService::Process, there is no PageActionSlug defined for this environment");
 
                 var entity = _actionHelper.GenerateUrl(submitSlug.URL, mappingData.FormAnswers);

--- a/src/TagParsers/PaymentAmountTagParser.cs
+++ b/src/TagParsers/PaymentAmountTagParser.cs
@@ -23,7 +23,7 @@ namespace form_builder.TagParsers
         public Page Parse(Page page, FormAnswers formAnswers)
         {
             var leadingParagraphRegexIsMatch = !string.IsNullOrEmpty(page.LeadingParagraph) && Regex.IsMatch(page.LeadingParagraph);
-            var pageHasElementsMatchingRegex = page.Elements.Any(_ => _.Properties.Text != null && Regex.IsMatch(_.Properties.Text));
+            var pageHasElementsMatchingRegex = page.Elements.Any(_ => _.Properties.Text is not null && Regex.IsMatch(_.Properties.Text));
 
             if (leadingParagraphRegexIsMatch || pageHasElementsMatchingRegex)
             {

--- a/src/Validators/AddressPostcodeValidator.cs
+++ b/src/Validators/AddressPostcodeValidator.cs
@@ -11,38 +11,21 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.Address || (element.Type == EElementType.Address && !viewModel.IsInitial()))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(EElementType.Address) || (element.Type.Equals(EElementType.Address) && !viewModel.IsInitial()))
+                return new ValidationResult { IsValid = true };
 
             var addressElement = (Address)element;
 
             if (!viewModel.ContainsKey(addressElement.AddressSearchQuestionId))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[addressElement.AddressSearchQuestionId]) && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel[addressElement.AddressSearchQuestionId];
             var isValid = true;
             if (!AddressConstants.POSTCODE_REGEX.Match(value).Success)
-            {
                 isValid = false;
-            }
 
             return new ValidationResult
             {

--- a/src/Validators/AutomaticAddressElementValidator.cs
+++ b/src/Validators/AutomaticAddressElementValidator.cs
@@ -9,31 +9,16 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != Enum.EElementType.Address)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(Enum.EElementType.Address))
+                return new ValidationResult { IsValid = true };
 
             var addressElement = (Address)element;
             if (!viewModel.ContainsKey(addressElement.AddressSelectQuestionId))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel[addressElement.AddressSelectQuestionId];
             if (addressElement.Properties.Optional && string.IsNullOrEmpty(value))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var isValid = AddressConstants.UPRN_REGEX.IsMatch(value);
 

--- a/src/Validators/BookingValidator.cs
+++ b/src/Validators/BookingValidator.cs
@@ -12,14 +12,9 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.Booking ||
-                (element.Type == EElementType.Booking && viewModel.IsCheckYourBooking()))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(EElementType.Booking) ||
+                (element.Type.Equals(EElementType.Booking) && viewModel.IsCheckYourBooking()))
+                return new ValidationResult { IsValid = true };
 
             var bookingElement = (Booking)element;
 
@@ -27,12 +22,7 @@ namespace form_builder.Validators
             var containsBookingStartTime = viewModel.ContainsKey(bookingElement.StartTimeQuestionId);
 
             if (!containsBookingDate && !containsBookingStartTime && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             if (!containsBookingDate)
             {
@@ -86,10 +76,7 @@ namespace form_builder.Validators
                 };
             }
 
-            return new ValidationResult
-            {
-                IsValid = true
-            };
+            return new ValidationResult { IsValid = true };
         }
 
         private string ValidationMessage(bool isDateValid, bool isTimeValid, string customValidationMessage)

--- a/src/Validators/CheckboxValidator.cs
+++ b/src/Validators/CheckboxValidator.cs
@@ -9,36 +9,18 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.Checkbox && element.Type != EElementType.Declaration)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(EElementType.Checkbox) && !element.Type.Equals(EElementType.Declaration))
+                return new ValidationResult { IsValid = true };
 
             var containsValue = viewModel.ContainsKey(element.Properties.QuestionId);
             if (!containsValue && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             dynamic value = viewModel[element.Properties.QuestionId] as List<string> ?? viewModel[element.Properties.QuestionId];
-            if (value == null)
-            {
-                return new ValidationResult
-                {
-                    IsValid = false
-                };
-            }
+            if (value is null)
+                return new ValidationResult { IsValid = false };
 
-            return new ValidationResult
-            {
-                IsValid = true
-            };
+            return new ValidationResult { IsValid = true };
         }
     }
 }

--- a/src/Validators/DateInputElementValidator.cs
+++ b/src/Validators/DateInputElementValidator.cs
@@ -10,13 +10,8 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.DateInput)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(EElementType.DateInput))
+                return new ValidationResult { IsValid = true };
 
             var valueDay = viewModel.ContainsKey($"{element.Properties.QuestionId}-day")
                 ? viewModel[$"{element.Properties.QuestionId}-day"]
@@ -32,12 +27,7 @@ namespace form_builder.Validators
 
             var isOptional = string.IsNullOrEmpty(valueDay) && string.IsNullOrEmpty(valueMonth) && string.IsNullOrEmpty(valueYear) && element.Properties.Optional;
             if (isOptional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var isValid = !string.IsNullOrEmpty(valueDay) || !string.IsNullOrEmpty(valueMonth) || !string.IsNullOrEmpty(valueYear);
             if (!isValid)

--- a/src/Validators/DatePickerElementValidator.cs
+++ b/src/Validators/DatePickerElementValidator.cs
@@ -11,24 +11,14 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.DatePicker || !viewModel.ContainsKey(element.Properties.QuestionId))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(EElementType.DatePicker) || !viewModel.ContainsKey(element.Properties.QuestionId))
+                return new ValidationResult { IsValid = true };
 
             var date = viewModel[element.Properties.QuestionId];
 
             var isValid = !string.IsNullOrEmpty(date);
             if (!isValid && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             if (!isValid && !element.Properties.Optional)
             {

--- a/src/Validators/EmailElementValidator.cs
+++ b/src/Validators/EmailElementValidator.cs
@@ -10,7 +10,7 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!(bool)element.Properties.Email)
+            if (!element.Properties.Email.GetValueOrDefault())
                 return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[element.Properties.QuestionId]) && element.Properties.Optional)

--- a/src/Validators/EmailElementValidator.cs
+++ b/src/Validators/EmailElementValidator.cs
@@ -10,29 +10,14 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Properties.Email != true)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!(bool)element.Properties.Email)
+                return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[element.Properties.QuestionId]) && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             if (!element.Properties.Email.HasValue || !element.Properties.Email.Value || !viewModel.ContainsKey(element.Properties.QuestionId))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel[element.Properties.QuestionId];
             var isValid = true;
@@ -40,9 +25,7 @@ namespace form_builder.Validators
             Match match = regex.Match(value);
 
             if (!match.Success)
-            {
                 isValid = false;
-            }
 
             return new ValidationResult
             {

--- a/src/Validators/IntegrityChecks/Behaviours/EmptyBehaviourSlugsCheck.cs
+++ b/src/Validators/IntegrityChecks/Behaviours/EmptyBehaviourSlugsCheck.cs
@@ -12,7 +12,7 @@ namespace form_builder.Validators.IntegrityChecks.Behaviours
 
             foreach (var behaviour in behaviours)
             {
-                if (string.IsNullOrEmpty(behaviour.PageSlug) && (behaviour.SubmitSlugs is null || behaviour.SubmitSlugs.Count == 0))
+                if (string.IsNullOrEmpty(behaviour.PageSlug) && (behaviour.SubmitSlugs is null || behaviour.SubmitSlugs.Count.Equals(0)))
                     result.AddFailureMessage("Empty Behaviour Slug, Incorrectly configured behaviour slug was discovered");
             }
             return result;

--- a/src/Validators/IntegrityChecks/Elements/BookingElementCheck.cs
+++ b/src/Validators/IntegrityChecks/Elements/BookingElementCheck.cs
@@ -33,19 +33,19 @@ namespace form_builder.Validators.IntegrityChecks.Elements
                 return result;
             }
 
-            if (appointmentTypeForEnv.AppointmentId == Guid.Empty &&
+            if (appointmentTypeForEnv.AppointmentId.Equals(Guid.Empty) &&
                 string.IsNullOrEmpty(appointmentTypeForEnv.AppointmentIdKey))
             {
                 result.AddFailureMessage("Booking Element Check, You must supply either an AppointmentId or an AppointmentIdKey in the AppointmentType.");
             }
 
-            if (appointmentTypeForEnv.AppointmentId != Guid.Empty &&
+            if (!appointmentTypeForEnv.AppointmentId.Equals(Guid.Empty) &&
                 !string.IsNullOrEmpty(appointmentTypeForEnv.AppointmentIdKey))
             {
                 result.AddFailureMessage("Booking Element Check, You cannot use both AppointmentId and AppointmentIdKey in the AppointmentType.");
             }
 
-            if (appointmentTypeForEnv.OptionalResources.Count == 0)
+            if (appointmentTypeForEnv.OptionalResources.Count.Equals(0))
                 return result;
 
             foreach (var resource in appointmentTypeForEnv.OptionalResources)

--- a/src/Validators/IntegrityChecks/Elements/UploadedFilesSummaryQuestionsIsSetCheck.cs
+++ b/src/Validators/IntegrityChecks/Elements/UploadedFilesSummaryQuestionsIsSetCheck.cs
@@ -16,7 +16,7 @@ namespace form_builder.Validators.IntegrityChecks.Elements
             if (string.IsNullOrEmpty(element.Properties.Text))
                 result.AddFailureMessage("Uploaded Files Summary Question Is Set, Uploaded files summary text must not be empty.");
 
-            if (element.Properties.FileUploadQuestionIds.Count == 0)
+            if (element.Properties.FileUploadQuestionIds.Count.Equals(0))
                 result.AddFailureMessage("Uploaded Files Summary Question Is Set, Uploaded files summary must have atleast one file questionId specified to display the list of uploaded files.");
 
             return result;

--- a/src/Validators/IntegrityChecks/Form/AnyConditionTypeCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/AnyConditionTypeCheck.cs
@@ -30,7 +30,7 @@ namespace form_builder.Validators.IntegrityChecks.Form
             anyConditionType.AddRange(anyConditionTypeRenderConditions);
             anyConditionType.AddRange(anyConditionTypeBehaviours);
 
-            if (anyConditionType.Count == 0)
+            if (anyConditionType.Count.Equals(0))
                 return result;
 
             anyConditionType.ForEach(condition =>

--- a/src/Validators/IntegrityChecks/Form/BookingQuestionIdExistsForCustomerAddressCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/BookingQuestionIdExistsForCustomerAddressCheck.cs
@@ -18,7 +18,7 @@ namespace form_builder.Validators.IntegrityChecks.Form
                 .Where(element => element.Type.Equals(EElementType.Booking))
                 .ToList();
 
-            if (bookingElements.Count == 0)
+            if (bookingElements.Count.Equals(0))
                 return result;
 
             foreach (var bookingElement in bookingElements)

--- a/src/Validators/IntegrityChecks/Form/ConditionalElementCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/ConditionalElementCheck.cs
@@ -27,7 +27,7 @@ namespace form_builder.Validators.IntegrityChecks.Form
                 .Where(element => element.Properties.isConditionalElement)
                 .ToList();
 
-            if (elementsWithConditionals.Count == 0)
+            if (elementsWithConditionals.Count.Equals(0))
                 return result;
 
             foreach (var element in elementsWithConditionals)

--- a/src/Validators/IntegrityChecks/Form/DocumentDownloadCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/DocumentDownloadCheck.cs
@@ -20,7 +20,7 @@ namespace form_builder.Validators.IntegrityChecks.Form
                 return result;
             }
 
-            if (schema.DocumentType.Count == 0)
+            if (schema.DocumentType.Count.Equals(0))
             {
                 result.AddFailureMessage($"Document Download Check, No document download type configured.");
                 return result;

--- a/src/Validators/IntegrityChecks/Form/DynamicLookupChecks.cs
+++ b/src/Validators/IntegrityChecks/Form/DynamicLookupChecks.cs
@@ -32,7 +32,7 @@ namespace form_builder.Validators.IntegrityChecks.Form
                        element.Lookup.Equals(LookUpConstants.Dynamic))
                 .ToList();
 
-            if (elements.Count == 0)
+            if (elements.Count.Equals(0))
                 return result;
 
             foreach (var element in elements)

--- a/src/Validators/IntegrityChecks/Form/EmailActionsCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/EmailActionsCheck.cs
@@ -29,7 +29,7 @@ namespace form_builder.Validators.IntegrityChecks.Form
                 .Concat(backOfficeEmail)
                 .ToList();
 
-            if (actions.Count == 0)
+            if (actions.Count.Equals(0))
                 return result;
 
             actions.ForEach(action =>

--- a/src/Validators/IntegrityChecks/Form/RetrieveExternalActionsCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/RetrieveExternalActionsCheck.cs
@@ -27,7 +27,7 @@ namespace form_builder.Validators.IntegrityChecks.Form
                 .Concat(schema.Pages.SelectMany(page => page.PageActions)
                 .Where(pageAction => pageAction.Type.Equals(EActionType.RetrieveExternalData))).ToList();
 
-            if (actions.Count == 0)
+            if (actions.Count.Equals(0))
                 return result;
 
             actions.ForEach(action =>

--- a/src/Validators/IntegrityChecks/Form/TemplatedEmailActionCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/TemplatedEmailActionCheck.cs
@@ -18,7 +18,7 @@ namespace form_builder.Validators.IntegrityChecks.Form
                 .Concat(schema.Pages.SelectMany(page => page.PageActions)
                     .Where(pageAction => pageAction.Type.Equals(EActionType.TemplatedEmail))).ToList();
 
-            if (actions.Count == 0)
+            if (actions.Count.Equals(0))
                 return result;
 
             actions.ForEach(action =>

--- a/src/Validators/IntegrityChecks/Form/ValidateActionCheck.cs
+++ b/src/Validators/IntegrityChecks/Form/ValidateActionCheck.cs
@@ -25,10 +25,10 @@ namespace form_builder.Validators.IntegrityChecks.Form
             List<IAction> actions = schema.FormActions
                 .Where(formAction => formAction.Type.Equals(EActionType.Validate))
                 .Concat(schema.Pages.SelectMany(page => page.PageActions)
-                .Where(action => action.Type == EActionType.Validate))
+                .Where(action => action.Type.Equals(EActionType.Validate)))
                 .ToList();
 
-            if (actions.Count == 0)
+            if (actions.Count.Equals(0))
                 return result;
 
             actions.ForEach(action =>

--- a/src/Validators/IsDateAfterAbsoluteValidator.cs
+++ b/src/Validators/IsDateAfterAbsoluteValidator.cs
@@ -11,19 +11,20 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            var successResult = new ValidationResult { IsValid = true };
-            if ((element.Type != EElementType.DatePicker && 
-                element.Type != EElementType.DateInput) || 
+            ValidationResult successResult = new() { IsValid = true };
+
+            if ((!element.Type.Equals(EElementType.DatePicker) && 
+                !element.Type.Equals(EElementType.DateInput)) || 
                 string.IsNullOrEmpty(element.Properties.IsDateAfterAbsolute))
             {
                 return successResult;
             }
 
             DateTime? dateValue = new DateTime();
-            if (element.Type == EElementType.DatePicker)
+            if (element.Type.Equals(EElementType.DatePicker))
                 dateValue = DatePicker.GetDate(viewModel, element.Properties.QuestionId);
 
-            if (element.Type == EElementType.DateInput)
+            if (element.Type.Equals(EElementType.DateInput))
                 dateValue = DateInput.GetDate(viewModel, element.Properties.QuestionId);
             
             if (!dateValue.HasValue)

--- a/src/Validators/IsDateAfterValidator.cs
+++ b/src/Validators/IsDateAfterValidator.cs
@@ -39,7 +39,7 @@ namespace form_builder.Validators
             if (currentElementValue > comparisonElementValue) 
                 return new ValidationResult { IsValid = true };
 
-            if (currentElement.Properties.IsDateEqualityAllowed && currentElementValue == comparisonElementValue)
+            if (currentElement.Properties.IsDateEqualityAllowed && currentElementValue.Equals(comparisonElementValue))
                 return new ValidationResult { IsValid = true };
 
             return new ValidationResult {
@@ -52,13 +52,13 @@ namespace form_builder.Validators
 
         private bool IsValidatorRelevant(IElement element, IElement comparisonElement)
         {
-            if (element.Type != EElementType.DatePicker && element.Type != EElementType.DateInput)
+            if (!element.Type.Equals(EElementType.DatePicker) && !element.Type.Equals(EElementType.DateInput))
                 return false;
             
-            if (comparisonElement == null)
+            if (comparisonElement is null)
                 return false;
 
-            if (comparisonElement.Type != EElementType.DatePicker && comparisonElement.Type != EElementType.DateInput)
+            if (!comparisonElement.Type.Equals(EElementType.DatePicker) && !comparisonElement.Type.Equals(EElementType.DateInput))
                 return false;
 
             if ((string.IsNullOrEmpty(element.Properties.IsDateAfter)))
@@ -69,10 +69,10 @@ namespace form_builder.Validators
         
         private DateTime? GetElementValue(IElement element, Dictionary<string, dynamic> viewModel)
         {   
-            if (element.Type == EElementType.DatePicker)
+            if (element.Type.Equals(EElementType.DatePicker))
                 return DatePicker.GetDate(viewModel, element.Properties.QuestionId);
 
-            if (element.Type == EElementType.DateInput)
+            if (element.Type.Equals(EElementType.DateInput))
                 return DateInput.GetDate(viewModel, element.Properties.QuestionId);
 
             return new DateTime();
@@ -80,10 +80,10 @@ namespace form_builder.Validators
 
         private DateTime? GetElementValue(IElement element,  FormAnswers formAnswers)
         {            
-            if (element.Type == EElementType.DatePicker)
+            if (element.Type.Equals(EElementType.DatePicker))
                 return DatePicker.GetDate(formAnswers, element.Properties.QuestionId);
 
-            if (element.Type == EElementType.DateInput)
+            if (element.Type.Equals(EElementType.DateInput))
                 return DateInput.GetDate(formAnswers, element.Properties.QuestionId);
 
             return new DateTime();

--- a/src/Validators/IsDateBeforeAbsouteValidator.cs
+++ b/src/Validators/IsDateBeforeAbsouteValidator.cs
@@ -11,18 +11,18 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if ((element.Type != EElementType.DatePicker && 
-                element.Type != EElementType.DateInput) || 
+            if ((!element.Type.Equals(EElementType.DatePicker) && 
+                !element.Type.Equals(EElementType.DateInput)) || 
                 string.IsNullOrEmpty(element.Properties.IsDateBeforeAbsolute))
             {
                 return new ValidationResult { IsValid = true };
             }
 
             DateTime? dateValue = new DateTime();
-            if (element.Type == EElementType.DatePicker)
+            if (element.Type.Equals(EElementType.DatePicker))
                 dateValue = DatePicker.GetDate(viewModel, element.Properties.QuestionId);
 
-            if (element.Type == EElementType.DateInput)
+            if (element.Type.Equals(EElementType.DateInput))
                 dateValue = DateInput.GetDate(viewModel, element.Properties.QuestionId);
 
             if (!dateValue.HasValue)

--- a/src/Validators/IsDateBeforeValidator.cs
+++ b/src/Validators/IsDateBeforeValidator.cs
@@ -39,7 +39,7 @@ namespace form_builder.Validators
             if (currentElementValue < comparisonElementValue) 
                 return new ValidationResult { IsValid = true };
 
-            if (currentElement.Properties.IsDateEqualityAllowed && currentElementValue == comparisonElementValue)
+            if (currentElement.Properties.IsDateEqualityAllowed && currentElementValue.Equals(comparisonElementValue))
                 return new ValidationResult { IsValid = true };
 
             return new ValidationResult {
@@ -52,13 +52,13 @@ namespace form_builder.Validators
 
         private bool IsValidatorRelevant(IElement element, IElement comparisonElement)
         {
-            if (element.Type != EElementType.DatePicker && element.Type != EElementType.DateInput)
+            if (!element.Type.Equals(EElementType.DatePicker) && !element.Type.Equals(EElementType.DateInput))
                 return false;
             
-            if (comparisonElement == null)
+            if (comparisonElement is null)
                 return false;
 
-            if (comparisonElement.Type != EElementType.DatePicker && comparisonElement.Type != EElementType.DateInput)
+            if (!comparisonElement.Type.Equals(EElementType.DatePicker) && !comparisonElement.Type.Equals(EElementType.DateInput))
                 return false;
 
             if ((string.IsNullOrEmpty(element.Properties.IsDateBefore)))
@@ -69,10 +69,10 @@ namespace form_builder.Validators
         
         private DateTime? GetElementValue(IElement element, Dictionary<string, dynamic> viewModel)
         {   
-            if (element.Type == EElementType.DatePicker)
+            if (element.Type.Equals(EElementType.DatePicker))
                 return DatePicker.GetDate(viewModel, element.Properties.QuestionId);
 
-            if (element.Type == EElementType.DateInput)
+            if (element.Type.Equals(EElementType.DateInput))
                 return DateInput.GetDate(viewModel, element.Properties.QuestionId);
 
             return new DateTime();
@@ -80,10 +80,10 @@ namespace form_builder.Validators
 
         private DateTime? GetElementValue(IElement element,  FormAnswers formAnswers)
         {            
-            if (element.Type == EElementType.DatePicker)
+            if (element.Type.Equals(EElementType.DatePicker))
                 return DatePicker.GetDate(formAnswers, element.Properties.QuestionId);
 
-            if (element.Type == EElementType.DateInput)
+            if (element.Type.Equals(EElementType.DateInput))
                 return DateInput.GetDate(formAnswers, element.Properties.QuestionId);
 
             return new DateTime();

--- a/src/Validators/ManualAddressValidator.cs
+++ b/src/Validators/ManualAddressValidator.cs
@@ -11,13 +11,8 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!(element.Type == EElementType.Address && viewModel.IsManual()))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!(element.Type.Equals(EElementType.Address) && viewModel.IsManual()))
+                return new ValidationResult { IsValid = true };
 
             var valueAddressLine1 = viewModel.ContainsKey($"{element.Properties.QuestionId}-{AddressManualConstants.ADDRESS_LINE_1}")
                 ? viewModel[$"{element.Properties.QuestionId}-{AddressManualConstants.ADDRESS_LINE_1}"]
@@ -45,7 +40,7 @@ namespace form_builder.Validators
                 addressPostcodeMessage = ValidationConstants.POSTCODE_EMPTY;
                 addressPostcodeValid = false;
             }
-            else if (!AddressConstants.STOCKPORT_POSTCODE_REGEX.IsMatch(valueAddressPostcode) && element.Properties.StockportPostcode == true)
+            else if (!AddressConstants.STOCKPORT_POSTCODE_REGEX.IsMatch(valueAddressPostcode) && element.Properties.StockportPostcode)
             {
                 addressPostcodeMessage = ValidationConstants.POSTCODE_INCORRECT_FORMAT;
                 addressPostcodeValid = false;

--- a/src/Validators/MaxLengthvalidator.cs
+++ b/src/Validators/MaxLengthvalidator.cs
@@ -10,20 +10,10 @@ namespace form_builder.Validators
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
             if (!viewModel.ContainsKey(element.Properties.QuestionId))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
-            if (element.Type == EElementType.FileUpload || element.Type == EElementType.Map || element.Type == EElementType.Checkbox || element.Type == EElementType.AddAnother)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (element.Type.Equals(EElementType.FileUpload) || element.Type.Equals(EElementType.Map) || element.Type.Equals(EElementType.Checkbox) || element.Type.Equals(EElementType.AddAnother))
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel.ContainsKey(element.Properties.QuestionId) ? viewModel[element.Properties.QuestionId] : "";
 
@@ -36,10 +26,7 @@ namespace form_builder.Validators
                 };
             }
 
-            return new ValidationResult
-            {
-                IsValid = true
-            };
+            return new ValidationResult { IsValid = true };
         }
     }
 }

--- a/src/Validators/MultipleFileUploadElementValidator.cs
+++ b/src/Validators/MultipleFileUploadElementValidator.cs
@@ -23,7 +23,7 @@ namespace form_builder.Validators
 
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.MultipleFileUpload)
+            if (!element.Type.Equals(EElementType.MultipleFileUpload))
                 return new ValidationResult { IsValid = true };
 
             if (element.Properties.Optional && viewModel.ContainsKey(ButtonConstants.SUBMIT))
@@ -38,20 +38,20 @@ namespace form_builder.Validators
 
             isValid = !(value is null);
 
-            if (value == null)
+            if (value is null)
             {
                 var sessionGuid = _sessionHelper.GetSessionGuid();
                 var cachedAnswers = _distributedCache.GetString(sessionGuid);
 
-                var convertedAnswers = cachedAnswers == null
+                var convertedAnswers = cachedAnswers is null
                     ? new FormAnswers { Pages = new List<PageAnswers>() }
                     : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
                 var path = viewModel.FirstOrDefault(_ => _.Key.Equals("Path")).Value;
 
-                var pageAnswersString = convertedAnswers.Pages.FirstOrDefault(_ => _.PageSlug.Equals(path))?.Answers.FirstOrDefault(_ => _.QuestionId == key);
+                var pageAnswersString = convertedAnswers.Pages.FirstOrDefault(_ => _.PageSlug.Equals(path))?.Answers.FirstOrDefault(_ => _.QuestionId.Equals(key));
                 var response = new List<FileUploadModel>();
-                if (pageAnswersString != null)
+                if (pageAnswersString is not null)
                 {
                     response = JsonConvert.DeserializeObject<List<FileUploadModel>>(pageAnswersString.Response.ToString());
 

--- a/src/Validators/NumericValueValidator.cs
+++ b/src/Validators/NumericValueValidator.cs
@@ -9,21 +9,11 @@ namespace form_builder.Validators
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
             if (!element.Properties.Numeric || !viewModel.ContainsKey(element.Properties.QuestionId))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel[element.Properties.QuestionId];
             if (string.IsNullOrEmpty(value) && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var isValid = int.TryParse(value, out int output);
             if (!isValid)
@@ -88,10 +78,7 @@ namespace form_builder.Validators
                 }
             }
 
-            return new ValidationResult
-            {
-                IsValid = true
-            };
+            return new ValidationResult { IsValid = true };
         }
     }
 }

--- a/src/Validators/PostcodeElementValidator.cs
+++ b/src/Validators/PostcodeElementValidator.cs
@@ -9,7 +9,7 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!(bool)element.Properties.Postcode)
+            if (!element.Properties.Postcode.GetValueOrDefault())
                 return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[element.Properties.QuestionId]) && element.Properties.Optional)

--- a/src/Validators/PostcodeElementValidator.cs
+++ b/src/Validators/PostcodeElementValidator.cs
@@ -9,36 +9,19 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Properties.Postcode != true)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!(bool)element.Properties.Postcode)
+                return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[element.Properties.QuestionId]) && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             if ((!element.Properties.Postcode.HasValue || !element.Properties.Postcode.Value) || !viewModel.ContainsKey(element.Properties.QuestionId))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel[element.Properties.QuestionId];
             var isValid = true;
             if (!AddressConstants.POSTCODE_REGEX.Match(value).Success)
-            {
                 isValid = false;
-            }
 
             return new ValidationResult
             {

--- a/src/Validators/RegexElementValidator.cs
+++ b/src/Validators/RegexElementValidator.cs
@@ -10,28 +10,13 @@ namespace form_builder.Validators
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
             if (string.IsNullOrEmpty(element.Properties.Regex))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[element.Properties.QuestionId]) && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(element.Properties.Regex) || !viewModel.ContainsKey(element.Properties.QuestionId))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel[element.Properties.QuestionId];
             var isValid = true;
@@ -39,9 +24,7 @@ namespace form_builder.Validators
             Match match = regex.Match(value);
 
             if (!match.Success)
-            {
                 isValid = false;
-            }
 
             return new ValidationResult
             {

--- a/src/Validators/RequiredElementValidator.cs
+++ b/src/Validators/RequiredElementValidator.cs
@@ -11,32 +11,25 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type == EElementType.DateInput || element.Type == EElementType.Map ||
-                element.Type == EElementType.TimeInput || element.Type == EElementType.DatePicker ||
-                element.Type == EElementType.MultipleFileUpload || element.Properties.Optional ||
-                element.Type == EElementType.Booking || element.Type == EElementType.AddAnother ||
-                (element.Type == EElementType.Address && viewModel.IsManual()))
+            if (element.Type.Equals(EElementType.DateInput) || element.Type.Equals(EElementType.Map) ||
+                element.Type.Equals(EElementType.TimeInput) || element.Type.Equals(EElementType.DatePicker) ||
+                element.Type.Equals(EElementType.MultipleFileUpload) || element.Properties.Optional ||
+                element.Type.Equals(EElementType.Booking) || element.Type.Equals(EElementType.AddAnother) ||
+                (element.Type.Equals(EElementType.Address) && viewModel.IsManual()))
             {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
+                return new ValidationResult { IsValid = true };
             }
 
             var key = element.Properties.QuestionId;
             var validationMessage = string.Empty;
 
-            if (element.Type != EElementType.Address && element.Type != EElementType.Street && element.Type != EElementType.Organisation)
-            {
+            if (!element.Type.Equals(EElementType.Address) && !element.Type.Equals(EElementType.Street) && !element.Type.Equals(EElementType.Organisation))
                 validationMessage = !string.IsNullOrEmpty(element.Properties.CustomValidationMessage) ? element.Properties.CustomValidationMessage : "Enter the " + element.Properties.Label.ToLower();
-            }
 
-            if (element.Type == EElementType.FileUpload)
-            {
+            if (element.Type.Equals(EElementType.FileUpload))
                 key = $"{element.Properties.QuestionId}{FileUploadConstants.SUFFIX}";
-            }
 
-            if (element.Type == EElementType.Address)
+            if (element.Type.Equals(EElementType.Address))
             {
                 if (viewModel.IsAutomatic())
                 {
@@ -51,7 +44,7 @@ namespace form_builder.Validators
                 }
             }
 
-            if (element.Type == EElementType.Street)
+            if (element.Type.Equals(EElementType.Street))
             {
                 if (viewModel.IsAutomatic())
                 {
@@ -65,7 +58,7 @@ namespace form_builder.Validators
                 }
             }
 
-            if (element.Type == EElementType.Organisation)
+            if (element.Type.Equals(EElementType.Organisation))
             {
                 if (viewModel.IsAutomatic())
                 {
@@ -80,7 +73,7 @@ namespace form_builder.Validators
             }
 
             bool isValid;
-            if (element.Type == EElementType.FileUpload)
+            if (element.Type.Equals(EElementType.FileUpload))
             {
                 List<DocumentModel> value = viewModel.ContainsKey(key)
                     ? viewModel[key]

--- a/src/Validators/RequiredIfValidator.cs
+++ b/src/Validators/RequiredIfValidator.cs
@@ -9,41 +9,29 @@ namespace form_builder.Validators
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
             if (string.IsNullOrEmpty(element.Properties.RequiredIf))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var isValid = true;
             var requiredIf = element.Properties.RequiredIf.Split(':');
             var requiredKey = requiredIf[0];
 
-            dynamic answeredValue = string.Empty;
-            if (!viewModel.TryGetValue(requiredKey, out answeredValue))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!viewModel.TryGetValue(requiredKey, out dynamic answeredValue))
+                return new ValidationResult { IsValid = true };
 
             answeredValue = viewModel[requiredKey];
 
-            if (answeredValue == requiredIf[1])
+            if (answeredValue.Equals(requiredIf[1]))
             {
-                if (element.Type == Enum.EElementType.Textarea || element.Type == Enum.EElementType.Textbox)
+                if (element.Type.Equals(Enum.EElementType.Textarea) || element.Type.Equals(Enum.EElementType.Textbox))
                 {
-                    if (viewModel[element.Properties.QuestionId] == string.Empty || viewModel[element.Properties.QuestionId] == null) isValid = false;
+                    if (viewModel[element.Properties.QuestionId].Equals(string.Empty) || viewModel[element.Properties.QuestionId] is null) isValid = false;
                 }
                 else
                 {
-                    dynamic value = string.Empty;
-                    if (viewModel.TryGetValue(element.Properties.QuestionId, out value))
+                    if (viewModel.TryGetValue(element.Properties.QuestionId, out dynamic value))
                     {
                         isValid = true;
-                        if (value == string.Empty) isValid = false;
+                        if (value.Equals(string.Empty)) isValid = false;
                     }
                     else
                     {

--- a/src/Validators/RestrictCombinedFileSizeValidator.cs
+++ b/src/Validators/RestrictCombinedFileSizeValidator.cs
@@ -24,7 +24,7 @@ namespace form_builder.Validators
 
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.MultipleFileUpload)
+            if (!element.Type.Equals(EElementType.MultipleFileUpload))
                 return new ValidationResult { IsValid = true };
 
             var key = $"{element.Properties.QuestionId}{FileUploadConstants.SUFFIX}";
@@ -34,7 +34,7 @@ namespace form_builder.Validators
 
             List<DocumentModel> documentModel = viewModel[key];
 
-            if (documentModel == null)
+            if (documentModel is null)
                 return new ValidationResult { IsValid = true };
 
             var maxCombinedFileSize = element.Properties.MaxCombinedFileSize > 0 ? element.Properties.MaxCombinedFileSize * SystemConstants.OneMBInBinaryBytes : SystemConstants.DefaultMaxCombinedFileSize;
@@ -42,15 +42,15 @@ namespace form_builder.Validators
             var sessionGuid = _sessionHelper.GetSessionGuid();
             var cachedAnswers = _distributedCache.GetString(sessionGuid);
 
-            var convertedAnswers = cachedAnswers == null
+            var convertedAnswers = cachedAnswers is null
                 ? new FormAnswers { Pages = new List<PageAnswers>() }
                 : JsonConvert.DeserializeObject<FormAnswers>(cachedAnswers);
 
             var path = viewModel.FirstOrDefault(_ => _.Key.Equals("Path")).Value;
 
-            var pageAnswersString = convertedAnswers.Pages.FirstOrDefault(_ => _.PageSlug.Equals(path))?.Answers.FirstOrDefault(_ => _.QuestionId == key);
-            var response = new List<FileUploadModel>();
-            if (pageAnswersString != null)
+            var pageAnswersString = convertedAnswers.Pages.FirstOrDefault(_ => _.PageSlug.Equals(path))?.Answers.FirstOrDefault(_ => _.QuestionId.Equals(key));
+            List<FileUploadModel> response = new();
+            if (pageAnswersString is not null)
             {
                 response = JsonConvert.DeserializeObject<List<FileUploadModel>>(pageAnswersString.Response.ToString());
             }

--- a/src/Validators/RestrictCurrentDateValidator.cs
+++ b/src/Validators/RestrictCurrentDateValidator.cs
@@ -10,13 +10,8 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!element.Properties.RestrictCurrentDate || element.Type == EElementType.DatePicker)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Properties.RestrictCurrentDate || element.Type.Equals(EElementType.DatePicker))
+                return new ValidationResult { IsValid = true };
 
             var valueDay = viewModel.ContainsKey($"{element.Properties.QuestionId}-day")
                 ? viewModel[$"{element.Properties.QuestionId}-day"]
@@ -31,12 +26,7 @@ namespace form_builder.Validators
                 : null;
 
             if (element.Properties.Optional && string.IsNullOrEmpty(valueDay) && string.IsNullOrEmpty(valueMonth) && string.IsNullOrEmpty(valueYear))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var isValidDate = DateTime.TryParse($"{valueDay}/{valueMonth}/{valueYear}", out _);
             if (!isValidDate)
@@ -53,7 +43,7 @@ namespace form_builder.Validators
             var date = DateTime.Today;
             var dateOutput = DateTime.Parse($"{valueDay}/{valueMonth}/{valueYear}");
 
-            if (element.Properties.RestrictCurrentDate && dateOutput == date)
+            if (element.Properties.RestrictCurrentDate && dateOutput.Equals(date))
             {
                 return new ValidationResult
                 {

--- a/src/Validators/RestrictCurrentDatepickerValidator.cs
+++ b/src/Validators/RestrictCurrentDatepickerValidator.cs
@@ -10,13 +10,8 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!element.Properties.RestrictCurrentDate || element.Type != EElementType.DatePicker || element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Properties.RestrictCurrentDate || !element.Type.Equals(EElementType.DatePicker) || element.Properties.Optional)
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel.ContainsKey(element.Properties.QuestionId) ? viewModel[element.Properties.QuestionId] : null;
 
@@ -37,7 +32,7 @@ namespace form_builder.Validators
             var date = DateTime.Today;
             var dateOutput = DateTime.Parse(value);
 
-            if (dateOutput == date)
+            if (dateOutput.Equals(date))
             {
                 return new ValidationResult
                 {

--- a/src/Validators/RestrictFileSizeValidator.cs
+++ b/src/Validators/RestrictFileSizeValidator.cs
@@ -11,7 +11,7 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.FileUpload && element.Type != EElementType.MultipleFileUpload)
+            if (!element.Type.Equals(EElementType.FileUpload) && !element.Type.Equals(EElementType.MultipleFileUpload))
                 return new ValidationResult { IsValid = true };
 
             var key = $"{element.Properties.QuestionId}{FileUploadConstants.SUFFIX}";
@@ -21,10 +21,10 @@ namespace form_builder.Validators
 
             List<DocumentModel> documentModel = viewModel[key];
 
-            if (documentModel == null)
+            if (documentModel is null)
                 return new ValidationResult { IsValid = true };
 
-            return element.Type == EElementType.FileUpload
+            return element.Type.Equals(EElementType.FileUpload)
                 ? SingleFileUpload(element, documentModel)
                 : MultiFileUpload(element, documentModel);
         }
@@ -38,7 +38,7 @@ namespace form_builder.Validators
             if (!invalidFileSizes.Any())
                 return new ValidationResult { IsValid = true };
 
-            var validationMessage = documentModel.Count == 1
+            var validationMessage = documentModel.Count.Equals(1)
                 ? $"The selected file must be smaller than {maxFileSize / SystemConstants.OneMBInBinaryBytes}MB"
                 : invalidFileSizes.Select(_ => $"{_.FileName} must be smaller than {maxFileSize / SystemConstants.OneMBInBinaryBytes}MB").Aggregate((curr, acc) => $"{acc} <br/> {curr}");
 

--- a/src/Validators/RestrictFutureDateValidator.cs
+++ b/src/Validators/RestrictFutureDateValidator.cs
@@ -10,13 +10,8 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!element.Properties.RestrictFutureDate || element.Type == EElementType.DatePicker)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Properties.RestrictFutureDate || element.Type.Equals(EElementType.DatePicker))
+                return new ValidationResult { IsValid = true };
 
             var valueDay = viewModel.ContainsKey($"{element.Properties.QuestionId}-day")
                 ? viewModel[$"{element.Properties.QuestionId}-day"]
@@ -31,12 +26,7 @@ namespace form_builder.Validators
                 : null;
 
             if (element.Properties.Optional && string.IsNullOrEmpty(valueDay) && string.IsNullOrEmpty(valueMonth) && string.IsNullOrEmpty(valueYear))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var isValidDate = DateTime.TryParse($"{valueDay}/{valueMonth}/{valueYear}", out _);
             if (!isValidDate)

--- a/src/Validators/RestrictFutureDatepickerValidatorr.cs
+++ b/src/Validators/RestrictFutureDatepickerValidatorr.cs
@@ -10,13 +10,8 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!element.Properties.RestrictFutureDate || element.Type != EElementType.DatePicker || element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Properties.RestrictFutureDate || !element.Type.Equals(EElementType.DatePicker) || element.Properties.Optional)
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel.ContainsKey(element.Properties.QuestionId) ? viewModel[element.Properties.QuestionId] : null;
             var outDate = DateTime.Now;

--- a/src/Validators/RestrictMimeTypeValidator.cs
+++ b/src/Validators/RestrictMimeTypeValidator.cs
@@ -14,57 +14,37 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.FileUpload && element.Type != EElementType.MultipleFileUpload)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(EElementType.FileUpload) && !element.Type.Equals(EElementType.MultipleFileUpload))
+                return new ValidationResult { IsValid = true };
 
             var key = $"{element.Properties.QuestionId}{FileUploadConstants.SUFFIX}";
 
             if (!viewModel.ContainsKey(key))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             List<DocumentModel> documentModel = viewModel[key];
 
-            if (documentModel == null)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (documentModel is null)
+                return new ValidationResult { IsValid = true };
 
             var allowedFileTypes = element.Properties.AllowedFileTypes ?? SystemConstants.AcceptedMimeTypes;
 
             var fileTypes = documentModel.Select(_ => new MimeTypeFile { FileType = Convert.FromBase64String(_.Content).GetFileType(), File = _ });
             var invalidFiles = new List<MimeTypeFile>();
-            if (fileTypes != null)
+            if (fileTypes is not null)
             {
-                var availableFileTypes = fileTypes.Where(_ => _ != null && _.FileType != null);
-                var unknownFileTypes = fileTypes.Where(_ => _ != null && _.FileType == null);
+                var availableFileTypes = fileTypes.Where(_ => _ is not null && _.FileType is not null);
+                var unknownFileTypes = fileTypes.Where(_ => _ is not null && _.FileType is null);
 
                 if (unknownFileTypes.Any())
                     invalidFiles.AddRange(unknownFileTypes.ToList());
 
                 invalidFiles.AddRange(availableFileTypes.Where(_ => !allowedFileTypes.Contains($".{_.FileType.Extension}")).ToList());
                 if (!invalidFiles.Any())
-                {
-                    return new ValidationResult
-                    {
-                        IsValid = true
-                    };
-                }
+                    return new ValidationResult { IsValid = true };
             }
 
-            return element.Type == EElementType.FileUpload
+            return element.Type.Equals(EElementType.FileUpload)
                ? SingleFileUpload(allowedFileTypes, documentModel)
                : MultiFileUpload(allowedFileTypes, invalidFiles, documentModel);
         }
@@ -73,7 +53,7 @@ namespace form_builder.Validators
         {
             var fileTypesErrorMessage = allowedFileTypes.ToReadableFileType("or");
 
-            var validationMessage = documentModel.Count == 1
+            var validationMessage = documentModel.Count.Equals(1)
                 ? $"The selected file must be a {fileTypesErrorMessage}."
                 : invalidFiles.Select(_ => $"{_.File.FileName} must be a {fileTypesErrorMessage}.").Aggregate((curr, acc) => $"{acc} <br/> {curr}");
 

--- a/src/Validators/RestrictPastDateValidator.cs
+++ b/src/Validators/RestrictPastDateValidator.cs
@@ -10,13 +10,8 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!element.Properties.RestrictPastDate || element.Type == EElementType.DatePicker)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Properties.RestrictPastDate || element.Type.Equals(EElementType.DatePicker))
+                return new ValidationResult { IsValid = true };
 
             var valueDay = viewModel.ContainsKey($"{element.Properties.QuestionId}-day")
                 ? viewModel[$"{element.Properties.QuestionId}-day"]
@@ -31,12 +26,7 @@ namespace form_builder.Validators
                 : null;
 
             if (element.Properties.Optional && string.IsNullOrEmpty(valueDay) && string.IsNullOrEmpty(valueMonth) && string.IsNullOrEmpty(valueYear))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var isValidDate = DateTime.TryParse($"{valueDay}/{valueMonth}/{valueYear}", out _);
 

--- a/src/Validators/RestrictPastDatepickerValidator.cs
+++ b/src/Validators/RestrictPastDatepickerValidator.cs
@@ -10,15 +10,8 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!element.Properties.RestrictPastDate
-                || element.Type != EElementType.DatePicker
-                || element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Properties.RestrictPastDate || !element.Type.Equals(EElementType.DatePicker) || element.Properties.Optional)
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel.ContainsKey(element.Properties.QuestionId) ? viewModel[element.Properties.QuestionId] : null;
             var outDate = DateTime.Now;

--- a/src/Validators/StockportAddressPostcodeElementValidator.cs
+++ b/src/Validators/StockportAddressPostcodeElementValidator.cs
@@ -11,45 +11,23 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.Address || (element.Type == EElementType.Address && !viewModel.IsInitial()))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(EElementType.Address) || (element.Type.Equals(EElementType.Address) && !viewModel.IsInitial()))
+                return new ValidationResult { IsValid = true };
 
-            if (element.Properties.StockportPostcode != true)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!(bool)element.Properties.StockportPostcode)
+                return new ValidationResult { IsValid = true };
 
             if ((!element.Properties.StockportPostcode.HasValue || !element.Properties.StockportPostcode.Value) || !viewModel.ContainsKey($"{element.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}"))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[$"{element.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}"]) && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel[$"{element.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}"];
             var isValid = true;
 
             if (!AddressConstants.STOCKPORT_POSTCODE_REGEX.Match(value).Success)
-            {
                 isValid = false;
-            }
 
             return new ValidationResult
             {

--- a/src/Validators/StockportAddressPostcodeElementValidator.cs
+++ b/src/Validators/StockportAddressPostcodeElementValidator.cs
@@ -14,7 +14,7 @@ namespace form_builder.Validators
             if (!element.Type.Equals(EElementType.Address) || (element.Type.Equals(EElementType.Address) && !viewModel.IsInitial()))
                 return new ValidationResult { IsValid = true };
 
-            if (!(bool)element.Properties.StockportPostcode)
+            if (!element.Properties.StockportPostcode.GetValueOrDefault())
                 return new ValidationResult { IsValid = true };
 
             if ((!element.Properties.StockportPostcode.HasValue || !element.Properties.StockportPostcode.Value) || !viewModel.ContainsKey($"{element.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}"))

--- a/src/Validators/StockportPostcodeElementValidator.cs
+++ b/src/Validators/StockportPostcodeElementValidator.cs
@@ -10,37 +10,20 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.Textbox)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(EElementType.Textbox))
+                return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[element.Properties.QuestionId]) && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             if ((!element.Properties.StockportPostcode.HasValue || !element.Properties.StockportPostcode.Value) || !viewModel.ContainsKey(element.Properties.QuestionId))
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel[element.Properties.QuestionId];
             var isValid = true;
 
             if (!AddressConstants.STOCKPORT_POSTCODE_REGEX.Match(value).Success)
-            {
                 isValid = false;
-            }
 
             return new ValidationResult
             {

--- a/src/Validators/StreetSearchValidator.cs
+++ b/src/Validators/StreetSearchValidator.cs
@@ -9,26 +9,18 @@ namespace form_builder.Validators
 {
     public class StreetSearchValidator : IElementValidator
     {
-        public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm) {
-            if (element.Type != EElementType.Street || (element.Type == EElementType.Street && !viewModel.IsInitial())) {
-                return new ValidationResult {
-                    IsValid = true
-                };
-            }
+        public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
+        {
+            if (!element.Type.Equals(EElementType.Street) || (element.Type.Equals(EElementType.Street) && !viewModel.IsInitial()))
+                return new ValidationResult { IsValid = true };
 
             var streetElement = (Street)element;
 
-            if (!viewModel.ContainsKey(streetElement.StreetSearchQuestionId)) {
-                return new ValidationResult {
-                    IsValid = true
-                };
-            }
+            if (!viewModel.ContainsKey(streetElement.StreetSearchQuestionId))
+                return new ValidationResult { IsValid = true };
 
-            if (string.IsNullOrEmpty(viewModel[streetElement.StreetSearchQuestionId]) && element.Properties.Optional) {
-                return new ValidationResult {
-                    IsValid = true
-                };
-            }
+            if (string.IsNullOrEmpty(viewModel[streetElement.StreetSearchQuestionId]) && element.Properties.Optional)
+                return new ValidationResult { IsValid = true };
 
             var value = viewModel[streetElement.StreetSearchQuestionId];
             var isValid = true;

--- a/src/Validators/TimeInputValidator.cs
+++ b/src/Validators/TimeInputValidator.cs
@@ -10,13 +10,8 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (element.Type != EElementType.TimeInput)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+            if (!element.Type.Equals(EElementType.TimeInput))
+                return new ValidationResult { IsValid = true };
 
             var valueHours = viewModel.ContainsKey($"{element.Properties.QuestionId}{TimeConstants.HOURS_SUFFIX}")
                 ? viewModel[$"{element.Properties.QuestionId}{TimeConstants.HOURS_SUFFIX}"]
@@ -32,12 +27,7 @@ namespace form_builder.Validators
 
 
             if (string.IsNullOrEmpty(valueHours) && string.IsNullOrEmpty(valueMinutes) && string.IsNullOrEmpty(valueAmPm) && element.Properties.Optional)
-            {
-                return new ValidationResult
-                {
-                    IsValid = true
-                };
-            }
+                return new ValidationResult { IsValid = true };
 
             var isValid = !string.IsNullOrEmpty(valueHours) && !string.IsNullOrEmpty(valueMinutes);
 

--- a/src/Views/Shared/Address/AddressSearch.cshtml
+++ b/src/Views/Shared/Address/AddressSearch.cshtml
@@ -7,7 +7,7 @@
 
 <div class="govuk-form-group @(!Model.IsValid ? "govuk-form-group--error" : string.Empty)">
 
-    @if ((bool)Model.Properties.StockportPostcode)
+    @if (Model.Properties.StockportPostcode.GetValueOrDefault())
     {
         <partial name="InsetText" model="Model.Properties.AddressIAG" />
     }

--- a/src/Views/Shared/Address/AddressSearch.cshtml
+++ b/src/Views/Shared/Address/AddressSearch.cshtml
@@ -7,7 +7,7 @@
 
 <div class="govuk-form-group @(!Model.IsValid ? "govuk-form-group--error" : string.Empty)">
 
-    @if (Model.Properties.StockportPostcode == true)
+    @if ((bool)Model.Properties.StockportPostcode)
     {
         <partial name="InsetText" model="Model.Properties.AddressIAG" />
     }

--- a/src/Views/Shared/HtmlElements/Header/Header.cshtml
+++ b/src/Views/Shared/HtmlElements/Header/Header.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-    var isError = ViewData.Any(_ => _.Key == "IsError") 
+    var isError = ViewData.Any(_ => _.Key.Equals("IsError"))
         ? (bool)ViewData["IsError"] 
         : false;
         

--- a/src/Views/Shared/Time/TimeHeader.cshtml
+++ b/src/Views/Shared/Time/TimeHeader.cshtml
@@ -3,7 +3,7 @@
 <div class="smbc-time__header">
     <div class="smbc-time__period">
         <input class="smbc-time__period__input" 
-            @(Model.SelectedTimePeriod == ETimePeriod.Morning ? "checked" : string.Empty) 
+            @(Model.SelectedTimePeriod.Equals(ETimePeriod.Morning) ? "checked" : string.Empty) 
             type='radio' 
             value='@BookingConstants.APPOINTMENT_TIME_OF_DAY_MORNING' 
             name='@Model.Date.Day@BookingConstants.APPOINTMENT_TIME_OF_DAY_SUFFIX' 
@@ -14,7 +14,7 @@
     </div>
     <div class="smbc-time__period">
         <input class="smbc-time__period__input" 
-            @(Model.SelectedTimePeriod == ETimePeriod.Afternoon ? "checked" : string.Empty) 
+            @(Model.SelectedTimePeriod.Equals(ETimePeriod.Afternoon) ? "checked" : string.Empty) 
             type='radio' 
             value='@BookingConstants.APPOINTMENT_TIME_OF_DAY_AFTERNOON' 
             name='@Model.Date.Day@BookingConstants.APPOINTMENT_TIME_OF_DAY_SUFFIX' 

--- a/src/Views/Shared/Time/TimePeriod.cshtml
+++ b/src/Views/Shared/Time/TimePeriod.cshtml
@@ -14,7 +14,7 @@
             <div class="smbc-time__time">
                 <input class="smbc-time__time__input"
                        type='radio'
-                       @(Model.CurrentValue == Model.Value(startTime).ToString() ? "checked" : string.Empty)
+                       @(Model.CurrentValue.Equals(Model.Value(startTime).ToString()) ? "checked" : string.Empty)
                        value="@Model.Value(startTime)|@Model.Value(endTime)"
                        name='@Model.Id'
                        aria-describedby="@Model.GetTimeInputHint(i)"

--- a/src/Views/Shared/TimeInput/TimeInput.cshtml
+++ b/src/Views/Shared/TimeInput/TimeInput.cshtml
@@ -49,11 +49,11 @@
         <div class="govuk-form-group govuk-!-margin-top-2">
             <div class="govuk-radios govuk-radios--inline govuk-radios--small">
                 <div class="govuk-radios__item govuk-!-margin-right-2">
-                    <input type="radio" class="govuk-radios__input" name=@Model.GetCustomItemId("ampm") id=@Model.GetCustomItemId("am") value="am" @(Model.Properties.AmPm.ToLower() == "am" ? "checked" : string.Empty) />
+                    <input type="radio" class="govuk-radios__input" name=@Model.GetCustomItemId("ampm") id=@Model.GetCustomItemId("am") value="am" @(Model.Properties.AmPm.Equals("am", StringComparison.OrdinalIgnoreCase) ? "checked" : string.Empty) />
                     <label class="govuk-label govuk-radios__label" for=@Model.GetCustomItemId("am")>am</label>
                 </div>
                 <div class="govuk-radios__item">
-                    <input type="radio" class="govuk-radios__input" name=@Model.GetCustomItemId("ampm") id=@Model.GetCustomItemId("pm") value="pm" @(Model.Properties.AmPm.ToLower() == "pm" ? "checked" : string.Empty) />
+                    <input type="radio" class="govuk-radios__input" name=@Model.GetCustomItemId("ampm") id=@Model.GetCustomItemId("pm") value="pm" @(Model.Properties.AmPm.Equals("pm", StringComparison.OrdinalIgnoreCase) ? "checked" : string.Empty) />
                     <label class="govuk-label govuk-radios__label" for=@Model.GetCustomItemId("pm")>pm</label>
                 </div>
             </div>

--- a/src/Workflows/ActionsWorkflow/ActionsWorkflow.cs
+++ b/src/Workflows/ActionsWorkflow/ActionsWorkflow.cs
@@ -35,20 +35,20 @@ namespace form_builder.Workflows.ActionsWorkflow
 
         public async Task Process(List<IAction> actions, FormSchema formSchema, string formName)
         {
-            if (formSchema == null)
+            if (formSchema is null)
                 formSchema = await _schemaFactory.Build(formName);
 
             if (actions.Any(_ => _.Type.Equals(EActionType.RetrieveExternalData)))
-                await _retrieveExternalDataService.Process(actions.Where(_ => _.Type == EActionType.RetrieveExternalData).ToList(), formSchema, formName);
+                await _retrieveExternalDataService.Process(actions.Where(_ => _.Type.Equals(EActionType.RetrieveExternalData)).ToList(), formSchema, formName);
 
             if (actions.Any(_ => _.Type.Equals(EActionType.UserEmail) || _.Type.Equals(EActionType.BackOfficeEmail)))
-                await _emailService.Process(actions.Where(_ => _.Type == EActionType.UserEmail || _.Type == EActionType.BackOfficeEmail).ToList());
+                await _emailService.Process(actions.Where(_ => _.Type.Equals(EActionType.UserEmail) || _.Type.Equals(EActionType.BackOfficeEmail)).ToList());
 
             if (actions.Any(_ => _.Type.Equals(EActionType.Validate)))
-                await _validateService.Process(actions.Where(_ => _.Type == EActionType.Validate).ToList(), formSchema, formName);
+                await _validateService.Process(actions.Where(_ => _.Type.Equals(EActionType.Validate)).ToList(), formSchema, formName);
 
             if (actions.Any(_ => _.Type.Equals(EActionType.TemplatedEmail)))
-                _ = _templatedEmailService.ProcessTemplatedEmail(actions.Where(_ => _.Type == EActionType.TemplatedEmail).ToList());
+                _ = _templatedEmailService.ProcessTemplatedEmail(actions.Where(_ => _.Type.Equals(EActionType.TemplatedEmail)).ToList());
         }
     }
 }

--- a/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
+++ b/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
@@ -28,7 +28,7 @@ namespace form_builder.Workflows.DocumentWorkflow
         {
             var formData = _distributedCache.GetString($"document-{id.ToString()}");
 
-            if (formData == null)
+            if (formData is null)
                 throw new DocumentExpiredException($"DocumentWorkflow::GenerateSummaryDocument, Previous answers has expired, unable to generate {documentType.ToString()} document for summary");
 
             var previousAnswers = JsonConvert.DeserializeObject<FormAnswers>(formData);

--- a/tests/unit-tests/Builders/ActionBuilder.cs
+++ b/tests/unit-tests/Builders/ActionBuilder.cs
@@ -105,7 +105,7 @@ namespace form_builder_tests.Builders
 
         public ActionBuilder WithPageActionSlug(PageActionSlug pageActionSlug)
         {
-            if (_actionProperties.PageActionSlugs == null) _actionProperties.PageActionSlugs = new List<PageActionSlug>();
+            if (_actionProperties.PageActionSlugs is null) _actionProperties.PageActionSlugs = new List<PageActionSlug>();
             _actionProperties.PageActionSlugs.Add(pageActionSlug);
 
             return this;

--- a/tests/unit-tests/Builders/AppointmentTypeBuilder.cs
+++ b/tests/unit-tests/Builders/AppointmentTypeBuilder.cs
@@ -43,7 +43,7 @@ namespace form_builder_tests.Builders
 
         public AppointmentTypeBuilder WithOptionalResource(BookingResource resource)
         {
-            if(_optionalResources == null)
+            if(_optionalResources is null)
                 _optionalResources = new List<BookingResource>();
 
             _optionalResources.Add(resource);

--- a/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
@@ -1063,26 +1063,26 @@ namespace form_builder_tests.UnitTests.Helpers
             // Arrange                                        
             var questionId = "Item1";
             var currentAnswerKey = $"file-{questionId}-{Guid.NewGuid()}";
-            var file = new List<CustomFormFile>();
-            file.Add(new CustomFormFile(null, questionId, 1, null));
+            List<CustomFormFile> file = new();
+            file.Add(new(null, questionId, 1, "test"));
 
-            var fileUpload = new List<FileUploadModel>();
-            fileUpload.Add(
-                new FileUploadModel
+            List<FileUploadModel> fileUpload = new()
+            {
+                new()
                 {
                     Key = currentAnswerKey,
                     TrustedOriginalFileName = WebUtility.HtmlEncode("replace-me.txt"),
                     UntrustedOriginalFileName = "replace-me.txt",
                     FileSize = 0
                 }
-            );
+            };
 
-            var page = new PageAnswers
+            PageAnswers page = new()
             {
                 PageSlug = "path",
-                Answers = new List<Answers>
+                Answers = new()
                 {
-                    new Answers { QuestionId = "Item1", Response = JsonConvert.SerializeObject(fileUpload) }
+                    new() { QuestionId = "Item1", Response = JsonConvert.SerializeObject(fileUpload) }
                 }
             };
 

--- a/tests/unit-tests/UnitTests/Providers/PaymentProvider/CivicaPayProviderTests.cs
+++ b/tests/unit-tests/UnitTests/Providers/PaymentProvider/CivicaPayProviderTests.cs
@@ -36,7 +36,7 @@ namespace form_builder_tests.UnitTests.Providers.PaymentProvider
                 .Returns(new HostString("www.test.com"));
 
             _mockCivicaPayGateway.Setup(_ => _.CreateImmediateBasketAsync(It.IsAny<CreateImmediateBasketRequest>()))
-                .ReturnsAsync(new HttpResponse<CreateImmediateBasketResponse> { StatusCode = HttpStatusCode.OK, ResponseContent = new CreateImmediateBasketResponse { BasketReference = "testRef", BasketToken = "testBasketToken" } });
+                .ReturnsAsync(new HttpResponse<CreateImmediateBasketResponse> { IsSuccessStatusCode = true, StatusCode = HttpStatusCode.OK, ResponseContent = new CreateImmediateBasketResponse { BasketReference = "testRef", BasketToken = "testBasketToken" } });
 
             _civicaPayConfig.Setup(_ => _.Value).Returns(new CivicaPaymentConfiguration { CustomerId = "testId", ApiPassword = "test" });
 

--- a/tests/unit-tests/UnitTests/Validators/StockportAddressPostCodeValidatorTests.cs
+++ b/tests/unit-tests/UnitTests/Validators/StockportAddressPostCodeValidatorTests.cs
@@ -8,7 +8,7 @@ namespace form_builder_tests.UnitTests.Validators
 {
     public class StockportAddressPostCodeValidatorTests
     {
-        private readonly StockportAddressPostcodeElementValidator _stockportPostcodeValidator = new StockportAddressPostcodeElementValidator();
+        private readonly StockportAddressPostcodeElementValidator _stockportPostcodeValidator = new();
 
         [Fact]
         public void Validate_ShouldReturnTrue_WhenDoesNotPostcode()
@@ -37,7 +37,7 @@ namespace form_builder_tests.UnitTests.Validators
                 .WithType(EElementType.Address)
                 .Build();
 
-            var viewModel = new Dictionary<string, dynamic>();
+            Dictionary<string, dynamic> viewModel = new();
             viewModel.Add("testaddress-postcode", "SK4 1AA");
 
             // Act


### PR DESCRIPTION
### Description

Just an attempt to make things all seem similar... I don't mind if it provokes a discussion, needs more work, or is accepted as is...

0) Fat Arrow / Expression-Bodied members => ( for Element Models Constructors )
1) "this == that" to "this.Equals(that)"
2) "this != that" to "!this.Equals(that)"
3) "== null" to "is null"
4) != null to is not null
5) ToLower() to this.Equals(that, StringComparison.OrdinalIgnoreCase)
6) ValidationResult { IsValid = true }; ( changed to inline return object )

PageService : 
Moved if (string.IsNullOrEmpty(path)) up before the call to distributed cache get string, as this is the point when it first loads the form and redirects to the first page... so, save a call to the cache?

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary