### PR TITLE
fix(script_encoding): add classic for to encode all user input

### DIFF
--- a/src/Extensions/DictionaryExtensions.cs
+++ b/src/Extensions/DictionaryExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Web;
 using form_builder.Constants;
 
 namespace form_builder.Extensions
@@ -9,13 +10,18 @@ namespace form_builder.Extensions
     {
         public static Dictionary<string, object> ToNormaliseDictionary(this Dictionary<string, string[]> formData, string subPath)
         {
-            var normalisedFormData = new Dictionary<string, dynamic>();
+            Dictionary<string, dynamic> normalisedFormData = new();
             normalisedFormData.Add(LookUpConstants.SubPathViewModelKey, subPath);
 
             foreach (var item in formData)
             {
                 if (item.Key.EndsWith(FileUploadConstants.SUFFIX))
                     continue;
+
+                for (int x = 0; x < item.Value.Length; x++)
+                {
+                    item.Value[x] = HttpUtility.HtmlEncode(item.Value[x]);
+                }
 
                 if (item.Value.Length.Equals(1))
                 {

--- a/tests/unit-tests/UnitTests/Extensions/DictionaryExtensionsTests.cs
+++ b/tests/unit-tests/UnitTests/Extensions/DictionaryExtensionsTests.cs
@@ -8,6 +8,24 @@ namespace form_builder_tests.UnitTests.Extensions
 {
     public class DictionaryExtensionsTests
     {
+        [Fact]
+        public void ToNormaliseDictionary_ShouldEncodeAllUserInput()
+        {
+            // Arrange
+            string questionId = "questionId";
+            var disallowedChars = new char[] { '<', '>', '&', '\"' };
+            Dictionary<string, string[]> viewModel = new() { { questionId, new string[] { disallowedChars.ToString() } } };
+
+            // Act
+            var result = viewModel.ToNormaliseDictionary(string.Empty);
+            result.TryGetValue(questionId, out var encodedUserInput);
+
+            // Assert
+            foreach (char character in disallowedChars)
+            {
+                Assert.False(encodedUserInput.ToString().Contains(character));
+            }
+        }
 
         [Fact]
         public void ToNormaliseDictionary_ShouldRemoveAny_Keys_AssociatedWith_Time_And_Add_AppointmentStart_EndTime()


### PR DESCRIPTION
### Description
To do with [Jira Card 6501](https://stockportbi.atlassian.net/browse/DIGITAL-6501)...

I tidied that card up a bit after discussions with Jon C and Stephen L.

This is designed as a quick fix to encode all user input and make sure no Script tags are rendered on the page.

Understand sql injection is not to be protected against here.

Would cover text/textarea inputs that attempt to submit '<script>hacked()<script>'

or

"`></><p onload="hacked()"><p>`"

Believe there is further investigation into this area of security.

**To test :** 

Pull branch, launch solution with exemplar.json, and view summary page ( previously scripts inputted would fire on this page ). 

Ensure no alerts can fire through something like <script>window.alert("HACKED!")</script>.

Ensure other data has not been altered.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary