### PR TITLE
refactor(UserPageTransforms): refactor to only do when needed

### DIFF
--- a/src/Extensions/FormSchemaExtensions.cs
+++ b/src/Extensions/FormSchemaExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using form_builder.Constants;
+using form_builder.Models;
+
+namespace form_builder.Extensions
+{
+    public static class FormSchemaExtensions
+    {
+        public static List<Page> GetReducedPages(this FormSchema schema, FormAnswers answers)
+            => RecursivelyReducePages(
+                answers.Pages.SelectMany(_ => _.Answers).ToDictionary(x => x.QuestionId, x => x.Response),
+                schema.Pages,
+                !string.IsNullOrEmpty(answers.Path) && answers.Path.Equals(FileUploadConstants.DOCUMENT_UPLOAD_URL_PATH) ? answers.Path : schema.FirstPageSlug,
+                new List<Page>());
+
+        private static List<Page> RecursivelyReducePages(
+            Dictionary<string, object> answersDictionary,
+            List<Page> schemaPages,
+            string currentPageSlug,
+            List<Page> reducedPages)
+        {
+            var page = new Page();
+            var currentSchema = schemaPages.FindAll(_ => _.PageSlug.Equals(currentPageSlug));
+            
+            if (!currentSchema.Any())
+                return reducedPages;
+
+            page = currentSchema.Count > 1
+                ? currentSchema.FirstOrDefault(page => page.CheckPageMeetsConditions(answersDictionary))
+                : currentSchema.FirstOrDefault();
+
+            if (page is null)
+                return reducedPages;
+
+            reducedPages.Add(page);
+
+            if (currentPageSlug.Equals("success"))
+                return reducedPages;
+
+            var behaviour = page.GetNextPage(answersDictionary);
+
+            if (behaviour is null || string.IsNullOrEmpty(behaviour.PageSlug))
+                return reducedPages;
+            
+            return RecursivelyReducePages(answersDictionary, schemaPages, behaviour.PageSlug, reducedPages);
+        }
+    }
+}

--- a/src/Factories/Schema/ISchemaFactory.cs
+++ b/src/Factories/Schema/ISchemaFactory.cs
@@ -5,6 +5,8 @@ namespace form_builder.Factories.Schema
 {
     public interface ISchemaFactory
     {
-        Task<FormSchema> Build(string formKey, string sessionGuid = "");
+        Task<FormSchema> Build(string formKey);
+
+        Task<Page> TransformPage(Page page, string sessionGuid);
     }
 }

--- a/src/Factories/Schema/ISchemaFactory.cs
+++ b/src/Factories/Schema/ISchemaFactory.cs
@@ -7,6 +7,6 @@ namespace form_builder.Factories.Schema
     {
         Task<FormSchema> Build(string formKey);
 
-        Task<Page> TransformPage(Page page, string sessionGuid);
+        Task<Page> TransformPage(Page page, FormAnswers convertedAnswers);
     }
 }

--- a/src/Factories/Schema/SchemaFactory.cs
+++ b/src/Factories/Schema/SchemaFactory.cs
@@ -79,10 +79,10 @@ namespace form_builder.Factories.Schema
             return formSchema;
         }
 
-        public async Task<Page> TransformPage(Page page, string sessionGuid)
+        public async Task<Page> TransformPage(Page page, FormAnswers convertedAnswers)
         {
             foreach (var userPageFactory in _userPageTransformFactories)
-                await userPageFactory.Transform(page, sessionGuid);
+                await userPageFactory.Transform(page, convertedAnswers);
 
             return page;
         }

--- a/src/Factories/Transform/UserSchema/AddAnotherPageTransformFactory.cs
+++ b/src/Factories/Transform/UserSchema/AddAnotherPageTransformFactory.cs
@@ -27,11 +27,12 @@ namespace form_builder.Factories.Transform.UserSchema
         public async Task<Page> Transform(Page page, string sessionGuid)
         {
             var newListOfElements = new List<IElement>();
+            var convertedAnswers = _pageHelper.GetSavedAnswers(sessionGuid);
             foreach (var element in page.Elements)
             {
                 if (element.Type.Equals(EElementType.AddAnother))
                 {
-                    newListOfElements.AddRange(GenerateListOfIncrementedElements(page.Elements, sessionGuid));
+                    newListOfElements.AddRange(GenerateListOfIncrementedElements(page.Elements, convertedAnswers));
                 }
 
                 newListOfElements.Add(element);
@@ -42,21 +43,11 @@ namespace form_builder.Factories.Transform.UserSchema
             return page;
         }
 
-        private IEnumerable<IElement> GenerateListOfIncrementedElements(IReadOnlyCollection<IElement> currentPageElements, string sessionGuid)
+        private IEnumerable<IElement> GenerateListOfIncrementedElements(IReadOnlyCollection<IElement> currentPageElements, FormAnswers convertedAnswers)
         {
             var addAnotherElement = currentPageElements.FirstOrDefault(_ => _.Type.Equals(EElementType.AddAnother));
             var addAnotherReplacementElements = new List<IElement>();
-            if (string.IsNullOrEmpty(sessionGuid))
-            {
-                sessionGuid = _sessionHelper.GetSessionGuid();
-                if (string.IsNullOrEmpty(sessionGuid))
-                {
-                    sessionGuid = Guid.NewGuid().ToString();
-                    _sessionHelper.SetSessionGuid(sessionGuid);
-                }
-            }
 
-            var convertedAnswers = _pageHelper.GetSavedAnswers(sessionGuid);
             var formDataIncrementKey = $"{AddAnotherConstants.IncrementKeyPrefix}{addAnotherElement.Properties.QuestionId}";
             var fieldsetIncrements = convertedAnswers.FormData.ContainsKey(formDataIncrementKey) ? int.Parse(convertedAnswers.FormData.GetValueOrDefault(formDataIncrementKey).ToString()) : 1;
 

--- a/src/Factories/Transform/UserSchema/AddAnotherPageTransformFactory.cs
+++ b/src/Factories/Transform/UserSchema/AddAnotherPageTransformFactory.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using form_builder.Builders;
 using form_builder.Constants;
 using form_builder.Enum;
-using form_builder.Helpers.PageHelpers;
-using form_builder.Helpers.Session;
 using form_builder.Models;
 using form_builder.Models.Elements;
 using Newtonsoft.Json;
@@ -15,19 +12,9 @@ namespace form_builder.Factories.Transform.UserSchema
 {
     public class AddAnotherPageTransformFactory : IUserPageTransformFactory
     {
-        private readonly IPageHelper _pageHelper;
-        private readonly ISessionHelper _sessionHelper;
-
-        public AddAnotherPageTransformFactory(IPageHelper pageHelper, ISessionHelper sessionHelper)
-        {
-            _pageHelper = pageHelper;
-            _sessionHelper = sessionHelper;
-        }
-
-        public async Task<Page> Transform(Page page, string sessionGuid)
+        public async Task<Page> Transform(Page page, FormAnswers convertedAnswers)
         {
             var newListOfElements = new List<IElement>();
-            var convertedAnswers = _pageHelper.GetSavedAnswers(sessionGuid);
             foreach (var element in page.Elements)
             {
                 if (element.Type.Equals(EElementType.AddAnother))
@@ -49,7 +36,7 @@ namespace form_builder.Factories.Transform.UserSchema
             var addAnotherReplacementElements = new List<IElement>();
 
             var formDataIncrementKey = $"{AddAnotherConstants.IncrementKeyPrefix}{addAnotherElement.Properties.QuestionId}";
-            var fieldsetIncrements = convertedAnswers.FormData.ContainsKey(formDataIncrementKey) ? int.Parse(convertedAnswers.FormData.GetValueOrDefault(formDataIncrementKey).ToString()) : 1;
+            var fieldsetIncrements = convertedAnswers.FormData is not null && convertedAnswers.FormData.ContainsKey(formDataIncrementKey) ? int.Parse(convertedAnswers.FormData.GetValueOrDefault(formDataIncrementKey).ToString()) : 1;
 
             foreach (var pageElement in currentPageElements)
             {

--- a/src/Factories/Transform/UserSchema/DynamicLookupPageTransformFactory.cs
+++ b/src/Factories/Transform/UserSchema/DynamicLookupPageTransformFactory.cs
@@ -5,8 +5,6 @@ using System.Threading.Tasks;
 using form_builder.Constants;
 using form_builder.Extensions;
 using form_builder.Helpers.ActionsHelpers;
-using form_builder.Helpers.PageHelpers;
-using form_builder.Helpers.Session;
 using form_builder.Models;
 using form_builder.Models.Elements;
 using form_builder.Models.Properties.ElementProperties;
@@ -21,35 +19,31 @@ namespace form_builder.Factories.Transform.UserSchema
     {
         private readonly IActionHelper _actionHelper;
         private readonly IEnumerable<ILookupProvider> _lookupProviders;
-        private readonly IPageHelper _pageHelper;
         private readonly IWebHostEnvironment _environment;
 
         public DynamicLookupPageTransformFactory(IActionHelper actionHelper,
-            IEnumerable<ILookupProvider> lookupProviders, 
-            IPageHelper pageHelper, 
+            IEnumerable<ILookupProvider> lookupProviders,
             IWebHostEnvironment environment)
         {
             _actionHelper = actionHelper;
             _lookupProviders = lookupProviders;
-            _pageHelper = pageHelper;
             _environment = environment;
         }
 
-        public async Task<Page> Transform(Page page, string sessionGuid)
+        public async Task<Page> Transform(Page page, FormAnswers convertedAnswers)
         {
             if (page.HasDynamicLookupElements)
             {
-                var convertedAnswers = _pageHelper.GetSavedAnswers(sessionGuid);
                 foreach (var element in page.Elements.Where(_ => !string.IsNullOrEmpty(_.Lookup) && _.Lookup.Equals(LookUpConstants.Dynamic)))
                 {
-                    await AddDynamicOptions(element, convertedAnswers, sessionGuid);
+                    await AddDynamicOptions(element, convertedAnswers);
                 }
             }
 
             return page;
         }
 
-        private async Task AddDynamicOptions(IElement element, FormAnswers convertedAnswers, string sessionGuid)
+        private async Task AddDynamicOptions(IElement element, FormAnswers convertedAnswers)
         {
             LookupSource submitDetails = element.Properties.LookupSources
                 .SingleOrDefault(x => x.EnvironmentName
@@ -64,26 +58,10 @@ namespace form_builder.Factories.Transform.UserSchema
                 throw new Exception("DynamicLookupPageTransformFactory::AddDynamicOptions, No Provider name given in LookupSources");
 
             var lookupProvider = _lookupProviders.Get(submitDetails.Provider);
-            List<Option> lookupOptions = new();
-
-            if (convertedAnswers is not null)
-            {
-                var lookUpCacheResults = convertedAnswers.FormData.SingleOrDefault(x => x.Key.Equals(request.Url, StringComparison.OrdinalIgnoreCase));
-                if (!string.IsNullOrEmpty(lookUpCacheResults.Key) && lookUpCacheResults.Value is not null)
-                {
-                    lookupOptions = JsonConvert.DeserializeObject<List<Option>>(JsonConvert.SerializeObject(lookUpCacheResults.Value));
-                }
-            }
+            List<Option> lookupOptions =  await lookupProvider.GetAsync(request.Url, submitDetails.AuthToken);
 
             if (!lookupOptions.Any())
-            {
-                lookupOptions = await lookupProvider.GetAsync(request.Url, submitDetails.AuthToken);
-
-                if (!lookupOptions.Any())
-                    throw new Exception("DynamicLookupPageTransformFactory::AddDynamicOptions, Provider returned no options");
-            }
-
-            _pageHelper.SaveFormData(request.Url, lookupOptions, sessionGuid, convertedAnswers.FormName);
+                throw new Exception("DynamicLookupPageTransformFactory::AddDynamicOptions, Provider returned no options");
 
             element.Properties.Options.AddRange(lookupOptions);
         }

--- a/src/Factories/Transform/UserSchema/IUserPageTransformFactory.cs
+++ b/src/Factories/Transform/UserSchema/IUserPageTransformFactory.cs
@@ -5,6 +5,6 @@ namespace form_builder.Factories.Transform.UserSchema
 {
     public interface IUserPageTransformFactory
     {
-        Task<Page> Transform(Page page, string sessionGuid);
+        Task<Page> Transform(Page page, FormAnswers convertedAnswers);
     }
 }

--- a/src/Helpers/ActionsHelpers/ActionHelper.cs
+++ b/src/Helpers/ActionsHelpers/ActionHelper.cs
@@ -18,22 +18,6 @@ namespace form_builder.Helpers.ActionsHelpers
         public RequestEntity GenerateUrl(string baseUrl, FormAnswers formAnswers)
         {
             var matches = TagRegex.Matches(baseUrl);
-
-            if (matches.Any())
-            {
-                foreach (Match match in matches.ToList())
-                {
-                    if (!formAnswers.AllAnswers.ToList().Any(_ => _.QuestionId.Equals(match.Value)))
-                    {
-                        return new RequestEntity
-                        {
-                            Url = baseUrl,
-                            IsPost = !matches.Any()
-                        };
-                    }
-                }
-            }
-
             var newUrl = matches.Aggregate(baseUrl, (current, match) => Replace(match, current, formAnswers));
 
             return new RequestEntity

--- a/src/Services/DocumentService/DocumentSummaryService.cs
+++ b/src/Services/DocumentService/DocumentSummaryService.cs
@@ -31,6 +31,12 @@ namespace form_builder.Services.DocumentService
 
         public async Task<byte[]> GenerateDocument(DocumentSummaryEntity entity)
         {
+            var journeyPages = entity.FormSchema.GetReducedPages(entity.PreviousAnswers);
+            foreach (var page in journeyPages)
+            {
+                await _schemaFactory.TransformPage(page, entity.PreviousAnswers);
+            }
+
             switch (entity.DocumentType)
             {
                 case EDocumentType.Txt:
@@ -42,11 +48,7 @@ namespace form_builder.Services.DocumentService
 
         private async Task<byte[]> GenerateTextFile(FormAnswers formAnswers, FormSchema formSchema)
         {
-            var journeyPages = formSchema.GetReducedPages(formAnswers);
-            foreach (var page in journeyPages)
-            {
-                await _schemaFactory.TransformPage(page, formAnswers);
-            }
+            
 
             var data = await _documentCreationHelper.GenerateQuestionAndAnswersList(formAnswers, formSchema);
 

--- a/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
+++ b/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
@@ -32,7 +32,7 @@ namespace form_builder.Workflows.DocumentWorkflow
                 throw new DocumentExpiredException($"DocumentWorkflow::GenerateSummaryDocument, Previous answers has expired, unable to generate {documentType.ToString()} document for summary");
 
             var previousAnswers = JsonConvert.DeserializeObject<FormAnswers>(formData);
-            var baseForm = await _schemaFactory.Build(previousAnswers.FormName, $"document-{id}");
+            var baseForm = await _schemaFactory.Build(previousAnswers.FormName);
 
             return await _documentSummaryService.GenerateDocument(new DocumentSummaryEntity
             {

--- a/src/Workflows/SuccessWorkflow/SuccessWorkflow.cs
+++ b/src/Workflows/SuccessWorkflow/SuccessWorkflow.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using form_builder.Enum;
 using form_builder.Factories.Schema;
+using form_builder.Helpers.Session;
 using form_builder.Services.PageService;
 using form_builder.Services.PageService.Entities;
 using form_builder.Workflows.ActionsWorkflow;
@@ -13,17 +14,23 @@ namespace form_builder.Workflows.SuccessWorkflow
         private readonly IPageService _pageService;
         private readonly ISchemaFactory _schemaFactory;
         private readonly IActionsWorkflow _actionsWorkflow;
+        private readonly ISessionHelper _sessionHelper;
 
-        public SuccessWorkflow(IPageService pageService, ISchemaFactory schemaFactory, IActionsWorkflow actionsWorkflow)
+        public SuccessWorkflow(IPageService pageService, ISchemaFactory schemaFactory, IActionsWorkflow actionsWorkflow, ISessionHelper sessionHelper)
         {
             _pageService = pageService;
             _schemaFactory = schemaFactory;
             _actionsWorkflow = actionsWorkflow;
+            _sessionHelper = sessionHelper;
         }
 
         public async Task<SuccessPageEntity> Process(EBehaviourType behaviourType, string form)
         {
             var baseForm = await _schemaFactory.Build(form);
+            var sessionGuid = _sessionHelper.GetSessionGuid();
+
+            foreach (var page in baseForm.Pages)
+                await _schemaFactory.TransformPage(page, sessionGuid);
 
             if (baseForm.FormActions.Any())
                 await _actionsWorkflow.Process(baseForm.FormActions, baseForm, form);

--- a/src/Workflows/SuccessWorkflow/SuccessWorkflow.cs
+++ b/src/Workflows/SuccessWorkflow/SuccessWorkflow.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using form_builder.Enum;
 using form_builder.Factories.Schema;
-using form_builder.Helpers.Session;
 using form_builder.Services.PageService;
 using form_builder.Services.PageService.Entities;
 using form_builder.Workflows.ActionsWorkflow;
@@ -14,23 +13,17 @@ namespace form_builder.Workflows.SuccessWorkflow
         private readonly IPageService _pageService;
         private readonly ISchemaFactory _schemaFactory;
         private readonly IActionsWorkflow _actionsWorkflow;
-        private readonly ISessionHelper _sessionHelper;
 
-        public SuccessWorkflow(IPageService pageService, ISchemaFactory schemaFactory, IActionsWorkflow actionsWorkflow, ISessionHelper sessionHelper)
+        public SuccessWorkflow(IPageService pageService, ISchemaFactory schemaFactory, IActionsWorkflow actionsWorkflow)
         {
             _pageService = pageService;
             _schemaFactory = schemaFactory;
             _actionsWorkflow = actionsWorkflow;
-            _sessionHelper = sessionHelper;
         }
 
         public async Task<SuccessPageEntity> Process(EBehaviourType behaviourType, string form)
         {
             var baseForm = await _schemaFactory.Build(form);
-            var sessionGuid = _sessionHelper.GetSessionGuid();
-
-            foreach (var page in baseForm.Pages)
-                await _schemaFactory.TransformPage(page, sessionGuid);
 
             if (baseForm.FormActions.Any())
                 await _actionsWorkflow.Process(baseForm.FormActions, baseForm, form);

--- a/tests/unit-tests/UnitTests/Controllers/BookingControllerTests.cs
+++ b/tests/unit-tests/UnitTests/Controllers/BookingControllerTests.cs
@@ -44,7 +44,7 @@ namespace form_builder_tests.UnitTests.Controllers
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build("valid",  string.Empty))
+            _schemaFactory.Setup(_ => _.Build("valid"))
                 .ReturnsAsync(schema);
 
             _bookingController = new BookingController(_bookingService.Object, _schemaFactory.Object, _pageService.Object);
@@ -145,14 +145,14 @@ namespace form_builder_tests.UnitTests.Controllers
         [Fact]
         public async Task CannotCancel_ShouldReturn_Cannot_Cancel_View()
         {
-            _schemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(new FormSchema());
 
             var result = await _bookingController.CannotCancel("form");
 
             var redirectResult = Assert.IsType<ViewResult>(result);
             Assert.Equal("CannotCancel", redirectResult.ViewName);
-            _schemaFactory.Verify(_ => _.Build(It.Is<string>(_ => _.Equals("form")), It.IsAny<string>()), Times.Once);
+            _schemaFactory.Verify(_ => _.Build(It.Is<string>(_ => _.Equals("form"))), Times.Once);
         }
 
         [Fact]

--- a/tests/unit-tests/UnitTests/Extensions/FormSchemaExtensionsTests.cs
+++ b/tests/unit-tests/UnitTests/Extensions/FormSchemaExtensionsTests.cs
@@ -1,0 +1,220 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using form_builder.Builders;
+using form_builder.Enum;
+using form_builder.Extensions;
+using form_builder.Models;
+using form_builder_tests.Builders;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.Extensions
+{
+    public class FormSchemaExtensionsTests
+    {
+        [Fact]
+        public void GetReducedPages_ShouldReturnOnlyPagesForUsersJourney()
+        {
+            // Arrange
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new PageAnswers
+                    {
+                        Answers = new List<Answers>(),
+                        PageSlug = "page-1"
+                    },
+                    new PageAnswers
+                    {
+                        Answers = new List<Answers>(),
+                        PageSlug = "page-2"
+                    }
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .Build();
+
+            var behaviour1 = new BehaviourBuilder()
+                .WithBehaviourType(EBehaviourType.GoToPage)
+                .WithPageSlug("summary")
+                .Build();
+
+            var page1 = new PageBuilder()
+                .WithElement(element)
+                .WithBehaviour(behaviour1)
+                .WithPageSlug("page-1")
+                .Build();
+
+            var pageBehaviour = new BehaviourBuilder()
+                .WithBehaviourType(EBehaviourType.GoToPage)
+                .WithPageSlug("summary")
+                .Build();
+
+            var page2 = new PageBuilder()
+                .WithElement(element)
+                .WithBehaviour(pageBehaviour)
+                .WithPageSlug("page-2")
+                .Build();
+
+            var summaryElement = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .Build();
+
+            var submitBehaviour = new BehaviourBuilder()
+                .WithBehaviourType(EBehaviourType.SubmitForm)
+                .WithPageSlug("success")
+                .Build();
+
+            var summaryPage = new PageBuilder()
+                .WithElement(summaryElement)
+                .WithBehaviour(submitBehaviour)
+                .WithPageSlug("summary")
+                .Build();
+
+            var successPage = new PageBuilder()
+                .WithPageSlug("success")
+                .Build();
+
+            var formSchema = new FormSchemaBuilder()
+                .WithPage(page1)
+                .WithPage(page2)
+                .WithPage(summaryPage)
+                .WithPage(successPage)
+                .WithFirstPageSlug("page-1")
+                .Build();
+
+            // Act
+            var result = formSchema.GetReducedPages(formAnswers);
+            var page1Result = result.Where(_ => _.PageSlug.Equals("page-1"));
+            var summaryResult = result.Where(_ => _.PageSlug.Equals("summary"));
+            var successResult = result.Where(_ => _.PageSlug.Equals("success"));
+
+            // Assert
+            Assert.Equal(3, result.Count);
+            Assert.Single(page1Result);
+            Assert.Single(summaryResult);
+            Assert.Single(successResult);
+        }
+
+        [Theory]
+        [InlineData("question2", "yes", "yes-routing-answer")]
+        [InlineData("question3", "no", "no-routing-answer")]
+        public void GetReducedAnswers_ShouldReturnCorrectPages_WhenSchemaContains_TwoOfSamePageSlug_WithRenderConditions(string questionId, string answer, string value)
+        {
+            // Arrange
+            var formAnswers = new FormAnswers
+            {
+                FormName = "test",
+                Pages = new List<PageAnswers>
+                {
+                    new PageAnswers
+                    {
+                        PageSlug = "page-1",
+                        Answers = new List<Answers>
+                        {
+                            new Answers
+                            {
+                                QuestionId = "test",
+                                Response = answer
+                            }
+                        }
+                    },
+                    new PageAnswers
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new Answers
+                            {
+                                QuestionId = questionId,
+                                Response = value
+                            }
+                        },
+                        PageSlug = "page-2"
+                    },
+                    new PageAnswers
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new Answers
+                            {
+                                QuestionId = "routingquestion",
+                                Response = "data"
+                            }
+                        },
+                        PageSlug = "page-4"
+                    }
+                }
+            };
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("test")
+                .Build();
+
+            var element2 = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("question2")
+                .Build();
+
+            var element3 = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("question3")
+                .Build();
+
+            var behaviour = new BehaviourBuilder()
+                .WithPageSlug("page-2")
+                .WithBehaviourType(EBehaviourType.GoToPage)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithPageSlug("page-1")
+                .WithElement(element)
+                .WithBehaviour(behaviour)
+                .Build();
+
+            var behaviour2 = new BehaviourBuilder()
+                .WithBehaviourType(EBehaviourType.SubmitForm)
+                .Build();
+
+            var page2 = new PageBuilder()
+                .WithPageSlug("page-2")
+                .WithBehaviour(behaviour2)
+                .WithElement(element2)
+                .WithRenderConditions(new Condition
+                {
+                    QuestionId = "test",
+                    ConditionType = ECondition.EqualTo,
+                    ComparisonValue = "yes"
+                })
+                .Build();
+
+            var page3 = new PageBuilder()
+                .WithPageSlug("page-2")
+                .WithBehaviour(behaviour2)
+                .WithElement(element3)
+                .WithRenderConditions(new Condition
+                {
+                    QuestionId = "test",
+                    ConditionType = ECondition.EqualTo,
+                    ComparisonValue = "no"
+                })
+                .Build();
+
+            var formSchema = new FormSchemaBuilder()
+                .WithPage(page)
+                .WithPage(page2)
+                .WithPage(page3)
+                .WithFirstPageSlug("page-1")
+                .Build();
+
+            // Act
+            var result = formSchema.GetReducedPages(formAnswers);
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.Equal(questionId, result[1].Elements[0].Properties.QuestionId);
+        }
+    }
+}

--- a/tests/unit-tests/UnitTests/Factories/Schema/SchemaFactoryTests.cs
+++ b/tests/unit-tests/UnitTests/Factories/Schema/SchemaFactoryTests.cs
@@ -268,5 +268,24 @@ namespace form_builder_tests.UnitTests.Factories.Schema
             _mockFormSchemaIntegrityValidator.Verify(_ => _.Validate(It.IsAny<FormSchema>()), Times.Once);
             _mockDistributedCache.Verify(_ => _.SetStringAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
         }
+
+        [Fact]
+        public async Task TransformPage_ShouldCallEachTransformFactory()
+        {
+            // Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.P)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            // Act
+            await _schemaFactory.TransformPage(page, new FormAnswers());
+
+            // Assert
+            _mockUserPageFactory.Verify(_ => _.Transform(It.IsAny<Page>(), It.IsAny<FormAnswers>()), Times.Once);
+        }
     }
 }

--- a/tests/unit-tests/UnitTests/Factories/Schema/SchemaFactoryTests.cs
+++ b/tests/unit-tests/UnitTests/Factories/Schema/SchemaFactoryTests.cs
@@ -37,10 +37,6 @@ namespace form_builder_tests.UnitTests.Factories.Schema
 
         public SchemaFactoryTests()
         {
-            _mockUserPageFactory
-                .Setup(_ => _.Transform(It.IsAny<Page>(), It.IsAny<string>()))
-                .ReturnsAsync(new Page());
-
             var mockUserPageFactoryItems = new List<IUserPageTransformFactory> { _mockUserPageFactory.Object };
             _mockUserPageFactories
                 .Setup(m => m.GetEnumerator())
@@ -111,7 +107,7 @@ namespace form_builder_tests.UnitTests.Factories.Schema
                 .ReturnsAsync(true);
 
             // Act
-            await _schemaFactory.Build("form", string.Empty);
+            await _schemaFactory.Build("form");
 
             // Assert
             _mockDistributedCache.Verify(_ => _.GetString(It.IsAny<string>()), Times.Once);

--- a/tests/unit-tests/UnitTests/Factories/Transform/AddAnotherPageTransformFactoryTests.cs
+++ b/tests/unit-tests/UnitTests/Factories/Transform/AddAnotherPageTransformFactoryTests.cs
@@ -5,22 +5,25 @@ using form_builder.Builders;
 using form_builder.Constants;
 using form_builder.Enum;
 using form_builder.Factories.Transform.UserSchema;
-using form_builder.Helpers.PageHelpers;
-using form_builder.Helpers.Session;
 using form_builder.Models;
 using form_builder.Models.Elements;
 using form_builder_tests.Builders;
-using Moq;
 using Xunit;
 
 namespace form_builder_tests.UnitTests.Factories.Transform
 {
     public class AddAnotherPageTransformFactoryTests
     {
-        private readonly Mock<IPageHelper> _mockPageHelper = new();
-        private readonly Mock<ISessionHelper> _mockSessionHelper = new();
         private readonly AddAnotherPageTransformFactory _transformFactory;
         private readonly Page _page;
+
+        private readonly FormAnswers _savedAnswers = new FormAnswers
+        {
+            FormData = new Dictionary<string, object>
+            {
+                { $"{AddAnotherConstants.IncrementKeyPrefix}person", 2 }
+            }
+        };
 
         public AddAnotherPageTransformFactoryTests()
         {
@@ -44,26 +47,16 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 .WithElement(addAnotherElement)
                 .Build();
 
-            var savedAnswers = new FormAnswers
-            {
-                FormData = new Dictionary<string, object>
-                {
-                    { $"{AddAnotherConstants.IncrementKeyPrefix}person", 2 }
-                }
-            };
+            
 
-            _mockPageHelper
-                .Setup(_ => _.GetSavedAnswers(It.IsAny<string>()))
-                .Returns(savedAnswers);
-
-            _transformFactory = new AddAnotherPageTransformFactory(_mockPageHelper.Object, _mockSessionHelper.Object);
+            _transformFactory = new AddAnotherPageTransformFactory();
         }
 
         [Fact]
         public async Task Transform_ShouldReturnCorrectNumberOfElementsOnPage()
         {
             // Act
-            var result = await _transformFactory.Transform(_page, "guid");
+            var result = await _transformFactory.Transform(_page, _savedAnswers);
 
             // Assert
             Assert.Equal(12, result.Elements.Count);
@@ -73,7 +66,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
         public async Task Transform_ShouldRetainOriginalAddnotherElement()
         {
             // Act
-            var result = await _transformFactory.Transform(_page, "guid");
+            var result = await _transformFactory.Transform(_page, _savedAnswers);
 
             // Assert
             Assert.Single(result.Elements.Where(_ => _.Type.Equals(EElementType.AddAnother)));
@@ -83,7 +76,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
         public async Task Transform_ShouldReturnCorrectNumberOf_FieldsetElements()
         {
             // Act
-            var result = await _transformFactory.Transform(_page, "guid");
+            var result = await _transformFactory.Transform(_page, _savedAnswers);
             var openingFieldsets = result.Elements.Count(_ => _.Type.Equals(EElementType.Fieldset) && _.Properties.OpeningTag);
             var closingFieldsets = result.Elements.Count(_ => _.Type.Equals(EElementType.Fieldset) && !_.Properties.OpeningTag);
 
@@ -97,7 +90,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
         public async Task Transform_ShouldReturnCorrectNumberOf_LegendElements()
         {
             // Act
-            var result = await _transformFactory.Transform(_page, "guid");
+            var result = await _transformFactory.Transform(_page, _savedAnswers);
 
             // Assert
             Assert.Equal(2, result.Elements.Count(_ => _.Type.Equals(EElementType.Legend)));
@@ -107,7 +100,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
         public async Task Transform_ShouldReturnCorrect_ButtonElements()
         {
             // Act
-            var result = await _transformFactory.Transform(_page, "guid");
+            var result = await _transformFactory.Transform(_page, _savedAnswers);
             var removeButtonZero = result.Elements.Where(_ => _.Type.Equals(EElementType.Button) && _.Properties.ButtonName.Equals("remove-1"));
             var removeButtonOne = result.Elements.Where(_ => _.Type.Equals(EElementType.Button) && _.Properties.ButtonName.Equals("remove-2"));
             var addAnotherButton = result.Elements.Where(_ => _.Type.Equals(EElementType.Button) && _.Properties.ButtonName.Equals(AddAnotherConstants.AddAnotherButtonKey)).ToList();
@@ -144,7 +137,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 .WithElement(addAnotherElement)
                 .Build();
 
-            var result = await _transformFactory.Transform(page, "guid");
+            var result = await _transformFactory.Transform(page, _savedAnswers);
             var addAnotherButton = result.Elements.Where(_ => _.Type.Equals(EElementType.Button) && _.Properties.ButtonName.Equals(AddAnotherConstants.AddAnotherButtonKey)).ToList();
 
             // Assert
@@ -156,7 +149,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
         public async Task Transform_ShouldReturnCorrect_TextboxElements()
         {
             // Act
-            var result = await _transformFactory.Transform(_page, "guid");
+            var result = await _transformFactory.Transform(_page, _savedAnswers);
             var textboxZero = result.Elements.Where(_ => _.Type.Equals(EElementType.Textbox) && _.Properties.QuestionId.Equals("textbox:1:")).ToList();
             var textboxOne = result.Elements.Where(_ => _.Type.Equals(EElementType.Textbox) && _.Properties.QuestionId.Equals("textbox:2:")).ToList();
 
@@ -208,7 +201,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 .Build();
 
             // Act
-            var result = await _transformFactory.Transform(page, "guid");
+            var result = await _transformFactory.Transform(page, _savedAnswers);
             var radioOne = result.Elements.FirstOrDefault(_ => _.Type.Equals(EElementType.Radio) && _.Properties.QuestionId.Equals("radio:1:"));
 
             // Assert

--- a/tests/unit-tests/UnitTests/Factories/Transform/DynamicLookupPageTransformFactoryTests.cs
+++ b/tests/unit-tests/UnitTests/Factories/Transform/DynamicLookupPageTransformFactoryTests.cs
@@ -25,7 +25,6 @@ namespace form_builder_tests.UnitTests.Factories.Transform
     public class DynamicLookupPageTransformFactoryTests
     {
         private readonly Mock<IActionHelper> _mockActionHelper = new();
-        private readonly Mock<IPageHelper> _mockPageHelper = new();
         private readonly Mock<IWebHostEnvironment> _mockWebHostEnvironment = new();
         private readonly IEnumerable<ILookupProvider> _mockLookupProviders;
         private readonly Mock<ILookupProvider> _fakeLookupProvider = new();
@@ -43,9 +42,6 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 _fakeLookupProvider.Object
             };
 
-            _mockPageHelper
-                .Setup(_ => _.GetSavedAnswers(It.IsAny<string>()))
-                .Returns(new FormAnswers());
             _mockActionHelper
                 .Setup(_ => _.GenerateUrl(It.IsAny<string>(), It.IsAny<FormAnswers>()))
                 .Returns(new RequestEntity
@@ -57,7 +53,6 @@ namespace form_builder_tests.UnitTests.Factories.Transform
 
             _dynamicLookupPageTransformFactory = new DynamicLookupPageTransformFactory(_mockActionHelper.Object,
                 _mockLookupProviders,
-                _mockPageHelper.Object,
                 _mockWebHostEnvironment.Object);
         }
 
@@ -80,12 +75,12 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 .Build();
 
             // Act & Assert
-            var result = await Assert.ThrowsAsync<Exception>(() => _dynamicLookupPageTransformFactory.Transform(page, "12345"));
+            var result = await Assert.ThrowsAsync<Exception>(() => _dynamicLookupPageTransformFactory.Transform(page, new FormAnswers()));
             Assert.Equal("DynamicLookupPageTransformFactory::AddDynamicOptions, No Environment specific details found", result.Message);
         }
 
         [Fact]
-        public async Task Transform_ShouldCall_PageHelper_And_ActionHelper()
+        public async Task Transform_ShouldCall_ActionHelper()
         {
             // Arrange
             var element = new ElementBuilder()
@@ -106,10 +101,9 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 .Build();
 
             // Act
-            await _dynamicLookupPageTransformFactory.Transform(page, "12345");
+            await _dynamicLookupPageTransformFactory.Transform(page, new FormAnswers());
 
             // Assert
-            _mockPageHelper.Verify(_ => _.GetSavedAnswers(It.IsAny<string>()), Times.Once);
             _mockActionHelper.Verify(_ => _.GenerateUrl(It.IsAny<string>(), It.IsAny<FormAnswers>()), Times.Once);
         }
 
@@ -134,7 +128,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 .Build();
 
             // Act & Assert
-            var result = await Assert.ThrowsAsync<Exception>(() => _dynamicLookupPageTransformFactory.Transform(page, "12345"));
+            var result = await Assert.ThrowsAsync<Exception>(() => _dynamicLookupPageTransformFactory.Transform(page, new FormAnswers()));
             Assert.Equal("DynamicLookupPageTransformFactory::AddDynamicOptions, No Provider name given in LookupSources", result.Message);
         }
 
@@ -160,50 +154,11 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 .Build();
 
             // Act & Assert
-            await Assert.ThrowsAsync<InvalidOperationException>(() => _dynamicLookupPageTransformFactory.Transform(page, "12345"));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _dynamicLookupPageTransformFactory.Transform(page, new FormAnswers()));
         }
 
         [Fact]
-        public async Task Transform_ShouldNotCallLookupProvider_IfOptionsFoundInCachedAnswers()
-        {
-            // Arrange
-            var formAnswers = new FormAnswers
-            {
-                FormData = new Dictionary<string, object>
-                {
-                    { "waste=waste", new List<Option> { new Option { Text = "option", Value = "option" } } }
-                }
-            };
-
-            _mockPageHelper
-                .Setup(_ => _.GetSavedAnswers(It.IsAny<string>()))
-                .Returns(formAnswers);
-
-            var element = new ElementBuilder()
-                .WithQuestionId("dynamicQuestion")
-                .WithLookup("dynamic")
-                .WithLookupSource(new LookupSource
-                {
-                    EnvironmentName = "local",
-                    Provider = "fake",
-                    URL = "waste={{wasteId}}"
-                })
-                .WithType(EElementType.Checkbox)
-                .Build();
-
-            var page = new PageBuilder()
-                .WithElement(element)
-                .Build();
-
-            // Act
-            await _dynamicLookupPageTransformFactory.Transform(page, "12345");
-
-            // Assert
-            _fakeLookupProvider.Verify(_ => _.GetAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-        }
-
-        [Fact]
-        public async Task Transform_ShouldCallLookupProvider_IfOptionsNotFoundInCachedAnswers()
+        public async Task Transform_ShouldCallLookupProvider()
         {
             // Arrange
             var element = new ElementBuilder()
@@ -224,7 +179,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 .Build();
 
             // Act
-            await _dynamicLookupPageTransformFactory.Transform(page, "12345");
+            await _dynamicLookupPageTransformFactory.Transform(page, new FormAnswers());
 
             // Assert
             _fakeLookupProvider.Verify(_ => _.GetAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
@@ -255,7 +210,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
                 .Build();
 
             // Act & Assert
-            var result = await Assert.ThrowsAsync<Exception>(() => _dynamicLookupPageTransformFactory.Transform(page, "12345"));
+            var result = await Assert.ThrowsAsync<Exception>(() => _dynamicLookupPageTransformFactory.Transform(page, new FormAnswers()));
             Assert.Equal("DynamicLookupPageTransformFactory::AddDynamicOptions, Provider returned no options", result.Message);
         }
     }

--- a/tests/unit-tests/UnitTests/Helpers/ActionHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/ActionHelperTests.cs
@@ -87,16 +87,6 @@ namespace form_builder_tests.UnitTests.Helpers
         public ActionHelperTests() => _actionHelper = new ActionHelper(_mockFormatters.Object);
 
         [Fact]
-        public void GenerateUrl_ShouldReturnUnchangedBaseUrl_IfAnyTagMatchesDontExistInAnswers()
-        {
-            // Act
-            var result = _actionHelper.GenerateUrl("www.testurl.com/{{unansweredQuestion}}", _mappingEntity.FormAnswers);
-
-            // Assert
-            Assert.Equal("www.testurl.com/{{unansweredQuestion}}", result.Url);
-        }
-
-        [Fact]
         public void GenerateUrl_ShouldGenerateCorrectGetUrl_PathParameters()
         {
             // Act

--- a/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
@@ -450,7 +450,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build("form", It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build("form"))
                 .ReturnsAsync(formSchema);
 
             Dictionary<string, object> viewModel = new()
@@ -510,7 +510,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build("form", It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build("form"))
                 .ReturnsAsync(formSchema);
 
             Dictionary<string, object> viewModel = new()
@@ -562,7 +562,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build("form", It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build("form"))
                 .ReturnsAsync(formSchema);
 
             Dictionary<string, object> viewModel = new()
@@ -622,7 +622,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build("form", It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build("form"))
                 .ReturnsAsync(formSchema);
 
             Dictionary<string, object> viewModel = new()
@@ -664,7 +664,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build("form", It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build("form"))
                 .ReturnsAsync(formSchema);
 
             // Assert
@@ -699,7 +699,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build("base-form", It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build("base-form"))
                 .ReturnsAsync(formSchema);
 
             var model = new Dictionary<string, object>{
@@ -738,7 +738,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build("base-form", It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build("base-form"))
                 .ReturnsAsync(formSchema);
 
             var model = new Dictionary<string, object>{
@@ -786,7 +786,7 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals("guid"))))
                 .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new FormAnswers { FormData = new Dictionary<string, object> { { bookingInformationCacheKey, new BookingInformation() } } }));
 
-            _schemaFactory.Setup(_ => _.Build("form", It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build("form"))
                 .ReturnsAsync(formSchema);
 
             var model = new Dictionary<string, object>{
@@ -804,7 +804,7 @@ namespace form_builder_tests.UnitTests.Services
         public async void ProcessMonthRequest_Should_Throw_ApplicationException_When_InvalidForm()
         {
             //
-            _schemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync((FormSchema)null);
 
             // Arrange
@@ -842,7 +842,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithBaseUrl(form)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build("base-form", It.IsAny<string>()))
+            _schemaFactory.Setup(_ => _.Build("base-form"))
                 .ReturnsAsync(formSchema);
 
 
@@ -1225,7 +1225,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build(formName, string.Empty))
+            _schemaFactory.Setup(_ => _.Build(formName))
                 .ReturnsAsync(formSchema);
 
             _bookingProvider.Setup(_ => _.GetBooking(bookingId))
@@ -1269,7 +1269,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build(formName, string.Empty))
+            _schemaFactory.Setup(_ => _.Build(formName))
                 .ReturnsAsync(formSchema);
 
             _bookingProvider.Setup(_ => _.GetBooking(bookingId))
@@ -1332,7 +1332,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _schemaFactory.Setup(_ => _.Build(formName, string.Empty))
+            _schemaFactory.Setup(_ => _.Build(formName))
                 .ReturnsAsync(formSchema);
 
             //Act

--- a/tests/unit-tests/UnitTests/Services/DocumentSummaryServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/DocumentSummaryServiceTests.cs
@@ -77,7 +77,7 @@ namespace form_builder_tests.UnitTests.Services
         }
 
         [Fact]
-        public async Task GenerateDocument_ShouldCallSchemaFactory_WhenDocumentTypeIsTxt()
+        public async Task GenerateDocument_ShouldCallSchemaFactory()
         {
             // Act
             await _documentSummaryService.GenerateDocument(new DocumentSummaryEntity { FormSchema = _formSchema, DocumentType = EDocumentType.Txt, PreviousAnswers = _formAnswers });

--- a/tests/unit-tests/UnitTests/Services/DocumentSummaryServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/DocumentSummaryServiceTests.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using form_builder.Builders;
+using form_builder.Enum;
+using form_builder.Factories.Schema;
+using form_builder.Helpers.DocumentCreation;
+using form_builder.Models;
+using form_builder.Providers.DocumentCreation;
+using form_builder.Services.DocumentService;
+using form_builder.Services.DocumentService.Entities;
+using form_builder_tests.Builders;
+using Moq;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.Services
+{
+    public class DocumentSummaryServiceTests
+    {
+        private readonly Mock<IDocumentCreationHelper> _mockDocumentCreationHelper = new();
+        private readonly Mock<ISchemaFactory> _mockSchemaFactory = new();
+        private readonly Mock<IDocumentCreation> _mockProvider = new();
+        private readonly DocumentSummaryService _documentSummaryService;
+        private readonly FormSchema _formSchema;
+        private readonly FormAnswers _formAnswers;
+
+        public DocumentSummaryServiceTests()
+        {
+            _mockProvider.Setup(_ => _.DocumentType).Returns(EDocumentType.Txt);
+            _mockProvider.Setup(_ => _.Priority).Returns(EProviderPriority.High);
+            var providers = new List<IDocumentCreation> { _mockProvider.Object };
+
+            _formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new PageAnswers
+                    {
+                        PageSlug = "page-1",
+                        Answers = new List<Answers>()
+                    }
+                }
+            };
+            
+            var behaviour = new BehaviourBuilder()
+                .WithBehaviourType(EBehaviourType.SubmitForm)
+                .WithPageSlug("success")
+                .Build();
+
+            var page1 = new PageBuilder()
+                .WithPageSlug("page-1")
+                .WithBehaviour(behaviour)
+                .Build();
+
+            var page2 = new PageBuilder()
+                .WithPageSlug("success")
+                .Build();
+
+            _formSchema = new FormSchemaBuilder()
+                .WithPage(page1)
+                .WithPage(page2)
+                .WithFirstPageSlug("page-1")
+                .Build();
+
+            _mockSchemaFactory.Setup(_ => _.TransformPage(page1, It.IsAny<FormAnswers>())).ReturnsAsync(page1);
+            _mockSchemaFactory.Setup(_ => _.TransformPage(page2, It.IsAny<FormAnswers>())).ReturnsAsync(page2);
+
+            _mockDocumentCreationHelper
+                .Setup(_ => _.GenerateQuestionAndAnswersList(It.IsAny<FormAnswers>(), It.IsAny<FormSchema>()))
+                .ReturnsAsync(new List<string>());
+
+            _mockProvider.Setup(_ => _.CreateDocument(It.IsAny<List<string>>())).Returns(new byte[1]);
+
+            _documentSummaryService = new DocumentSummaryService(_mockDocumentCreationHelper.Object, providers, _mockSchemaFactory.Object);
+        }
+
+        [Fact]
+        public async Task GenerateDocument_ShouldCallSchemaFactory_WhenDocumentTypeIsTxt()
+        {
+            // Act
+            await _documentSummaryService.GenerateDocument(new DocumentSummaryEntity { FormSchema = _formSchema, DocumentType = EDocumentType.Txt, PreviousAnswers = _formAnswers });
+
+            // Assert
+            _mockSchemaFactory.Verify(_ => _.TransformPage(It.IsAny<Page>(), It.IsAny<FormAnswers>()), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task GenerateDocument_ShouldCallDocumentCreationHelper_WhenDocumentTypeIsTxt()
+        {
+            // Act
+            await _documentSummaryService.GenerateDocument(new DocumentSummaryEntity { FormSchema = _formSchema, DocumentType = EDocumentType.Txt, PreviousAnswers = _formAnswers });
+
+            // Assert
+            _mockDocumentCreationHelper.Verify(_ => _.GenerateQuestionAndAnswersList(It.IsAny<FormAnswers>(), It.IsAny<FormSchema>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateDocument_ShouldCallTextfileProvider_WhenDocumentTypeIsTxt()
+        {
+            // Act
+            await _documentSummaryService.GenerateDocument(new DocumentSummaryEntity { FormSchema = _formSchema, DocumentType = EDocumentType.Txt, PreviousAnswers = _formAnswers });
+
+            // Assert
+            _mockProvider.Verify(_ => _.CreateDocument(It.IsAny<List<string>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GenerateDocument_ShouldThrow_WhenDocumentTypeIsUnknown()
+        {
+            // Act & Assert
+            var result = await Assert.ThrowsAsync<Exception>(() =>
+                _documentSummaryService.GenerateDocument(new DocumentSummaryEntity
+                    { FormSchema = _formSchema, DocumentType = EDocumentType.Unknown, PreviousAnswers = _formAnswers }));
+
+            Assert.Equal("DocumentSummaryService::GenerateDocument, Unknown Document type request for Summary", result.Message);
+        }
+    }
+}

--- a/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
@@ -93,7 +93,7 @@ namespace form_builder_tests.UnitTests.Services
                 FormJson = 1
             });
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockHostingEnv.Setup(_ => _.EnvironmentName).Returns("test");
@@ -118,7 +118,7 @@ namespace form_builder_tests.UnitTests.Services
             await _service.Map("form", "guid");
 
             // Assert
-            _mockSchemaFactory.Verify(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mockSchemaFactory.Verify(_ => _.Build(It.IsAny<string>()), Times.Once);
         }
 
         [Fact]
@@ -152,7 +152,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             // Act
@@ -189,7 +189,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockElementMapper.Setup(_ => _.GetAnswerValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()))
@@ -240,7 +240,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             // Act
@@ -279,7 +279,7 @@ namespace form_builder_tests.UnitTests.Services
             _mockElementMapper.Setup(_ => _.GetAnswerValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()))
                 .ReturnsAsync(new { });
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
@@ -309,7 +309,7 @@ namespace form_builder_tests.UnitTests.Services
         }
 
         [Fact]
-        public async Task Map_ShouldReturnExpandoObject_WhenFormContains_MutipleValidatableElementsWithComplexTargetMapping()
+        public async Task Map_ShouldReturnExpandoObject_WhenFormContains_MultipleValidatableElementsWithComplexTargetMapping()
         {
             // Arrange
             var element = new ElementBuilder()
@@ -335,7 +335,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
@@ -390,7 +390,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
@@ -434,7 +434,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
@@ -496,7 +496,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
@@ -551,7 +551,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockElementMapper.Setup(_ => _.GetAnswerValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()))
@@ -595,7 +595,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
@@ -644,7 +644,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             var element = new ElementBuilder()
@@ -665,7 +665,7 @@ namespace form_builder_tests.UnitTests.Services
             Assert.IsType<BookingRequest>(result);
             Assert.Equal(bookingGuid, result.AppointmentId);
             Assert.Equal(expectedValue, result.StartDateTime);
-            _mockSchemaFactory.Verify(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mockSchemaFactory.Verify(_ => _.Build(It.IsAny<string>()), Times.Once);
             _mockElementMapper.Verify(_ => _.GetAnswerValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()), Times.Once);
         }
 
@@ -705,7 +705,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockElementMapper.Setup(_ => _.GetAnswerStringValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()))
@@ -756,7 +756,7 @@ namespace form_builder_tests.UnitTests.Services
             Assert.Equal(bookingGuid, result.AppointmentId);
             Assert.Equal(expectedValue, result.StartDateTime);
             Assert.Equal("Address 1", result.Customer.Address);
-            _mockSchemaFactory.Verify(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mockSchemaFactory.Verify(_ => _.Build(It.IsAny<string>()), Times.Once);
             _mockElementMapper.Verify(_ => _.GetAnswerValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()), Times.Once);
             _mockElementMapper.Verify(_ => _.GetAnswerStringValue(addressElement, It.IsAny<FormAnswers>()), Times.Once);
         }
@@ -782,7 +782,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             var element = new ElementBuilder()
@@ -823,7 +823,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             var element = new ElementBuilder()
@@ -860,7 +860,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             var element = new ElementBuilder()
@@ -927,7 +927,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             var element = new ElementBuilder()
@@ -959,7 +959,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             var element = new ElementBuilder()

--- a/tests/unit-tests/UnitTests/Services/PageServicesTests.cs
+++ b/tests/unit-tests/UnitTests/Services/PageServicesTests.cs
@@ -151,7 +151,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithEnvironmentAvailability("local", false)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             var result = await _service.ProcessPage("form", "page-one", "", new QueryCollection());
@@ -167,7 +167,7 @@ namespace form_builder_tests.UnitTests.Services {
 
             // Assert
             Assert.Null(result);
-            _mockSchemaFactory.Verify(_ => _.Build(It.IsAny<string>(), string.Empty), Times.Once);
+            _mockSchemaFactory.Verify(_ => _.Build(It.IsAny<string>()), Times.Once);
         }
 
         [Fact]
@@ -190,7 +190,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -227,7 +227,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -256,7 +256,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .Build();
 
             _mockSchemaFactory
-                .Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+                .Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -290,7 +290,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithBaseUrl("new-form")
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -323,7 +323,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithBaseUrl("new-form")
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -358,7 +358,7 @@ namespace form_builder_tests.UnitTests.Services {
                 StartPageUrl = "https://www.test.com/textbox/page-one"
             };
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageFactory.Setup(_ => _.Build(It.IsAny<Page>(), It.IsAny<Dictionary<string, dynamic>>(), It.IsAny<FormSchema>(), It.IsAny<string>(), It.IsAny<FormAnswers>(), It.IsAny<List<object>>()))
@@ -409,7 +409,7 @@ namespace form_builder_tests.UnitTests.Services {
                 StartPageUrl = "https://www.test.com/form/page-one"
             };
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageFactory.Setup(_ => _.Build(It.IsAny<Page>(), It.IsAny<Dictionary<string, dynamic>>(), It.IsAny<FormSchema>(), It.IsAny<string>(), It.IsAny<FormAnswers>(), It.IsAny<List<object>>()))
@@ -427,6 +427,93 @@ namespace form_builder_tests.UnitTests.Services {
         }
 
         [Fact]
+        public async Task ProcessPage_ShouldCallPageFactory_TransformPage_OnCurrentPageOnly_WhenPageIsNotASummary()
+        {
+            // Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("test-textbox")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithPageSlug("page-one")
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithPage(page)
+                .WithBaseUrl("textbox")
+                .WithStartPageUrl("page-one")
+                .Build();
+
+            var viewModel = new FormBuilderViewModel
+            {
+                StartPageUrl = "https://www.test.com/textbox/page-one"
+            };
+
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
+                .ReturnsAsync(schema);
+
+            _mockPageFactory.Setup(_ => _.Build(It.IsAny<Page>(), It.IsAny<Dictionary<string, dynamic>>(), It.IsAny<FormSchema>(), It.IsAny<string>(), It.IsAny<FormAnswers>(), It.IsAny<List<object>>()))
+                .ReturnsAsync(viewModel);
+
+            // Act
+            await _service.ProcessPage("form", "page-one", "", new QueryCollection());
+
+            // Assert
+            _mockSchemaFactory.Verify(_ => _.TransformPage(page, It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ProcessPage_ShouldCallPageFactory_TransformPage_OnEachSchemaPage_WhenPageHasSummaryElement()
+        {
+            // Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("test-textbox")
+                .Build();
+
+            var summaryElement = new ElementBuilder()
+                .WithType(EElementType.Summary)
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithPageSlug("page-one")
+                .Build();
+
+            var summaryPage = new PageBuilder()
+                .WithElement(summaryElement)
+                .WithPageSlug("summary")
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithPage(page)
+                .WithPage(summaryPage)
+                .WithBaseUrl("textbox")
+                .WithStartPageUrl("page-one")
+                .Build();
+
+            var viewModel = new FormBuilderViewModel
+            {
+                StartPageUrl = "https://www.test.com/textbox/page-one"
+            };
+
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
+                .ReturnsAsync(schema);
+
+            _mockPageFactory.Setup(_ => _.Build(It.IsAny<Page>(), It.IsAny<Dictionary<string, dynamic>>(), It.IsAny<FormSchema>(), It.IsAny<string>(), It.IsAny<FormAnswers>(), It.IsAny<List<object>>()))
+                .ReturnsAsync(viewModel);
+
+            // Act
+            await _service.ProcessPage("form", "summary", "", new QueryCollection());
+
+            // Assert
+            _mockSchemaFactory.Verify(_ => _.TransformPage(page, It.IsAny<string>()), Times.Once);
+            _mockSchemaFactory.Verify(_ => _.TransformPage(summaryPage, It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
         public async Task ProcessRequest_ShouldThrowException_IfFormIsNotAvailable() {
             _mockFormAvailabilityService.Setup(_ => _.IsAvailable(It.IsAny<List<EnvironmentAvailability>>(), It.IsAny<string>()))
                 .Returns(false);
@@ -439,11 +526,48 @@ namespace form_builder_tests.UnitTests.Services {
 
             var viewModel = new Dictionary<string, dynamic>();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             await Assert.ThrowsAsync<ApplicationException>(() => _service.ProcessRequest("form", "page-one", viewModel, null, true));
             _mockFormAvailabilityService.Verify(_ => _.IsAvailable(It.IsAny<List<EnvironmentAvailability>>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ProcessRequest_ShouldCallSchemaFactory_TransformPage()
+        {
+            // Arrange
+            _sessionHelper.Setup(_ => _.GetSessionGuid()).Returns("1234567");
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithQuestionId("textbox")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithValidatedModel(true)
+                .WithPageSlug("page-one")
+                .Build();
+
+            var schema = new FormSchemaBuilder()
+                .WithPage(page)
+                .Build();
+
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
+                .ReturnsAsync(schema);
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                { "Guid", Guid.NewGuid().ToString() },
+                { element.Properties.QuestionId, "text" }
+            };
+
+            // Act
+            await _service.ProcessRequest("form", "page-one", viewModel, null, true);
+
+            // Assert
+            _mockSchemaFactory.Verify(_ => _.TransformPage(page, It.IsAny<string>()), Times.Once);
         }
 
         [Fact]
@@ -467,7 +591,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -507,7 +631,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -548,7 +672,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -583,7 +707,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -621,7 +745,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -663,7 +787,7 @@ namespace form_builder_tests.UnitTests.Services {
                 StartPageUrl = "https://www.test.com/textarea/first-page"
             };
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _sessionHelper.Setup(_ => _.GetSessionGuid())
@@ -698,7 +822,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -730,7 +854,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -771,7 +895,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -812,7 +936,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -854,7 +978,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -895,7 +1019,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -932,7 +1056,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             // Act
@@ -968,7 +1092,7 @@ namespace form_builder_tests.UnitTests.Services {
                 .WithPage(page)
                 .Build();
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             var viewModel = new Dictionary<string, dynamic>
@@ -1007,7 +1131,7 @@ namespace form_builder_tests.UnitTests.Services {
 
             _sessionHelper.Setup(_ => _.GetSessionGuid()).Returns("1234567");
 
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>(), string.Empty))
+            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockAddAnotherService

--- a/tests/unit-tests/UnitTests/Services/SubmitServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/SubmitServiceTests.cs
@@ -54,7 +54,7 @@ namespace form_builder_tests.UnitTests.Services
                 });
 
             _mockSchemaFactory
-                .Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(new FormSchema {
                     GenerateReferenceNumber = false
                 });
@@ -200,7 +200,7 @@ namespace form_builder_tests.UnitTests.Services
                 .Build();
 
             _mockSchemaFactory
-                .Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockPageHelper
@@ -248,7 +248,7 @@ namespace form_builder_tests.UnitTests.Services
                 .Returns(page);
 
             _mockSchemaFactory
-                .Setup(_ => _.Build(It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
             _mockGateway

--- a/tests/unit-tests/UnitTests/Workflows/SuccessWorkflowTests.cs
+++ b/tests/unit-tests/UnitTests/Workflows/SuccessWorkflowTests.cs
@@ -23,11 +23,10 @@ namespace form_builder_tests.UnitTests.Workflows
         private readonly Mock<IPageService> _mockPageService = new();
         private readonly Mock<ISchemaFactory> _mockSchemaFactory = new();
         private readonly Mock<IActionsWorkflow> _mockActionsWorkflow = new();
-        private readonly Mock<ISessionHelper> _mockSessionHelper = new();
 
         public SuccessWorkflowTests()
         {
-            _workflow = new SuccessWorkflow(_mockPageService.Object, _mockSchemaFactory.Object, _mockActionsWorkflow.Object, _mockSessionHelper.Object);
+            _workflow = new SuccessWorkflow(_mockPageService.Object, _mockSchemaFactory.Object, _mockActionsWorkflow.Object);
 
             var element = new ElementBuilder()
                 .WithType(EElementType.H2)
@@ -45,10 +44,6 @@ namespace form_builder_tests.UnitTests.Workflows
                 .WithBaseUrl("base-test")
                 .WithPage(page)
                 .Build();
-
-            _mockSessionHelper
-                .Setup(_ => _.GetSessionGuid())
-                .Returns("12345");
 
             _mockSchemaFactory
                 .Setup(_ => _.Build(It.IsAny<string>()))
@@ -70,51 +65,6 @@ namespace form_builder_tests.UnitTests.Workflows
 
             // Assert
             _mockSchemaFactory.Verify(_ => _.Build("form"), Times.Once);
-        }
-
-        [Fact]
-        public async Task Process_ShouldCallSessionHelper()
-        {
-            // Act
-            await _workflow.Process(EBehaviourType.SubmitForm, "form");
-
-            // Assert
-            _mockSessionHelper.Verify(_ => _.GetSessionGuid(), Times.Once);
-        }
-
-        [Fact]
-        public async Task Process_ShouldCallSchemaFactory_TransformPage_ForEachPageInSchema()
-        {
-            // Arrange
-            var element = new ElementBuilder()
-                .WithType(EElementType.H2)
-                .Build();
-
-            var page = new PageBuilder()
-                .WithElement(element)
-                .WithPageSlug("page-one")
-                .Build();
-
-            var successPage = new PageBuilder()
-                .WithElement(element)
-                .WithPageSlug("success")
-                .Build();
-
-            var formSchema = new FormSchemaBuilder()
-                .WithStartPageUrl("page-one")
-                .WithBaseUrl("base-test")
-                .WithPage(page)
-                .WithPage(successPage)
-                .Build();
-
-            _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>())).ReturnsAsync(formSchema);
-
-            // Act
-            await _workflow.Process(EBehaviourType.SubmitForm, "form");
-
-            // Assert
-            _mockSchemaFactory.Verify(_ => _.TransformPage(page, "12345"), Times.Once);
-            _mockSchemaFactory.Verify(_ => _.TransformPage(successPage, "12345"), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
### Description
- Create TransformPage method in SchemaFactory
- Call TransformPage on ProcessPage
  - All journey pages if Summary
  - Current page if not Summary
- Call TransformPage on ProcessRequest for current page
- Call TransformPage on DocumentDownload creation
- Create GetReducedPages Extension method to get pages for users journey
- Remove GetSession calls from UserPageTransform methods
- Remove saving DynamicOptions to cache
- Update and add new unit tests


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary