### PR TITLE
fix(structure tests): amend handling of converting env to S3EnvPrefix

### DIFF
--- a/src/Extensions/ListExtension.cs
+++ b/src/Extensions/ListExtension.cs
@@ -15,6 +15,6 @@ namespace form_builder.Extensions
                   : value.First().ToUpper();
         }
 
-        public static AppointmentType GetAppointmentTypeForEnvironment(this List<AppointmentType> value, string environment) => value.First(_ => _.Environment.Equals(environment, StringComparison.OrdinalIgnoreCase));
+        public static AppointmentType GetAppointmentTypeForEnvironment(this List<AppointmentType> value, string environment) => value.First(_ => _.Environment.Equals(environment.ToS3EnvPrefix(), StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/Extensions/StringExtensions.cs
+++ b/src/Extensions/StringExtensions.cs
@@ -11,8 +11,8 @@ namespace form_builder.Extensions
             switch (value)
             {
                 case "local":
-                    return "local";
                 case "uitest":
+                    return "local";
                 case "int":
                     return "Int";
                 case "qa":

--- a/src/Validators/IntegrityChecks/Elements/BookingElementCheck.cs
+++ b/src/Validators/IntegrityChecks/Elements/BookingElementCheck.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using form_builder.Enum;
+using form_builder.Extensions;
 using form_builder.Models;
 using form_builder.Models.Elements;
 using Microsoft.AspNetCore.Hosting;
@@ -25,7 +26,7 @@ namespace form_builder.Validators.IntegrityChecks.Elements
                 result.AddFailureMessage($"Booking Element Check, Booking element '{element.Properties.QuestionId}' requires a valid booking provider property.");
 
             AppointmentType appointmentTypeForEnv = element.Properties.AppointmentTypes
-                .FirstOrDefault(appointmentType => appointmentType.Environment.Equals(_environment.EnvironmentName, StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(appointmentType => appointmentType.Environment.Equals(_environment.EnvironmentName.ToS3EnvPrefix(), StringComparison.OrdinalIgnoreCase));
 
             if (appointmentTypeForEnv is null)
             {

--- a/tests/unit-tests/UnitTests/Extensions/ListExtensionsTests.cs
+++ b/tests/unit-tests/UnitTests/Extensions/ListExtensionsTests.cs
@@ -17,14 +17,14 @@ namespace form_builder_tests.UnitTests.Extensions
             {
                 new AppointmentType 
                 {
-                    Environment = "test",
+                    Environment = "local",
                     AppointmentId = id,
                     OptionalResources = new List<BookingResource>{
                         new BookingResource()
                     }
                 }
             };
-            var result = testList.GetAppointmentTypeForEnvironment("test");
+            var result = testList.GetAppointmentTypeForEnvironment("uitest");
 
             
             Assert.NotNull(result);

--- a/tests/unit-tests/UnitTests/Extensions/StringExtensionsTests.cs
+++ b/tests/unit-tests/UnitTests/Extensions/StringExtensionsTests.cs
@@ -7,7 +7,7 @@ namespace form_builder_tests.UnitTests.Extensions
     public class StringExtensionsTests
     {
         [Theory]
-        [InlineData("uitest", "Int")]
+        [InlineData("uitest", "local")]
         [InlineData("local", "local")]
         [InlineData("int", "Int")]
         [InlineData("qa", "QA")]

--- a/tests/unit-tests/UnitTests/Providers/SchemaProvider/S3FileSchemaProviderTests.cs
+++ b/tests/unit-tests/UnitTests/Providers/SchemaProvider/S3FileSchemaProviderTests.cs
@@ -116,7 +116,7 @@ namespace form_builder_tests.UnitTests.Providers.SchemaProvider
         [Fact]
         public async Task ValidateSchemaName_Should_Remove_BucketPrefix_WhenIndexing_List()
         {
-            var testIndexKey = $"Int/{_s3SchemaFolderName}/test-form-name.json";
+            var testIndexKey = $"local/{_s3SchemaFolderName}/test-form-name.json";
             var expected = "test-form-name.json";
             _mockS3Gateway.Setup(_ => _.ListObjectsV2(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new ListObjectsV2Response{ S3Objects = new List<S3Object>{ new S3Object { Key = testIndexKey } } });

--- a/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
@@ -51,7 +51,7 @@ namespace form_builder_tests.UnitTests.Services
         private readonly Mock<IHashUtil> _hashUtil = new();
         private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor = new();
 
-        const string environmentName = "test";
+        const string environmentName = "local";
         const string bookingProvider = "testBookingProvider";
 
         public BookingServiceTests()
@@ -188,7 +188,7 @@ namespace form_builder_tests.UnitTests.Services
             {
                 new AppointmentType
                 {
-                    Environment = "test",
+                    Environment = environmentName,
                     AppointmentId = appointmentId
                 }
             };
@@ -221,7 +221,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -264,6 +264,7 @@ namespace form_builder_tests.UnitTests.Services
 
             var appointmentType = new AppointmentTypeBuilder()
                 .WithAppointmentId(guid)
+                .WithEnvironment(environmentName)
                 .WithOptionalResource(new BookingResource { ResourceId = bookingResourceId, Quantity = bookingResourceQuantity })
                 .Build();
 
@@ -310,7 +311,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -349,7 +350,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -388,7 +389,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -435,7 +436,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithQuestionId(questionId)
                 .WithAppointmentType(new AppointmentType
                 {
-                    Environment = "test",
+                    Environment = environmentName,
                     AppointmentIdKey = questionId
                 })
                 .Build();
@@ -495,7 +496,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithQuestionId(questionId)
                 .WithAppointmentType(new AppointmentType
                 {
-                    Environment = "test",
+                    Environment = environmentName,
                     AppointmentIdKey = questionId
                 })
                 .Build();
@@ -547,7 +548,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithQuestionId(questionId)
                 .WithAppointmentType(new AppointmentType
                 {
-                    Environment = "test",
+                    Environment = environmentName,
                     AppointmentIdKey = questionId
                 })
                 .Build();
@@ -607,7 +608,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithQuestionId(questionId)
                 .WithAppointmentType(new AppointmentType
                 {
-                    Environment = "test",
+                    Environment = environmentName,
                     AppointmentId = appointmentId
                 })
                 .Build();
@@ -651,7 +652,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -686,7 +687,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -725,7 +726,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -763,7 +764,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = guid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -829,7 +830,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = Guid.NewGuid(), Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = Guid.NewGuid(), Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -862,7 +863,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -901,7 +902,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = environmentName })
                 .WithCheckYourBooking(false)
                 .Build();
 
@@ -943,7 +944,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = environmentName })
                 .WithCheckYourBooking(true)
                 .Build();
 
@@ -982,7 +983,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -1024,7 +1025,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -1069,7 +1070,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = selectedAppointmentTypeGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = selectedAppointmentTypeGuid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -1112,7 +1113,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -1153,7 +1154,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
-                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = appointmentTypeGuid, Environment = environmentName })
                 .Build();
 
             var page = new PageBuilder()
@@ -1282,7 +1283,7 @@ namespace form_builder_tests.UnitTests.Services
                 });
 
             _mockHostingEnv.Setup(_ => _.EnvironmentName)
-                .Returns("local");
+                .Returns(environmentName);
 
             _mockHttpContextAccessor.Setup(_ => _.HttpContext.Request.Host)
                .Returns(new HostString("www.test.com"));

--- a/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
@@ -62,7 +62,7 @@ namespace form_builder_tests.UnitTests.Services
             _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
                 .ReturnsAsync(schema);
 
-            _mockHostingEnv.Setup(_ => _.EnvironmentName).Returns("test");
+            _mockHostingEnv.Setup(_ => _.EnvironmentName).Returns("local");
 
             _service = new MappingService(_mockDistributedCache.Object, _mockElementMapper.Object, _mockSchemaFactory.Object, _mockHostingEnv.Object, _mockLogger.Object);
         }
@@ -692,7 +692,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(new AppointmentType { AppointmentId = bookingGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType { AppointmentId = bookingGuid, Environment = "local" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {
@@ -782,7 +782,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
                 .WithCustomerAddressId("address")
-                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "local" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {
@@ -830,7 +830,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "local" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {
@@ -871,7 +871,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "local" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {
@@ -908,7 +908,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "test" })
+                .WithAppointmentType(new AppointmentType{ AppointmentId = bookingGuid, Environment = "local" })
                 .Build();
 
             var viewModel = new Dictionary<string, object> {
@@ -929,7 +929,7 @@ namespace form_builder_tests.UnitTests.Services
             // Arrange
             string appointmentIdkey = "appointmentId";
             string appointmentId = "022ebc92-1c51-4a68-a079-f6edefc63a07";
-            AppointmentType appointmentType = new() { Environment = "test", AppointmentIdKey = appointmentIdkey };
+            AppointmentType appointmentType = new() { Environment = "local", AppointmentIdKey = appointmentIdkey };
             FormAnswers fromAnswers = new()
             {
                 Pages = new()
@@ -975,7 +975,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "local" })
                 .Build();
 
             var viewModel = new Dictionary<string, object>();
@@ -1007,7 +1007,7 @@ namespace form_builder_tests.UnitTests.Services
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)
                 .WithQuestionId("booking")
-                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "test" })
+                .WithAppointmentType(new AppointmentType{ AppointmentId = Guid.NewGuid(), Environment = "local" })
                 .Build();
 
             var viewModel = new Dictionary<string, object>();


### PR DESCRIPTION
### Description
* Amend GetAppointmentTypeForEnvironment ListExtension to convert env to S3EnvPrefix before comparing
* Amend StringExtension ToS3EnvPrefix to return "local" for uitest instead of "Int"
* Amend BookingElementCheck to compare against S3EnvPrefix
* Update UnitTests to use "local" for enviroment instead of "test"


### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary