### PR TITLE
refactor: moved callback to own try/catch to log error and not fail if exception is thrown

### DIFF
--- a/src/Services/PayService/PayService.cs
+++ b/src/Services/PayService/PayService.cs
@@ -86,33 +86,32 @@ namespace form_builder.Services.PayService
             try
             {
                 paymentProvider.VerifyPaymentResponse(responseCode);
-                var result = await _gateway.PostAsync(postUrl.CallbackUrl,
-                    new { CaseReference = reference, PaymentStatus = EPaymentStatus.Success.ToString() });
-
-                LogCallBackFailure(result, reference, EPaymentCallbackStatus.Success);
-                _pageHelper.SavePaymentAmount(sessionGuid, paymentInformation.Settings.Amount, mappingEntity.BaseForm.PaymentAmountMapping);
-                return reference;
+                await HandleCallback(EPaymentStatus.Success, reference, postUrl.CallbackUrl);
             }
             catch (PaymentDeclinedException)
             {
-                var result = await _gateway.PostAsync(postUrl.CallbackUrl,
-                    new { CaseReference = reference, PaymentStatus = EPaymentStatus.Declined.ToString() });
-
-                LogCallBackFailure(result, reference, EPaymentCallbackStatus.Declined);
+                await HandleCallback(EPaymentStatus.Declined, reference, postUrl.CallbackUrl);
                 throw new PaymentDeclinedException("PayService::ProcessPaymentResponse, PaymentProvider declined payment");
             }
             catch (PaymentFailureException)
             {
-                var result = await _gateway.PostAsync(postUrl.CallbackUrl,
-                    new { CaseReference = reference, PaymentStatus = EPaymentStatus.Failure.ToString() });
-
-                LogCallBackFailure(result, reference, EPaymentCallbackStatus.Failure);
+                await HandleCallback(EPaymentStatus.Failure, reference, postUrl.CallbackUrl);
                 throw new PaymentFailureException("PayService::ProcessPaymentResponse, PaymentProvider failed payment");
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "The payment callback failed");
-                throw new Exception(ex.Message);
+
+             _pageHelper.SavePaymentAmount(sessionGuid, paymentInformation.Settings.Amount, mappingEntity.BaseForm.PaymentAmountMapping);
+            return reference;
+        }
+
+        private async Task HandleCallback(EPaymentStatus paymentStatus, string reference, string callbackUrl)
+        {
+            try {
+                var result = await _gateway.PostAsync(callbackUrl,
+                    new { CaseReference = reference, PaymentStatus = paymentStatus });
+
+                LogErrorIfCallbackFails(result, reference, EPaymentCallbackStatus.Failure);
+            } catch(Exception e){
+                _logger.LogError($"PayService::HandleCallback, Payment callback to url {callbackUrl} failed. Payment status was {paymentStatus}, failed with Exception: {e.Message}, Payment reference {reference}");
             }
         }
 
@@ -126,7 +125,7 @@ namespace form_builder.Services.PayService
             return paymentProvider;
         }
 
-        private void LogCallBackFailure(HttpResponseMessage callbackResponse, string reference, EPaymentCallbackStatus callbackType) 
+        private void LogErrorIfCallbackFails(HttpResponseMessage callbackResponse, string reference, EPaymentCallbackStatus callbackType) 
         {
             if(!callbackResponse.IsSuccessStatusCode)
                 _logger.LogError($"PayService::ProcessPaymentResponse, Payment callback for {callbackType} failed with statuscode: {callbackResponse.StatusCode}, Payment reference {reference}, Response: {JsonConvert.SerializeObject(callbackResponse)}");


### PR DESCRIPTION
### Description

In some scenarios a payments may fail if the gateway callback call throws an exception (if the service fails to respond to the call). Instead of erroring if the payment was successful/declined/failure we log the exception and process the payment response as normal.
 
Moved gateway call to try/catch to log if an exception occures.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary