### PR TITLE
fix(MappingService): foreach visited page slug

### DIFF
--- a/src/Services/MappingService/MappingService.cs
+++ b/src/Services/MappingService/MappingService.cs
@@ -99,10 +99,10 @@ namespace form_builder.Services.MappingService
 
             var convertedAnswers = JsonConvert.DeserializeObject<FormAnswers>(sessionData);
 
-            var index = baseForm.Pages.IndexOf(baseForm.GetPage(_pageHelper, convertedAnswers.Path));
-            for (int x = 0; x <= index; x++)
+            IEnumerable<string> visitedPageSlugs = convertedAnswers.Pages.Select(page => page.PageSlug);
+            foreach (var pageSlug in visitedPageSlugs)
             {
-                await _schemaFactory.TransformPage(baseForm.Pages[x], convertedAnswers);
+                await _schemaFactory.TransformPage(baseForm.GetPage(_pageHelper, pageSlug), convertedAnswers);
             }
 
             convertedAnswers.Pages = convertedAnswers.GetReducedAnswers(baseForm);

--- a/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
@@ -58,7 +58,8 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
                 .Returns(JsonConvert.SerializeObject(new FormAnswers
                 {
-                    Pages = new List<PageAnswers>()
+                    Pages = new List<PageAnswers>(),
+                    Path = "page-one"
                 }));
 
             _mockSchemaFactory.Setup(_ => _.Build(It.IsAny<string>()))
@@ -253,7 +254,8 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
                .Returns(JsonConvert.SerializeObject(new FormAnswers
                {
-                   Pages = new List<PageAnswers>()
+                   Pages = new List<PageAnswers>(),
+                   Path = page.PageSlug
                }));
 
             // Act
@@ -309,7 +311,8 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
                .Returns(JsonConvert.SerializeObject(new FormAnswers
                {
-                   Pages = new List<PageAnswers>()
+                   Pages = new List<PageAnswers>(),
+                   Path = page.PageSlug
                }));
 
             _mockElementMapper.Setup(_ => _.GetAnswerValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()))
@@ -364,7 +367,8 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
                .Returns(JsonConvert.SerializeObject(new FormAnswers
                {
-                   Pages = new List<PageAnswers>()
+                   Pages = new List<PageAnswers>(),
+                   Path = page.PageSlug
                }));
 
             _mockElementMapper.Setup(_ => _.GetAnswerValue(It.IsAny<IElement>(), It.IsAny<FormAnswers>()))
@@ -408,7 +412,8 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
                .Returns(JsonConvert.SerializeObject(new FormAnswers
                {
-                   Pages = new List<PageAnswers>()
+                   Pages = new List<PageAnswers>(),
+                   Path = page.PageSlug
                }));
 
             _mockElementMapper.Setup(_ => _.GetAnswerValue(It.Is<IElement>(x => x.Properties.QuestionId == "file"), It.IsAny<FormAnswers>()))
@@ -470,7 +475,8 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
                .Returns(JsonConvert.SerializeObject(new FormAnswers
                {
-                   Pages = new List<PageAnswers>()
+                   Pages = new List<PageAnswers>(),
+                   Path = page.PageSlug
                }));
 
             _mockElementMapper.Setup(_ => _.GetAnswerValue(It.Is<IElement>(x => x.Properties.QuestionId == "file"), It.IsAny<FormAnswers>()))
@@ -529,7 +535,8 @@ namespace form_builder_tests.UnitTests.Services
                 .Returns(JsonConvert.SerializeObject(new FormAnswers
                 {
                     Pages = new List<PageAnswers>(),
-                    FormData = new Dictionary<string, object> { { $"{AddAnotherConstants.IncrementKeyPrefix}person", 1 } }
+                    FormData = new Dictionary<string, object> { { $"{AddAnotherConstants.IncrementKeyPrefix}person", 1 } },
+                    Path = page.PageSlug
                 }));
 
             // Act
@@ -570,7 +577,8 @@ namespace form_builder_tests.UnitTests.Services
                .Returns(JsonConvert.SerializeObject(new FormAnswers
                {
                    Pages = new List<PageAnswers>(),
-                   AdditionalFormData = new Dictionary<string, object> { { "additional", "answerData" } }
+                   AdditionalFormData = new Dictionary<string, object> { { "additional", "answerData" } },
+                   Path = page.PageSlug
                }));
 
             _mockElementMapper.Setup(_ => _.GetAnswerValue(It.Is<IElement>(x => x.Properties.QuestionId == "textbox"), It.IsAny<FormAnswers>()))
@@ -616,7 +624,8 @@ namespace form_builder_tests.UnitTests.Services
                 .Returns(JsonConvert.SerializeObject(new FormAnswers
                 {
                     Pages = new List<PageAnswers>(),
-                    PaymentAmount = "10.00"
+                    PaymentAmount = "10.00",
+                    Path = page.PageSlug
                 }));
 
             _mockElementMapper.Setup(_ => _.GetAnswerValue(It.Is<IElement>(x => x.Properties.QuestionId == "textbox"), It.IsAny<FormAnswers>()))
@@ -777,7 +786,8 @@ namespace form_builder_tests.UnitTests.Services
                                 }
                             }
                         }
-                    }
+                    },
+                    Path = page.PageSlug
                 }));
 
             var element = new ElementBuilder()

--- a/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/MappingServiceTests.cs
@@ -6,6 +6,7 @@ using form_builder.Builders;
 using form_builder.Constants;
 using form_builder.Enum;
 using form_builder.Factories.Schema;
+using form_builder.Helpers.PageHelpers;
 using form_builder.Mappers;
 using form_builder.Models;
 using form_builder.Models.Elements;
@@ -27,6 +28,7 @@ namespace form_builder_tests.UnitTests.Services
     {
         private readonly MappingService _service;
         private readonly Mock<ISchemaProvider> _mockSchemaProvider = new();
+        private readonly Mock<IPageHelper> _mockPageHelper = new();
         private readonly Mock<IDistributedCacheWrapper> _mockDistributedCache = new();
         private readonly Mock<IElementMapper> _mockElementMapper = new();
         private readonly Mock<ISchemaFactory> _mockSchemaFactory = new();
@@ -64,7 +66,7 @@ namespace form_builder_tests.UnitTests.Services
 
             _mockHostingEnv.Setup(_ => _.EnvironmentName).Returns("local");
 
-            _service = new MappingService(_mockDistributedCache.Object, _mockElementMapper.Object, _mockSchemaFactory.Object, _mockHostingEnv.Object, _mockLogger.Object);
+            _service = new MappingService(_mockDistributedCache.Object, _mockPageHelper.Object, _mockElementMapper.Object, _mockSchemaFactory.Object, _mockHostingEnv.Object, _mockLogger.Object);
         }
 
         [Fact]


### PR DESCRIPTION
### Description
Issue : Mapping Service > GetFormAnswers would apply "transform" to pages further down the form... 

-) Changed the foreach loop from each page on the form, to a classic for loop to transform each page up to and including the current page, based on the index taken from the page given by the page helper method.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary