### PR TITLE
fix(ProcessRequest): Sanitize string inputs to remove whitespace

### DIFF
--- a/src/Helpers/PageHelpers/IPageHelper.cs
+++ b/src/Helpers/PageHelpers/IPageHelper.cs
@@ -13,6 +13,8 @@ namespace form_builder.Helpers.PageHelpers
 
         FormAnswers GetSavedAnswers(string guid);
 
+        Dictionary<string, dynamic> SanitizeViewModel(Dictionary<string, dynamic> viewModel);
+
         void SaveAnswers(Dictionary<string, dynamic> viewModel, string guid, string form, IEnumerable<CustomFormFile> files, bool isPageValid, bool appendMultipleFileUploadParts = false);
 
         void SaveCaseReference(string guid, string caseReference, bool isGenerated = false, string generatedRefereceMappingId = "");

--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -139,6 +139,26 @@ namespace form_builder.Helpers.PageHelpers
             return convertedAnswers;
         }
 
+        public Dictionary<string, dynamic> SanitizeViewModel(Dictionary<string, dynamic> viewModel)
+        {
+            var sanitizedViewModel = new Dictionary<string, dynamic>();
+            foreach (var item in viewModel)
+            {
+                if (!_disallowedKeys.DisallowedAnswerKeys.Any(key => item.Key.Contains(key)))
+                {
+                    var valueType = item.Value?.GetType();
+                    if (valueType is not null && valueType.FullName.Equals("System.String"))
+                        sanitizedViewModel.Add(item.Key, item.Value.ToString().Trim());
+                    else
+                        sanitizedViewModel.Add(item.Key, item.Value);
+                }
+                else
+                    sanitizedViewModel.Add(item.Key, item.Value);
+            }
+
+            return sanitizedViewModel;
+        }
+
         public void SaveAnswers(Dictionary<string, dynamic> viewModel, string guid, string form, IEnumerable<CustomFormFile> files, bool isPageValid, bool appendMultipleFileUploadParts = false)
         {
             var formData = _distributedCache.GetString(guid);

--- a/src/Services/PageService/PageService.cs
+++ b/src/Services/PageService/PageService.cs
@@ -230,6 +230,7 @@ namespace form_builder.Services.PageService
             if (currentPage.HasIncomingPostValues)
                 viewModel = _incomingDataHelper.AddIncomingFormDataValues(currentPage, viewModel);
 
+            viewModel = _pageHelper.SanitizeViewModel(viewModel);
             currentPage.Validate(viewModel, _validators, baseForm);
 
             if (currentPage.Elements.Any(_ => _.Type.Equals(EElementType.AddAnother)))

--- a/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
@@ -502,6 +502,57 @@ namespace form_builder_tests.UnitTests.Helpers
         }
 
         [Fact]
+        public void SanitizeViewModel_ShouldTrimWhitespace_OnAllowedKeysWhereValueTypeIsString()
+        {
+            // Arrange
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                { "question", "   answer   " }
+            };
+
+            // Act
+            var result = _pageHelper.SanitizeViewModel(viewModel);
+
+            // Assert
+            Assert.Equal("answer", result["question"]);
+        }
+
+        [Fact]
+        public void SanitizeViewModel_ShouldNotTrimWhitespace_OnDisallowedKeys()
+        {
+            // Arrange
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                { "Path", "   path   " }
+            };
+
+            // Act
+            var result = _pageHelper.SanitizeViewModel(viewModel);
+
+            // Assert
+            Assert.Equal("   path   ", result["Path"]);
+        }
+
+        [Fact]
+        public void SanitizeViewModel_ShouldNotChangeCountOfViewModel()
+        {
+            // Arrange
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                { "questionOne", "   answer   " },
+                { "questionTwo", true },
+                { "Guid", Guid.NewGuid() },
+                { "Path", "path" }
+            };
+
+            // Act
+            var result = _pageHelper.SanitizeViewModel(viewModel);
+
+            // Assert
+            Assert.Equal(viewModel.Count, result.Count);
+        }
+
+        [Fact]
         public void SaveAnswers_ShouldCallCacheProvider()
         {
             // Arrange


### PR DESCRIPTION
### Description
- Add SanitizeViewModel method to PageHelper to remove whitespace from string inputs
- Amend ProcessRequest in PageService to call SanitizeViewModel
- Update and add unit tests

I have nested the checks to avoid getting the Value type for viewModel items we are disallowing, but happy to combine the check if people feel it won't be a significant overhead

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary