### PR TITLE
fix(ManualAddressValidation): fix issue with error on manual address …

### DIFF
--- a/src/Models/Elements/Textbox.cs
+++ b/src/Models/Elements/Textbox.cs
@@ -30,7 +30,7 @@ namespace form_builder.Models.Elements
 
         public override Dictionary<string, dynamic> GenerateElementProperties(string type = "")
         {
-            var properties = new Dictionary<string, dynamic>()
+            var properties = new Dictionary<string, dynamic>
             {
                 { "name", Properties.QuestionId },
                 { "id", Properties.QuestionId },
@@ -45,9 +45,6 @@ namespace form_builder.Models.Elements
                 properties.Add("max", Properties.Max);
                 properties.Add("min", Properties.Min);
             }
-
-            if (Properties.Telephone.GetValueOrDefault())
-                properties["autocomplete"] = "tel";
 
             if (DisplayAriaDescribedby)
                 properties.Add("aria-describedby", GetDescribedByAttributeValue());

--- a/src/Models/Properties/ElementProperties/AddressProperty.cs
+++ b/src/Models/Properties/ElementProperties/AddressProperty.cs
@@ -22,11 +22,9 @@ namespace form_builder.Models.Properties.ElementProperties
 
         public string AddressProvider { get; set; }
 
-        public bool? Postcode { get; set; }
-
         public string AddressIAG { get; set; } = "You must live in Stockport.";
 
-        public bool? StockportPostcode { get; set; }
+        public bool StockportPostcode { get; set; } = false;
 
         public bool DisplayNoResultsIAG { get; set; } = false;
 

--- a/src/Models/Properties/ElementProperties/BaseProperty.cs
+++ b/src/Models/Properties/ElementProperties/BaseProperty.cs
@@ -18,9 +18,9 @@ namespace form_builder.Models.Properties.ElementProperties
 
         public bool IsDynamicallyGeneratedElement { get; set; } = false;
 
-        public bool? Email { get; set; }
+        public bool Email { get; set; } = false;
 
-        public bool? Telephone { get; set; }
+        public bool Postcode { get; set; } = false;
 
         public bool Numeric { get; set; } = false;
 

--- a/src/Services/AddressService/AddressService.cs
+++ b/src/Services/AddressService/AddressService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using form_builder.Constants;
 using form_builder.ContentFactory.PageFactory;

--- a/src/Services/AddressService/AddressService.cs
+++ b/src/Services/AddressService/AddressService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using form_builder.Constants;
 using form_builder.ContentFactory.PageFactory;

--- a/src/Validators/EmailElementValidator.cs
+++ b/src/Validators/EmailElementValidator.cs
@@ -10,13 +10,13 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!element.Properties.Email.GetValueOrDefault())
+            if (!element.Properties.Email)
                 return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[element.Properties.QuestionId]) && element.Properties.Optional)
                 return new ValidationResult { IsValid = true };
 
-            if (!element.Properties.Email.HasValue || !element.Properties.Email.Value || !viewModel.ContainsKey(element.Properties.QuestionId))
+            if (!viewModel.ContainsKey(element.Properties.QuestionId))
                 return new ValidationResult { IsValid = true };
 
             var value = viewModel[element.Properties.QuestionId];

--- a/src/Validators/PostcodeElementValidator.cs
+++ b/src/Validators/PostcodeElementValidator.cs
@@ -9,13 +9,13 @@ namespace form_builder.Validators
     {
         public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
         {
-            if (!element.Properties.Postcode.GetValueOrDefault())
+            if (!element.Properties.Postcode)
                 return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[element.Properties.QuestionId]) && element.Properties.Optional)
                 return new ValidationResult { IsValid = true };
 
-            if ((!element.Properties.Postcode.HasValue || !element.Properties.Postcode.Value) || !viewModel.ContainsKey(element.Properties.QuestionId))
+            if (!viewModel.ContainsKey(element.Properties.QuestionId))
                 return new ValidationResult { IsValid = true };
 
             var value = viewModel[element.Properties.QuestionId];

--- a/src/Validators/StockportAddressPostcodeElementValidator.cs
+++ b/src/Validators/StockportAddressPostcodeElementValidator.cs
@@ -14,10 +14,7 @@ namespace form_builder.Validators
             if (!element.Type.Equals(EElementType.Address) || (element.Type.Equals(EElementType.Address) && !viewModel.IsInitial()))
                 return new ValidationResult { IsValid = true };
 
-            if (!element.Properties.StockportPostcode.GetValueOrDefault())
-                return new ValidationResult { IsValid = true };
-
-            if ((!element.Properties.StockportPostcode.HasValue || !element.Properties.StockportPostcode.Value) || !viewModel.ContainsKey($"{element.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}"))
+            if (!element.Properties.StockportPostcode || !viewModel.ContainsKey($"{element.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}"))
                 return new ValidationResult { IsValid = true };
 
             if (string.IsNullOrEmpty(viewModel[$"{element.Properties.QuestionId}{AddressConstants.SEARCH_SUFFIX}"]) && element.Properties.Optional)

--- a/src/Validators/StockportPostcodeElementValidator.cs
+++ b/src/Validators/StockportPostcodeElementValidator.cs
@@ -16,7 +16,7 @@ namespace form_builder.Validators
             if (string.IsNullOrEmpty(viewModel[element.Properties.QuestionId]) && element.Properties.Optional)
                 return new ValidationResult { IsValid = true };
 
-            if ((!element.Properties.StockportPostcode.HasValue || !element.Properties.StockportPostcode.Value) || !viewModel.ContainsKey(element.Properties.QuestionId))
+            if (!element.Properties.StockportPostcode || !viewModel.ContainsKey(element.Properties.QuestionId))
                 return new ValidationResult { IsValid = true };
 
             var value = viewModel[element.Properties.QuestionId];

--- a/src/Views/Shared/Address/AddressSearch.cshtml
+++ b/src/Views/Shared/Address/AddressSearch.cshtml
@@ -7,7 +7,7 @@
 
 <div class="govuk-form-group @(!Model.IsValid ? "govuk-form-group--error" : string.Empty)">
 
-    @if (Model.Properties.StockportPostcode.GetValueOrDefault())
+    @if (Model.Properties.StockportPostcode)
     {
         <partial name="InsetText" model="Model.Properties.AddressIAG" />
     }


### PR DESCRIPTION
…validation

### Description
- Make StockportPostcode not nullable and default to false
- Additionally make Postcode and Email not nullable and default to false
- Move Postcode to BaseProperties as it's not for Address only
- Remove Telephone as setting this to true and setting Purpose to "tel" in the json causes an error. As there is no validation for Telephone it seemed better to remove it altogether but open to discussion on that (it wasn't listed in the wiki as a Property although there was an example that used it)

### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary