### PR TITLE
fix(script_injection): change to encode only "<>"

### DIFF
--- a/src/Extensions/DictionaryExtensions.cs
+++ b/src/Extensions/DictionaryExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Web;
 using form_builder.Constants;
 
@@ -20,7 +21,15 @@ namespace form_builder.Extensions
 
                 for (int x = 0; x < item.Value.Length; x++)
                 {
-                    item.Value[x] = HttpUtility.HtmlEncode(item.Value[x]);
+                    if (item.Value[x] is null) continue;
+
+                    string lessThan = "<";
+                    if (item.Value[x].Contains(lessThan))
+                        item.Value[x] = item.Value[x].Replace(lessThan, "%3C");
+
+                    string moreThan = ">";
+                    if (item.Value[x].Contains(moreThan))
+                        item.Value[x] = item.Value[x].Replace(moreThan, "%3E");
                 }
 
                 if (item.Value.Length.Equals(1))

--- a/tests/unit-tests/UnitTests/Extensions/DictionaryExtensionsTests.cs
+++ b/tests/unit-tests/UnitTests/Extensions/DictionaryExtensionsTests.cs
@@ -10,9 +10,8 @@ namespace form_builder_tests.UnitTests.Extensions
     {
         [Theory]
         [InlineData("<script>window.alert('HACKED!')</script>")]
-        [InlineData("first-name></><p onload=hack()></p>")]
-        [InlineData("harmless this & that text")]
-        public void ToNormaliseDictionary_Should_EncodeUserInput(string userInput)
+        [InlineData("first-name</><p onload=hack()></p>")]
+        public void ToNormaliseDictionary_Should_EncodeAngleBrackets(string userInput)
         {
             // Arrange
             string questionId = "questionId";
@@ -23,7 +22,8 @@ namespace form_builder_tests.UnitTests.Extensions
             result.TryGetValue(questionId, out var encodedUserInput);
 
             // Assert
-            Assert.False(encodedUserInput.ToString().Equals(userInput));
+            Assert.True(userInput.Contains("<") || userInput.Contains(">"));
+            Assert.True(!encodedUserInput.ToString().Contains("<") || !encodedUserInput.ToString().Contains(">"));
         }
 
         [Fact]


### PR DESCRIPTION
### Description
Fix for the previous code, which encoded all input values;
-) Now it will loop through the string[] of input values
-) Check if null
-) Check if the string contains a < or > and replace it with the encoded string equivalent

This is part of larger conversation [JIRA Card](https://stockportbi.atlassian.net/browse/DIGITAL-6501), which will be reviewing security within Form Builder, and possibly all projects.

Jon H has agreed that the card should be resolved by targeting only the two angle brackets, opening & closing.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary