### PR TITLE
MailTo tag parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/src/TagParsers/MailToTagParser.cs
+++ b/src/TagParsers/MailToTagParser.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using form_builder.Models;
+using form_builder.TagParsers.Formatters;
+
+namespace form_builder.TagParsers
+{
+    public class MailToTagParser : TagParser, ITagParser, ISimpleTagParser
+    {
+        public MailToTagParser(IEnumerable<IFormatter> formatters) : base(formatters)
+        {
+        }
+
+        public Regex Regex => new Regex("(?<={{)MAILTO:.+?[@].+?(?=}})", RegexOptions.Compiled);
+        public string _htmlContent => "<a class='govuk-link' rel='noreferrer noopener' target='_blank' href='mailto:{0}'>{0}</a>";
+
+        public async Task<Page> Parse(Page page, FormAnswers formAnswers)
+        {
+            page.Elements.Select((element) =>
+            {
+                if (!string.IsNullOrEmpty(element.Properties?.Text))
+                    element.Properties.Text = Parse(element.Properties.Text, Regex, _htmlContent, FormatContent);
+
+                return element;
+            }).ToList();
+
+            return await Task.FromResult(page);
+        }
+
+        public string ParseString(string content, FormAnswers formAnswers) => Parse(content, Regex, _htmlContent, FormatContent);
+
+        public string FormatContent(string[] values) => string.Format(_htmlContent, values[0]);
+    }
+}

--- a/src/Utils/Startup/ServiceCollectionExtensions.cs
+++ b/src/Utils/Startup/ServiceCollectionExtensions.cs
@@ -146,6 +146,7 @@ namespace form_builder.Utils.Startup
             services.AddTransient<ITagParser, FormAnswerTagParser>();
             services.AddTransient<ITagParser, FormDataTagParser>();
             services.AddTransient<ITagParser, LinkTagParser>();
+            services.AddTransient<ITagParser, MailToTagParser>();
             services.AddTransient<ITagParser, PaymentAmountTagParser>();
             services.AddTransient<ITagParser, CaseReferenceTagParser>();
 

--- a/tests/unit-tests/UnitTests/TagParsers/MailToTagParserTests.cs
+++ b/tests/unit-tests/UnitTests/TagParsers/MailToTagParserTests.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using form_builder.Builders;
+using form_builder.Enum;
+using form_builder.Models;
+using form_builder.TagParsers;
+using form_builder.TagParsers.Formatters;
+using form_builder_tests.Builders;
+using Moq;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.TagParsers
+{
+    public class MailToTagParserTests
+    {
+        private readonly Mock<IEnumerable<IFormatter>> _mockFormatters = new();
+        private readonly MailToTagParser _tagParser;
+
+        public MailToTagParserTests()
+        {
+            _tagParser = new MailToTagParser(_mockFormatters.Object);
+        }
+
+        [Theory]
+        [InlineData("{{MAILTO:firstname@asdfasdf.com}}")]
+        [InlineData("{{MAILTO:ref@sadf.com}}")]
+        public void Regex_ShouldReturnTrue_Result(string value)
+        {
+            Assert.True(_tagParser.Regex.Match(value).Success);
+        }
+
+        [Theory]
+        [InlineData("{{Mail:firstname@asas.xom}}")]
+        [InlineData("{{MAIL2:ref@sdsd.copm}}")]
+        [InlineData("{MAILTO:@firstname.com}")]
+        [InlineData("{{MAILTO:firstname}")]
+        [InlineData("{{MAILTO4:firstname@asdfd.com}}")]
+        [InlineData("{{DIFFERENTTAG:firstname}}")]
+        public void Regex_ShouldReturnFalse_Result(string value)
+        {
+            Assert.False(_tagParser.Regex.Match(value).Success);
+        }
+
+        [Fact]
+        public void FormatContent_ShouldReturnValidFormattedText()
+        {
+            var url = "john.smith@stockport.gov.uk";
+            var expectValue = string.Format(_tagParser._htmlContent, url);
+            Assert.Equal(expectValue, _tagParser.FormatContent(new string[1] { url }));
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnInitialValue_WhenNoValuesAre_To_BeReplaced()
+        {
+            var element = new ElementBuilder()
+                .WithType(EElementType.P)
+                .WithPropertyText("this has no values to be replaced")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers();
+
+            var result = await _tagParser.Parse(page, formAnswers);
+
+            Assert.Equal(element.Properties.Text, result.Elements.FirstOrDefault().Properties.Text);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnInitialValue_When_NoTag_MatchesRegex()
+        {
+            var element = new ElementBuilder()
+                .WithType(EElementType.P)
+                .WithPropertyText("this value {{TAG:firstname}} should be replaced with name question")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers();
+
+            var result = await _tagParser.Parse(page, formAnswers);
+
+            Assert.Equal(element.Properties.Text, result.Elements.FirstOrDefault().Properties.Text);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturn_UpdatedText_WithReplacedValue()
+        {
+            var expectedString = $"this link {_tagParser.FormatContent(new string[1] { "john.smith@stockport.gov.uk" })} should be replaced";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this link {{MAILTO:john.smith@stockport.gov.uk}} should be replaced")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var result = await _tagParser.Parse(page, new FormAnswers());
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturnInitialValue_WhenNoValuesAre_To_BeReplaced()
+        {
+            var text = "this has no values to be replaced";
+            var formAnswers = new FormAnswers();
+
+            var result = _tagParser.ParseString(text, formAnswers);
+
+            Assert.Equal(text, result);
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturnInitialValue_When_NoTag_MatchesRegex()
+        {
+            var text = "this value {{TAG:firstname@yahoo.com}} should be replaced with name question";
+            var formAnswers = new FormAnswers();
+
+            var result = _tagParser.ParseString(text, formAnswers);
+
+            Assert.Equal(text, result);
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturn_UpdatedText_WithReplacedValue()
+        {
+            var expectedString = $"this link {_tagParser.FormatContent(new string[1] { "john.smith@stockport.gov.uk" })} should be replaced";
+
+            var text = "this link {{MAILTO:john.smith@stockport.gov.uk}} should be replaced";
+
+            var result = _tagParser.ParseString(text, new FormAnswers());
+            Assert.Equal(expectedString, result);
+        }
+    }
+}


### PR DESCRIPTION
…com}}

### Description
Added MailTo tag parser to enable to add {{MAILTO:john@yahoo.com}} to remove the need for html in text.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary