### PR TITLE
fix(GetPageActions): fix call to ActionsWorkflow to only pass in Get …

### DIFF
--- a/src/Services/PageService/PageService.cs
+++ b/src/Services/PageService/PageService.cs
@@ -180,7 +180,7 @@ namespace form_builder.Services.PageService
             }
 
             if (page.HasPageActionsGetValues)
-                await _actionsWorkflow.Process(page.PageActions, null, form);
+                await _actionsWorkflow.Process(page.PageActions.Where(_ => _.Properties.HttpActionType.Equals(EHttpActionType.Get)).ToList(), null, form);
 
             if (page.Elements.Any(_ => _.Type.Equals(EElementType.Booking)))
             {


### PR DESCRIPTION
…Actions

### Description
All PageActions were being processed in ProcessPage if there was at least one GET PageAction. Amended to only pass in Actions with HttpActionType GET


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary