### PR TITLE
refactor(Address): add ThrowError when results is null on automatic

### DIFF
--- a/src/Models/Elements/Address.cs
+++ b/src/Models/Elements/Address.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using form_builder.Constants;
 using form_builder.Enum;
@@ -70,6 +71,9 @@ namespace form_builder.Models.Elements
                     return await manualAddressElement.RenderAsync(viewRender, elementHelper, guid, viewModel, page, formSchema, environment, formAnswers, results);
 
                 case LookUpConstants.Automatic:
+                    if (results is null)
+                        throw new ApplicationException("Address::RenderAsync: retrieved automatic address search results cannot be null");
+
                     IsSelect = true;
                     Properties.Value = elementHelper.CurrentValue(Properties.QuestionId, viewModel, formAnswers, AddressConstants.SEARCH_SUFFIX);
 
@@ -78,7 +82,7 @@ namespace form_builder.Models.Elements
                     ManualAddressURL = $"{environment.EnvironmentName.ToReturnUrlPrefix()}/{formSchema.BaseURL}/{page.PageSlug}/manual";
 
                     var selectedAddress = elementHelper.CurrentValue(Properties.QuestionId, viewModel, formAnswers, AddressConstants.SELECT_SUFFIX);
-                    var searchSuffix = (bool)(results?.Count.Equals(1)) ? "address found" : "addresses found";
+                    var searchSuffix = results.Count.Equals(1) ? "address found" : "addresses found";
                     Items = new List<SelectListItem> { new SelectListItem($"{results.Count} {searchSuffix}", string.Empty) };
 
                     results.ForEach((objectResult) =>

--- a/tests/unit-tests/UnitTests/Models/Elements/AddressTests.cs
+++ b/tests/unit-tests/UnitTests/Models/Elements/AddressTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using form_builder.Builders;
 using form_builder.Constants;
@@ -26,7 +27,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
         }
 
         [Fact]
-        public async Task GenerateHtml_ShouldCallViewRenderWithCorrectPartial_WhenAddressSearch()
+        public async Task RenderAsync_ShouldCallViewRenderWithCorrectPartial_WhenAddressSearch()
         {
             //Arrange
             var element = new AddressBuilder()
@@ -60,7 +61,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
         }
 
         [Fact]
-        public async Task GenerateHtml_ShouldCallViewRenderWithCorrectPartial_WhenAddressSelect()
+        public async Task RenderAsync_ShouldCallViewRenderWithCorrectPartial_WhenAddressSelect()
         {
             //Arrange
             var element = new AddressBuilder()
@@ -103,7 +104,7 @@ namespace form_builder_tests.UnitTests.Models.Elements
         }
 
         [Fact]
-        public async Task Address_ShouldGenerateValidUrl_ForAddressSelect()
+        public async Task RenderAsync_ShouldGenerateValidUrl_ForAddressSelect()
         {
             //Arrange
             var callback = new Address();
@@ -156,10 +157,54 @@ namespace form_builder_tests.UnitTests.Models.Elements
         }
 
         [Fact]
+        public async Task RenderAsync_ShouldThrow_ForAddressSelect_IfResultsIsNull()
+        {
+            //Arrange
+            var element = new AddressBuilder()
+                .WithPropertyText("test")
+                .WithQuestionId("address-test")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithPageSlug("page-one")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {LookUpConstants.SubPathViewModelKey,
+                    LookUpConstants.Automatic}
+            };
+
+            var schema = new FormSchemaBuilder()
+                .WithName("form-name")
+                .WithBaseUrl("test")
+                .Build();
+
+            var formAnswers = new FormAnswers();
+
+            //Act
+            var result = await Assert.ThrowsAsync<ApplicationException>(() => element.RenderAsync(_mockIViewRender.Object,
+                _mockElementHelper.Object,
+                string.Empty,
+                viewModel,
+                page,
+                schema,
+                _mockHostingEnv.Object,
+                formAnswers,
+                null));
+            
+
+            //Assert
+            Assert.Equal($"Address::RenderAsync: retrieved automatic address search results cannot be null", result.Message);
+        }
+
+        [Fact]
         public void GetLabelText_ShouldGenerate_CorrectLabel_WhenSummaryLabel_IsDefined()
         {
-            var label = "Custom label";
             //Arrange
+            var label = "Custom label";
+            
             var element = new ElementBuilder()
                 .WithType(EElementType.Address)
                 .WithQuestionId("address-test")


### PR DESCRIPTION
### Description
In response to a Kibana log probably caused by a bot trying to go direct to an address/automatic page, added a Throw to log a better error message

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary