### PR TITLE
fis(file_upload_key): moved NewGuid() out

### DIFF
--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -271,7 +271,8 @@ namespace form_builder.Helpers.PageHelpers
                     }
                 }
 
-                IEnumerable<string> keys = filesToAdd.Select(_ => $"file-{file.Key}-{Guid.NewGuid()}");
+                Guid newGuid = Guid.NewGuid();
+                IEnumerable<string> keys = filesToAdd.Select(_ => $"file-{file.Key}-{newGuid}");
                 IEnumerable<string> fileContent = filesToAdd.Select(_ => _.Base64EncodedContent);
 
                 string fileStorageType = _configuration["FileStorageProvider:Type"];


### PR DESCRIPTION
### Description
Moved the NewGuid() method out into a sperate line

Found the behaviour previously was calling the NewGuid() creation each time the key was requested


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary