### PR TITLE
fix(MultiFileUpload): fixed logic in checking max file size

### DIFF
--- a/src/Models/Elements/MultipleFileUpload.cs
+++ b/src/Models/Elements/MultipleFileUpload.cs
@@ -17,7 +17,7 @@ namespace form_builder.Models.Elements
         public MultipleFileUpload() => Type = EElementType.MultipleFileUpload;
 
         public string AllowFileTypeText { get { return Properties.AllowedFileTypes?.ToReadableFileType("and") ?? SystemConstants.AcceptedMimeTypes.ToReadableFileType("and"); } }
-        public string MaxFileSizeText { get { return $"{(Properties.MaxFileSize * (SystemConstants.OneMBInBinaryBytes.Equals(0) ? SystemConstants.DefaultMaxFileSize.ToReadableMaxFileSize() : Properties.MaxFileSize))}MB"; } }
+        public string MaxFileSizeText { get { return $"{((Properties.MaxFileSize * SystemConstants.OneMBInBinaryBytes).Equals(0) ? SystemConstants.DefaultMaxFileSize.ToReadableMaxFileSize() : Properties.MaxFileSize)}MB"; } }
         public string MaxCombinedFileSizeText { get { return $"{(Properties.MaxCombinedFileSize.Equals(0) ? SystemConstants.DefaultMaxCombinedFileSize.ToReadableMaxFileSize() : Properties.MaxCombinedFileSize)}MB"; } }
         public override string QuestionId => $"{base.QuestionId}{FileUploadConstants.SUFFIX}";
         public List<string> CurrentFilesUploaded { get; set; } = new List<string>();

--- a/tests/unit-tests/UnitTests/Models/Elements/MultipleFileUploadTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/MultipleFileUploadTests.cs
@@ -136,5 +136,33 @@ namespace form_builder_tests.UnitTests.Models.Elements
             Assert.True(result.ContainsValue("smbc-multiple-file-upload"));
             Assert.True(result.ContainsValue(value * SystemConstants.OneMBInBinaryBytes));
         }
+
+        [Theory]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(15)]
+        public void MaxFileSizeText_ShouldReturnCorrectText_ForFileSizeProvided(int maxFileSize)
+        {
+            //Arrange
+            var element = (MultipleFileUpload)new ElementBuilder()
+                .WithType(EElementType.MultipleFileUpload)
+                .WithMaxFileSize(maxFileSize)
+                .Build();
+
+            //Act
+            Assert.Equal($"{maxFileSize}MB", element.MaxFileSizeText);
+        }
+
+        [Fact]
+        public void MaxFileSizeText_ShouldReturnCorrectText_WhenNo_MaxFileSize_Provided()
+        {
+            //Arrange
+            var element = (MultipleFileUpload)new ElementBuilder()
+                .WithType(EElementType.MultipleFileUpload)
+                .Build();
+
+            //Act
+            Assert.Equal("10MB", element.MaxFileSizeText);
+        }
     }
 }


### PR DESCRIPTION
### Description
Moved Parenthesis to correct wrap filesize calculation


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary