### PR TITLE
fix(duplicate_link): rm duplicate Link.cshtml

### DIFF
--- a/src/Views/Shared/HtmlElements/Link/Link.cshtml
+++ b/src/Views/Shared/HtmlElements/Link/Link.cshtml
@@ -1,11 +1,10 @@
-﻿@model Link
-@{
-    var OpenInTab = Model.Properties.OpenInTab ? "target='_blank'" : "";
-}
-
-<a href='@Model.Properties.Url' rel='noreferrer noopener' @OpenInTab class='@Model.Properties.ClassName'>
+﻿
+<a href=@Model.Properties.Url rel="noreferrer noopener"
+   target=@(Model.Properties.OpenInTab ? "_blank" : "_self")
+   class="@Model.Properties.ClassName">
     @Model.Properties.Text
-    @if(Model.Properties.DisplayRightChevron){
-        <partial name="ChevronSVG" />
+    @if(Model.Properties.DisplayRightChevron)
+    {
+        <partial name=ChevronSVG />
     }
 </a>

--- a/src/Views/Shared/HtmlElements/Link/Link.cshtml
+++ b/src/Views/Shared/HtmlElements/Link/Link.cshtml
@@ -1,9 +1,10 @@
-﻿
+﻿@model Link
+
 <a href=@Model.Properties.Url rel="noreferrer noopener"
    target=@(Model.Properties.OpenInTab ? "_blank" : "_self")
    class="@Model.Properties.ClassName">
     @Model.Properties.Text
-    @if(Model.Properties.DisplayRightChevron)
+    @if (Model.Properties.DisplayRightChevron)
     {
         <partial name=ChevronSVG />
     }

--- a/src/Views/Shared/Link.cshtml
+++ b/src/Views/Shared/Link.cshtml
@@ -1,6 +1,0 @@
-﻿@model form_builder.Models.Elements.Element
-@{
-    var OpenInTab = Model.Properties.OpenInTab ? "target='_blank'" : "";
-}
-
-<a href='@Model.Properties.Url' rel='noreferrer noopener' @OpenInTab class='@Model.Properties.ClassName'>@Model.Properties.Text</a>


### PR DESCRIPTION
### Description
Issue was the forms that were changed yesterday, see commit SHA e6d07911239bd7e4b9fdd448217a6ed50ebb7ee8 on form-builder-json, of which had the "right chevron"... were not displaying the right chevron. It was loading a duplicate ( higher level ) view.

Removed duplicate Link.cshtml view from Shared folder, as it already exists in Shared/HtmlElements/Link and has ViewLocation set in AddRazorViewEngineViewLocations in ServiceCollectionExtensions.cs

Tidied the original Link.cshtml view

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary