### PR TITLE
refactor(Config): Moved parsing config to IOptions, removed IConfiguration

### DIFF
--- a/src/Configuration/AwsSesKeysConfiguration.cs
+++ b/src/Configuration/AwsSesKeysConfiguration.cs
@@ -2,6 +2,8 @@
 {
     public class AwsSesKeysConfiguration
     {
+        public const string ConfigValue = "Ses";
+        
         public string Accesskey { get; set; }
         public string Secretkey { get; set; }
 

--- a/src/Configuration/AwsSesKeysConfiguration.cs
+++ b/src/Configuration/AwsSesKeysConfiguration.cs
@@ -3,7 +3,6 @@
     public class AwsSesKeysConfiguration
     {
         public const string ConfigValue = "Ses";
-        
         public string Accesskey { get; set; }
         public string Secretkey { get; set; }
 

--- a/src/Configuration/CivicaPaymentConfiguration.cs
+++ b/src/Configuration/CivicaPaymentConfiguration.cs
@@ -2,6 +2,7 @@
 {
     public class CivicaPaymentConfiguration
     {
+        public const string ConfigValue = "PaymentConfiguration";
         public string CustomerId { get; set; }
         public string ApiPassword { get; set; }
     }

--- a/src/Configuration/DistributedCacheExpirationConfiguration.cs
+++ b/src/Configuration/DistributedCacheExpirationConfiguration.cs
@@ -2,6 +2,7 @@ namespace form_builder.Configuration
 {
     public class DistributedCacheExpirationConfiguration
     {
+        public const string ConfigValue = "DistributedCacheExpiration";
         public int UserData { get; set; }
         public int PaymentConfiguration { get; set; }
         public int FormJson { get; set; }

--- a/src/Configuration/FileStorageProviderConfiguration.cs
+++ b/src/Configuration/FileStorageProviderConfiguration.cs
@@ -2,7 +2,7 @@ namespace form_builder.Configuration
 {
     public class FileStorageProviderConfiguration
     {
-        public const string ConfigValue = "NotifyConfiguration";
+        public const string ConfigValue = "FileStorageProvider";
         public string Type { get; set; }
         public string S3BucketName { get; set; }
     }

--- a/src/Configuration/FileStorageProviderConfiguration.cs
+++ b/src/Configuration/FileStorageProviderConfiguration.cs
@@ -1,0 +1,9 @@
+namespace form_builder.Configuration
+{
+    public class FileStorageProviderConfiguration
+    {
+        public const string ConfigValue = "NotifyConfiguration";
+        public string Type { get; set; }
+        public string S3BucketName { get; set; }
+    }
+}

--- a/src/Configuration/FormConfiguration.cs
+++ b/src/Configuration/FormConfiguration.cs
@@ -2,6 +2,7 @@
 {
     public class FormConfiguration
     {
+        public const string ConfigValue = "FormConfig";
         public string[] DisallowedAnswerKeys { get; set; }
 
         public string ValidReferenceCharacters { get; set; }

--- a/src/Configuration/FormConfiguration.cs
+++ b/src/Configuration/FormConfiguration.cs
@@ -4,7 +4,6 @@
     {
         public const string ConfigValue = "FormConfig";
         public string[] DisallowedAnswerKeys { get; set; }
-
         public string ValidReferenceCharacters { get; set; }
         
     }

--- a/src/Configuration/HashConfiguration.cs
+++ b/src/Configuration/HashConfiguration.cs
@@ -2,6 +2,7 @@
 {
     public class HashConfiguration
     {
+        public const string ConfigValue = "HashConfiguration";
         public string Salt { get; set; }
     }
 }

--- a/src/Configuration/ReCaptchaConfiguration.cs
+++ b/src/Configuration/ReCaptchaConfiguration.cs
@@ -2,6 +2,7 @@
 {
     public class ReCaptchaConfiguration
     {
+        public const string ConfigValue = "ReCaptchaConfiguration";
         public string ApiVerificationEndpoint { get; set; }
 
         public string AuthToken { get; set; }

--- a/src/Configuration/ReCaptchaConfiguration.cs
+++ b/src/Configuration/ReCaptchaConfiguration.cs
@@ -4,9 +4,7 @@
     {
         public const string ConfigValue = "ReCaptchaConfiguration";
         public string ApiVerificationEndpoint { get; set; }
-
         public string AuthToken { get; set; }
-
         public string SiteKey { get; set; }
     }
 }

--- a/src/Configuration/SubmissionServiceConfiguration.cs
+++ b/src/Configuration/SubmissionServiceConfiguration.cs
@@ -2,6 +2,7 @@ namespace form_builder.Configuration
 {
     public class SubmissionServiceConfiguration
     {
+        public const string ConfigValue = "SubmissionServiceConfiguration";
         public bool FakeSubmission { get; set; } = false;
         public bool FakePaymentSubmission { get; set; } = false;
     }

--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -30,9 +30,10 @@ namespace form_builder.Helpers.PageHelpers
         private readonly IWebHostEnvironment _environment;
         private readonly FormConfiguration _disallowedKeys;
         private readonly IDistributedCacheWrapper _distributedCache;
-        private readonly IEnumerable<IFileStorageProvider> _fileStorageProviders;
+        private readonly IFileStorageProvider _fileStorageProvider;
         private readonly DistributedCacheExpirationConfiguration _distributedCacheExpirationConfiguration;
-        private readonly IConfiguration _configuration;
+        private readonly FileStorageProviderConfiguration _fileStorageConfiguration;
+        
 
         public PageHelper(IViewRender viewRender, IElementHelper elementHelper,
             IDistributedCacheWrapper distributedCache,
@@ -41,17 +42,16 @@ namespace form_builder.Helpers.PageHelpers
             IOptions<DistributedCacheExpirationConfiguration> distributedCacheExpirationConfiguration,
             ISessionHelper sessionHelper,
             IEnumerable<IFileStorageProvider> fileStorageProviders,
-            IConfiguration configuration)
+            IOptions<FileStorageProviderConfiguration> fileStorageConfiguration)
         {
             _viewRender = viewRender;
             _elementHelper = elementHelper;
             _distributedCache = distributedCache;
-            _fileStorageProviders = fileStorageProviders;
             _disallowedKeys = disallowedKeys.Value;
             _environment = enviroment;
             _distributedCacheExpirationConfiguration = distributedCacheExpirationConfiguration.Value;
             _sessionHelper = sessionHelper;
-            _configuration = configuration;
+            _fileStorageProvider = fileStorageProviders.Get(fileStorageConfiguration.Value.Type);
         }
 
         public async Task<FormBuilderViewModel> GenerateHtml(
@@ -273,11 +273,10 @@ namespace form_builder.Helpers.PageHelpers
                     }
                 }
 
-                var fileStorageProvider = _fileStorageProviders.Get(_configuration["FileStorageProvider:Type"]);
                 foreach (var file in files)
                 {
                     string key = $"file-{questionId}-{Guid.NewGuid()}";
-                    fileStorageProvider.SetStringAsync(key, JsonConvert.SerializeObject(file.Base64EncodedContent), _distributedCacheExpirationConfiguration.FileUpload);
+                    _fileStorageProvider.SetStringAsync(key, JsonConvert.SerializeObject(file.Base64EncodedContent), _distributedCacheExpirationConfiguration.FileUpload);
                     fileUploadModel.Add(new()
                     {
                         Key = key,

--- a/src/Providers/FileStorage/s3FileStorageProvider.cs
+++ b/src/Providers/FileStorage/s3FileStorageProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Amazon.S3;
+using form_builder.Configuration;
 using form_builder.Gateways;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using System;
 using System.IO;
 using System.Threading;
@@ -12,18 +13,18 @@ namespace form_builder.Providers.FileStorage
     {
         public string ProviderName { get => "S3"; }
         private readonly IS3Gateway _s3Gateway;
-        private readonly IConfiguration _configuration;
+        private readonly FileStorageProviderConfiguration _fileStorageConfiguration;
 
-        public S3FileStorageProvider(IS3Gateway s3Service, IConfiguration configuration)
+        public S3FileStorageProvider(IS3Gateway s3Service, IOptions<FileStorageProviderConfiguration> fileStorageConfiguration)
         {
             _s3Gateway = s3Service;
-            _configuration = configuration;
+            _fileStorageConfiguration = fileStorageConfiguration.Value;
         }
         public async Task<string> GetString(string key)
         {
             try
             {
-                var s3Response = await _s3Gateway.GetObject(_configuration["FileStorageProvider:S3BucketName"], key);
+                var s3Response = await _s3Gateway.GetObject(_fileStorageConfiguration.S3BucketName, key);
                 var s3StringResponse = new StreamReader(s3Response.ResponseStream).ReadToEnd();
                 return s3StringResponse;
             }
@@ -41,7 +42,7 @@ namespace form_builder.Providers.FileStorage
         {
             try
             {
-                await _s3Gateway.DeleteObject(_configuration["FileStorageProvider:S3BucketName"], filename);
+                await _s3Gateway.DeleteObject(_fileStorageConfiguration.S3BucketName, filename);
             }
             catch (AmazonS3Exception e)
             {
@@ -57,7 +58,7 @@ namespace form_builder.Providers.FileStorage
         {
             try
             {
-                await _s3Gateway.PutObject(_configuration["FileStorageProvider:S3BucketName"], filename, value);
+                await _s3Gateway.PutObject(_fileStorageConfiguration.S3BucketName, filename, value);
             }
             catch (AmazonS3Exception e)
             {

--- a/src/Utils/Startup/ServiceCollectionExtensions.cs
+++ b/src/Utils/Startup/ServiceCollectionExtensions.cs
@@ -428,16 +428,18 @@ namespace form_builder.Utils.Startup
 
         public static IServiceCollection AddIOptionsConfiguration(this IServiceCollection services, IConfiguration configuration)
         {
-            services.Configure<FormConfiguration>(configuration.GetSection("FormConfig"));
-            services.Configure<CivicaPaymentConfiguration>(configuration.GetSection("PaymentConfiguration"));
-            services.Configure<DistributedCacheExpirationConfiguration>(configuration.GetSection("DistributedCacheExpiration"));
-            services.Configure<DistributedCacheConfiguration>(cacheOptions => cacheOptions.UseDistributedCache = configuration.GetValue<bool>("UseDistributedCache"));
-            services.Configure<AwsSesKeysConfiguration>(configuration.GetSection("Ses"));
-            services.Configure<ReCaptchaConfiguration>(configuration.GetSection("ReCaptchaConfiguration"));
-            services.Configure<SubmissionServiceConfiguration>(configuration.GetSection("SubmissionServiceConfiguration"));
-            services.Configure<TagManagerConfiguration>(TagManagerId => TagManagerId.TagManagerId = configuration.GetValue<string>("TagManagerId"));
-            services.Configure<HashConfiguration>(configuration.GetSection("HashConfiguration"));
+            services.Configure<AwsSesKeysConfiguration>(configuration.GetSection(AwsSesKeysConfiguration.ConfigValue));
+            services.Configure<CivicaPaymentConfiguration>(configuration.GetSection(CivicaPaymentConfiguration.ConfigValue));
+            services.Configure<DistributedCacheExpirationConfiguration>(configuration.GetSection(DistributedCacheExpirationConfiguration.ConfigValue));
+            services.Configure<FileStorageProviderConfiguration>(configuration.GetSection(NotifyConfiguration.ConfigValue));
+            services.Configure<FormConfiguration>(configuration.GetSection(FormConfiguration.ConfigValue));
+            services.Configure<HashConfiguration>(configuration.GetSection(HashConfiguration.ConfigValue));
             services.Configure<NotifyConfiguration>(configuration.GetSection(NotifyConfiguration.ConfigValue));
+            services.Configure<ReCaptchaConfiguration>(configuration.GetSection(ReCaptchaConfiguration.ConfigValue));
+            services.Configure<SubmissionServiceConfiguration>(configuration.GetSection(SubmissionServiceConfiguration.ConfigValue));
+
+            services.Configure<DistributedCacheConfiguration>(cacheOptions => cacheOptions.UseDistributedCache = configuration.GetValue<bool>("UseDistributedCache"));
+            services.Configure<TagManagerConfiguration>(TagManagerId => TagManagerId.TagManagerId = configuration.GetValue<string>("TagManagerId"));
 
             return services;
         }

--- a/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
@@ -39,11 +39,11 @@ namespace form_builder_tests.UnitTests.Helpers
         private readonly Mock<IWebHostEnvironment> _mockHostingEnv = new();
         private readonly Mock<IOptions<DistributedCacheExpirationConfiguration>> _mockDistributedCacheExpirationSettings = new();
         private readonly Mock<ISessionHelper> _mockSessionHelper = new();
-        private readonly Mock<IConfiguration> _mockConfiguration = new();
+        private readonly Mock<IOptions<FileStorageProviderConfiguration>> _mockFileStorageConfiguration = new();
 
         public PageHelperTests()
         {
-            _mockConfiguration.Setup(_ => _["FileStorageProvider:Type"]).Returns("Redis");
+            _mockFileStorageConfiguration.Setup(_ => _.Value).Returns(new FileStorageProviderConfiguration { Type = "Redis" });
 
             _fileStorageProvider.Setup(_ => _.ProviderName).Returns("Redis");
             _fileStorageProviders = new List<IFileStorageProvider>
@@ -73,7 +73,7 @@ namespace form_builder_tests.UnitTests.Helpers
                 _mockElementHelper.Object, _mockDistributedCache.Object,
                 _mockDisallowedKeysOptions.Object, _mockHostingEnv.Object,
                 _mockDistributedCacheExpirationSettings.Object,
-                _mockSessionHelper.Object, _fileStorageProviders, _mockConfiguration.Object);
+                _mockSessionHelper.Object, _fileStorageProviders, _mockFileStorageConfiguration.Object);
         }
 
         [Fact]

--- a/tests/unit-tests/UnitTests/Providers/FileStorage/S3FileStorageProviderTests.cs
+++ b/tests/unit-tests/UnitTests/Providers/FileStorage/S3FileStorageProviderTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
+using form_builder.Configuration;
 using form_builder.Gateways;
 using form_builder.Providers.FileStorage;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -12,13 +14,13 @@ namespace form_builder_tests.UnitTests.Providers.FileStorage
     {
         private readonly S3FileStorageProvider _s3FileStorageProvider;
         private readonly Mock<IS3Gateway> _mockS3Gateway = new();
-        private readonly Mock<IConfiguration> _mockConfiguration = new();
+        private readonly Mock<IOptions<FileStorageProviderConfiguration>> _mockFileStorageConfiguration = new();
 
         public S3FileStorageProviderTests()
         {
-            _mockConfiguration.Setup(_ => _["FileStorageProvider:Type"]).Returns("S3");
-            _mockConfiguration.Setup(_ => _["FileStorageProvider:S3BucketName"]).Returns("formbuilder-s3-file-storage");
-            _s3FileStorageProvider = new S3FileStorageProvider(_mockS3Gateway.Object, _mockConfiguration.Object);
+            _mockFileStorageConfiguration.Setup(_ => _.Value).Returns(new FileStorageProviderConfiguration { Type = "S3", S3BucketName = "formbuilder-s3-file-storage" });
+
+            _s3FileStorageProvider = new S3FileStorageProvider(_mockS3Gateway.Object, _mockFileStorageConfiguration.Object);
         }
 
         [Fact]

--- a/tests/unit-tests/UnitTests/Services/FileUploadServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/FileUploadServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using form_builder.Builders;
+using form_builder.Configuration;
 using form_builder.Constants;
 using form_builder.ContentFactory.PageFactory;
 using form_builder.Enum;
@@ -17,6 +18,7 @@ using form_builder.Validators;
 using form_builder.ViewModels;
 using form_builder_tests.Builders;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -33,7 +35,7 @@ namespace form_builder_tests.UnitTests.Services
         private readonly Mock<IFileStorageProvider> _fileStorageProvider = new();
         private readonly Mock<IPageFactory> _mockPageFactory = new();
         private readonly Mock<IPageHelper> _mockPageHelper = new();
-        private readonly Mock<IConfiguration> _mockConfiguration = new();
+        private readonly Mock<IOptions<FileStorageProviderConfiguration>> _mockFileStorageConfiguration = new();
 
         private static readonly Element _element = new ElementBuilder()
             .WithType(EElementType.MultipleFileUpload)
@@ -53,7 +55,7 @@ namespace form_builder_tests.UnitTests.Services
 
         public FileUploadServiceTests()
         {
-            _mockConfiguration.Setup(_ => _["FileStorageProvider:Type"]).Returns("Redis");
+            _mockFileStorageConfiguration.Setup(_ => _.Value).Returns(new FileStorageProviderConfiguration { Type = "Redis" });
 
             _fileStorageProvider.Setup(_ => _.ProviderName).Returns("Redis");
             _fileStorageProviders = new List<IFileStorageProvider>
@@ -77,7 +79,7 @@ namespace form_builder_tests.UnitTests.Services
 
             _validators.Setup(m => m.GetEnumerator()).Returns(() => elementValidatorItems.GetEnumerator());
 
-            _service = new FileUploadService(_mockDistributedCache.Object, _fileStorageProviders, _mockPageFactory.Object, _mockPageHelper.Object, _mockConfiguration.Object);
+            _service = new FileUploadService(_mockDistributedCache.Object, _fileStorageProviders, _mockPageFactory.Object, _mockPageHelper.Object, _mockFileStorageConfiguration.Object);
         }
 
         [Fact]

--- a/tests/unit-tests/UnitTests/Services/PageServicesTests.cs
+++ b/tests/unit-tests/UnitTests/Services/PageServicesTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using form_builder.Builders;
@@ -10,7 +9,6 @@ using form_builder.ContentFactory.PageFactory;
 using form_builder.ContentFactory.SuccessPageFactory;
 using form_builder.Enum;
 using form_builder.Factories.Schema;
-using form_builder.Helpers.ElementHelpers;
 using form_builder.Helpers.IncomingDataHelper;
 using form_builder.Helpers.PageHelpers;
 using form_builder.Helpers.Session;
@@ -67,11 +65,11 @@ namespace form_builder_tests.UnitTests.Services {
         private readonly Mock<IFormAvailabilityService> _mockFormAvailabilityService = new();
         private readonly Mock<IFormSchemaIntegrityValidator> _mockFormSchemaIntegrityValidator = new();
         private readonly Mock<ILogger<IPageService>> _mockLogger = new();
-        private readonly Mock<IConfiguration> _mockConfiguration = new();
+        private readonly Mock<IOptions<FileStorageProviderConfiguration>> _mockFileStorageConfiguration = new();
         private readonly Mock<IAddAnotherService> _mockAddAnotherService = new();
 
         public PageServicesTests() {
-            _mockConfiguration.Setup(_ => _["FileStorageProvider:Type"]).Returns("Redis");
+            _mockFileStorageConfiguration.Setup(_ => _.Value).Returns(new FileStorageProviderConfiguration { Type = "Redis" });
 
             _fileStorageProvider.Setup(_ => _.ProviderName).Returns("Redis");
             _fileStorageProviders = new List<IFileStorageProvider>
@@ -138,7 +136,7 @@ namespace form_builder_tests.UnitTests.Services {
                 _mockAddAnotherService.Object,
                 _mockFormAvailabilityService.Object,
                 _mockLogger.Object, _fileStorageProviders,
-                _mockConfiguration.Object
+                _mockFileStorageConfiguration.Object
                 );
         }
 


### PR DESCRIPTION
### Description

- Changed how IOptions are registered in startup to be the same via a const ConfigValue within the Configuration object across all IOptions
- Removed IConfiguration from some servives/helpers for just the IOptions it requires
- Do selection of IFileStorageProvider within Constructor, as FileStorageProvider does not change per form like Lookups, is singular.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary