### PR TITLE
fix(warning): warning element not displaying, aria described by

### DIFF
--- a/src/Models/Elements/Element.cs
+++ b/src/Models/Elements/Element.cs
@@ -37,9 +37,7 @@ namespace form_builder.Models.Elements
 
         public virtual string WarningID => $"{QuestionId}-warning";
 
-        public virtual bool DisplayWarning => !string.IsNullOrEmpty(Properties.Warning.Trim());
-
-        public bool DisplayAriaDescribedby => DisplayWarning || DisplayHint || !IsValid;
+        public bool DisplayAriaDescribedby => DisplayHint || !IsValid;
 
         public bool IsValid => validationResult.IsValid;
 
@@ -85,9 +83,7 @@ namespace form_builder.Models.Elements
         private string CreateDescribedByAttributeValue(string key)
         {
             var describedBy = new List<string>();
-            if (DisplayWarning)
-                describedBy.Add(WarningID);
-            else if (DisplayHint)
+            if (DisplayHint)
                 describedBy.Add(HintId);
     
             if (!IsValid)

--- a/src/Views/Shared/Booking/Booking.cshtml
+++ b/src/Views/Shared/Booking/Booking.cshtml
@@ -21,7 +21,7 @@
 
     <partial name="LegendH1" />
 
-    <partial name="WarningText.cshtml" />
+    <partial name="WarningText" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/Booking/Booking.cshtml
+++ b/src/Views/Shared/Booking/Booking.cshtml
@@ -21,7 +21,7 @@
 
     <partial name="LegendH1" />
 
-    <partial name="Warning" />
+    <partial name="WarningText.cshtml" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/DateInput/DateInput.cshtml
+++ b/src/Views/Shared/DateInput/DateInput.cshtml
@@ -29,7 +29,7 @@
 
     <partial name="LegendH1" />
 
-    <partial name="Warning" />
+    <partial name="WarningText" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/DatePicker/DatePicker.cshtml
+++ b/src/Views/Shared/DatePicker/DatePicker.cshtml
@@ -8,7 +8,7 @@
 
     <partial name="LabelH1" />
 
-    <partial name="Warning" />
+    <partial name="WarningText" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/FileUpload/FileUpload.cshtml
+++ b/src/Views/Shared/FileUpload/FileUpload.cshtml
@@ -9,7 +9,7 @@
 
     <partial name="LabelH1" />
 
-    <partial name="Warning" />
+    <partial name="WarningText" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/HtmlElements/Inputs/Checkbox/Checkbox.cshtml
+++ b/src/Views/Shared/HtmlElements/Inputs/Checkbox/Checkbox.cshtml
@@ -5,7 +5,7 @@
 
     <partial name="LegendH1" />
 
-    <partial name="Warning" />
+    <partial name="WarningText" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/HtmlElements/Inputs/Radio/Radio.cshtml
+++ b/src/Views/Shared/HtmlElements/Inputs/Radio/Radio.cshtml
@@ -5,7 +5,7 @@
 
     <partial name="LegendH1" />
 
-    <partial name="Warning" />
+    <partial name="WarningText" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/HtmlElements/Select/Select.cshtml
+++ b/src/Views/Shared/HtmlElements/Select/Select.cshtml
@@ -4,7 +4,7 @@
 
     <partial name="LabelH1" />
 
-    <partial name="Warning" />
+    <partial name="WarningText" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/HtmlElements/Textarea/Textarea.cshtml
+++ b/src/Views/Shared/HtmlElements/Textarea/Textarea.cshtml
@@ -12,7 +12,7 @@
         <div class="govuk-form-group @(!Model.IsValid ? "govuk-form-group--error" : string.Empty)">
             <partial name="LabelH1" />
 
-            <partial name="Warning" />
+            <partial name="WarningText" />
 
             <partial name="InsetText" model="Model.Properties.IAG" />
 
@@ -33,7 +33,7 @@ else
     <div class="govuk-form-group @(!Model.IsValid ? "govuk-form-group--error" : string.Empty)">
         <partial name="LabelH1" />
 
-        <partial name="Warning" />
+        <partial name="WarningText" />
 
         <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/HtmlElements/Textbox/Textbox.cshtml
+++ b/src/Views/Shared/HtmlElements/Textbox/Textbox.cshtml
@@ -31,7 +31,7 @@
 
     <partial name="LabelH1" />
 
-    <partial name="Warning" />
+    <partial name="WarningText" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/src/Views/Shared/IAG/WarningText.cshtml
+++ b/src/Views/Shared/IAG/WarningText.cshtml
@@ -1,6 +1,8 @@
-@if (Model.DisplayWarning && !string.IsNullOrEmpty(Model.Warning))
+@model Element
+
+@if (!string.IsNullOrEmpty(Model.Warning))
 {
-    <div class="govuk-warning-text">
+    <div class="govuk-warning-text" id=@Model.WarningID aria-describedby="@Model.WarningID")>
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
         <strong class="govuk-warning-text__text">
             <span class="govuk-warning-text__assistive">Warning</span>

--- a/src/Views/Shared/TimeInput/TimeInput.cshtml
+++ b/src/Views/Shared/TimeInput/TimeInput.cshtml
@@ -21,7 +21,7 @@
     @Html.BeginFieldSet(Model, new string[] { "govuk-fieldset" })
     <partial name="LegendH1" />
 
-    <partial name="Warning" />
+    <partial name="WarningText" />
 
     <partial name="InsetText" model="Model.Properties.IAG" />
 

--- a/tests/unit-tests/UnitTests/Models/ElementTests.cs
+++ b/tests/unit-tests/UnitTests/Models/ElementTests.cs
@@ -48,30 +48,6 @@ namespace form_builder_tests.UnitTests.Models
             Assert.False(element.DisplayAriaDescribedby);
         }
         
-        [Fact]
-        public void DisplayAriaDescribedby_ShouldReturnFalse_WhenPropertiesWarning_IsEmpty()
-        {
-            // Arrange
-            var element = new ElementBuilder()
-                .WithWarning(string.Empty)
-                .Build();
-
-            // Assert
-            Assert.False(element.DisplayAriaDescribedby);
-        }
-
-        [Fact]
-        public void DisplayAriaDescribedby_ShouldReturnTrue_WhenPropertiesWarning_NotEmpty()
-        {
-            // Arrange
-            var element = new ElementBuilder()
-                .WithWarning("non-empty")
-                .Build();
-
-            // Assert
-            Assert.True(element.DisplayAriaDescribedby);
-        }
-
         [Theory]
         [InlineData(EElementType.Textarea)]
         public void GenerateElementProperties_ShouldReturnCorrectPropertiesFor_TextArea(EElementType type)


### PR DESCRIPTION
### Description
The warning element was no longer showing due to a new view we'd made for the warning property. This new view has now be renamed to 'WarningText.cshtml' in order to distinguish it, and the warning element is now displaying as it was.

A change to the WarningText div so it now has an ID in it and a matching aria-describedby tag. This was to remove the error it was getting in siteimprove.

### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary