### PR TITLE
chore(refactor_file_uploads): refactor

### DIFF
--- a/src/Mappers/ElementMapper.cs
+++ b/src/Mappers/ElementMapper.cs
@@ -180,7 +180,7 @@ namespace form_builder.Mappers
             if (value is null || value.Response is null)
                 return null;
 
-            List<FileUploadModel> uploadedFiles = value.Response.ToObject(typeof(List<FileUploadModel>));
+            List<FileUploadModel> uploadedFiles = JsonConvert.DeserializeObject<List<FileUploadModel>>(value.Response.ToString());
 
             var fileStorageProvider = _fileStorageProviders.Get(_configuration["FileStorageProvider:Type"]);
 

--- a/src/Mappers/ElementMapper.cs
+++ b/src/Mappers/ElementMapper.cs
@@ -177,10 +177,10 @@ namespace form_builder.Mappers
                 .SelectMany(_ => _.Answers)
                 .FirstOrDefault(_ => _.QuestionId.Equals(key));
 
-                List<FileUploadModel> uploadedFiles = value.Response.ToObject(typeof(List<FileUploadModel>));
             if (value is null || value.Response is null)
                 return null;
 
+            List<FileUploadModel> uploadedFiles = value.Response.ToObject(typeof(List<FileUploadModel>));
 
             var fileStorageProvider = _fileStorageProviders.Get(_configuration["FileStorageProvider:Type"]);
 

--- a/src/Providers/FileStorage/InMemoryStorageProvider.cs
+++ b/src/Providers/FileStorage/InMemoryStorageProvider.cs
@@ -16,24 +16,14 @@ namespace form_builder.Providers.FileStorage
 
         public string ProviderName { get => "Application"; }
 
-        public InMemoryStorageProvider(IDistributedCacheWrapper distributedCache)
-        {
+        public InMemoryStorageProvider(IDistributedCacheWrapper distributedCache) =>
             _distributedCache = distributedCache;
-        }
 
-        public async Task<string> GetString(string key)
-        {
-            return await Task.Run(() =>
-            {
-                return _distributedCache.GetString(key);
-            });
-        }
+        public async Task<string> GetString(string key) => await Task.Run(() => _distributedCache.GetString(key));
 
         public async Task Remove(string key) => await _distributedCache.RemoveAsync(key);
 
-        public Task SetStringAsync(string key, string value, int expiration, CancellationToken token = default)
-        {
-            return _distributedCache.SetStringAsync(key, value, expiration, token);
-        }
+        public Task SetStringAsync(string key, string value, int expiration, CancellationToken token = default) =>
+            _distributedCache.SetStringAsync(key, value, expiration, token);
     }
 }

--- a/src/Services/FileUploadService/FileUploadService.cs
+++ b/src/Services/FileUploadService/FileUploadService.cs
@@ -40,11 +40,11 @@ namespace form_builder.Services.FileUploadService
 
         public Dictionary<string, dynamic> AddFiles(Dictionary<string, dynamic> viewModel, IEnumerable<CustomFormFile> fileUpload)
         {
-            fileUpload.Where(_ => _ is not null)
-                .ToList()
+            fileUpload
+                .Where(_ => _ is not null)
                 .GroupBy(_ => _.QuestionId)
                 .ToList()
-                .ForEach((group) =>
+                .ForEach(group =>
                 {
                     viewModel.Add(group.Key, group.Select(_ => new DocumentModel
                     {

--- a/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
@@ -162,7 +162,7 @@ namespace form_builder_tests.UnitTests.Helpers
             var viewModel = new Dictionary<string, dynamic>
             {
                 {
-                    LookUpConstants.SubPathViewModelKey, 
+                    LookUpConstants.SubPathViewModelKey,
                     LookUpConstants.Automatic
                 }
             };
@@ -1162,23 +1162,20 @@ namespace form_builder_tests.UnitTests.Helpers
         {
             // Arrange
             var questionId = "fileUpload";
-            var file = new List<CustomFormFile>();
-            file.Add(new CustomFormFile("content", questionId, 1, "newfile.txt"));
-            file.Add(new CustomFormFile("content", questionId, 1, "existingfile.txt"));
-            file.Add(new CustomFormFile("content", questionId, 1, "existingfiletwo.txt"));
+            List<CustomFormFile> files = new();
+            files.Add(new("content", questionId, 1, "newfile.txt"));
+            files.Add(new("content", questionId, 1, "existingfile.txt"));
+            files.Add(new("content", questionId, 1, "existingfiletwo.txt"));
 
-            var fileUpload = new List<FileUploadModel>();
-            fileUpload.Add(
-              new FileUploadModel
-              {
-                  Key = questionId,
-                  TrustedOriginalFileName = WebUtility.HtmlEncode("existingfile.txt"),
-                  UntrustedOriginalFileName = "existingfile.txt",
-                  FileSize = 0
-              }
-            );
-            fileUpload.Add(
-            new FileUploadModel
+            List<FileUploadModel> fileUpload = new();
+            fileUpload.Add(new()
+            {
+                Key = questionId,
+                TrustedOriginalFileName = WebUtility.HtmlEncode("existingfile.txt"),
+                UntrustedOriginalFileName = "existingfile.txt",
+                FileSize = 0
+            });
+            fileUpload.Add(new()
             {
                 Key = questionId,
                 TrustedOriginalFileName = WebUtility.HtmlEncode("existingfiletwo.txt"),
@@ -1186,17 +1183,17 @@ namespace form_builder_tests.UnitTests.Helpers
                 FileSize = 0
             });
 
-            var page = new PageAnswers
+            PageAnswers pageAnswers = new()
             {
                 PageSlug = "path",
-                Answers = new List<Answers>
+                Answers = new()
                 {
-                    new Answers { QuestionId = questionId, Response = JsonConvert.SerializeObject(fileUpload) }
+                    new() { QuestionId = questionId, Response = JsonConvert.SerializeObject(fileUpload) }
                 }
             };
 
             // Act
-            _pageHelper.SaveFormFileAnswers(page.Answers, file, true, page);
+            _pageHelper.SaveFormFileAnswers(pageAnswers.Answers, files, true, pageAnswers);
 
             // Assert
             _fileStorageProvider.Verify(_ => _.SetStringAsync(It.Is<string>(x => x.StartsWith($"file-{questionId}-")), It.IsAny<string>(), It.Is<int>(_ => _ == 60), It.IsAny<CancellationToken>()), Times.Once());
@@ -1240,7 +1237,7 @@ namespace form_builder_tests.UnitTests.Helpers
         public void SavePaymentAmount_ShouldCallDistributedCache()
         {
             var sessionGuid = Guid.NewGuid().ToString();
-            _pageHelper.SavePaymentAmount(sessionGuid, "10.00" );
+            _pageHelper.SavePaymentAmount(sessionGuid, "10.00");
 
             _mockDistributedCache.Verify(_ => _.GetString(sessionGuid), Times.Once);
             _mockDistributedCache.Verify(_ => _.SetStringAsync(sessionGuid, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);


### PR DESCRIPTION
### Description
refactor as mentioned the other day... to make reading code a little clearer and clean up extra bits.

Pagehelper.SaveFormFileAnswers:
-) moved all the stuff about elementAt(index) into a foreach loop
-) renamed linq foreach anonymous variable from "file" to "group"
-) Removed a couple of ".ToList()" calls

Mappers.ElementMapper:
-) C# 9 new()
-) inverted if null check
-) removed extra ".ToList()" call

FileStorage.InMemoryFileStorageProviser:
-) moved to expression bodied constructor

FileUploadService:
-) removed extra ".ToList()"
-) removed parenthesis around linq foreach anonymous variable

PageHelperTests:
-) C# 9

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary