### PR TITLE
Fix: Add Check to see if FormData is null before processing the AddAnother elements on Summary and Submission

### DIFF
--- a/src/Helpers/ElementHelpers/ElementHelper.cs
+++ b/src/Helpers/ElementHelpers/ElementHelper.cs
@@ -255,7 +255,8 @@ namespace form_builder.Helpers.ElementHelpers
             if (formAnswers.FormData.Any()) {
                 var formDataIncrementKey = $"{AddAnotherConstants.IncrementKeyPrefix}{addAnotherElement.Properties.QuestionId}";
                 return formAnswers.FormData.ContainsKey(formDataIncrementKey)
-                    ? int.Parse(formAnswers.FormData.GetValueOrDefault(formDataIncrementKey).ToString()) : 0;
+                    ? int.Parse(formAnswers.FormData.GetValueOrDefault(formDataIncrementKey).ToString())
+                    : 0;
             }
 
             return 0;

--- a/src/Helpers/ElementHelpers/ElementHelper.cs
+++ b/src/Helpers/ElementHelpers/ElementHelper.cs
@@ -252,10 +252,13 @@ namespace form_builder.Helpers.ElementHelpers
 
         public int GetAddAnotherNumberOfFieldsets(IElement addAnotherElement, FormAnswers formAnswers)
         {
-            var formDataIncrementKey = $"{AddAnotherConstants.IncrementKeyPrefix}{addAnotherElement.Properties.QuestionId}";
-            return formAnswers.FormData.ContainsKey(formDataIncrementKey)
-                ? int.Parse(formAnswers.FormData.GetValueOrDefault(formDataIncrementKey).ToString())
-                : throw new ApplicationException($"ElementHelper::GetCurrentAddAnotherIncrement, FormData key not found for {formDataIncrementKey}");
+            if (formAnswers.FormData.Any()) {
+                var formDataIncrementKey = $"{AddAnotherConstants.IncrementKeyPrefix}{addAnotherElement.Properties.QuestionId}";
+                return formAnswers.FormData.ContainsKey(formDataIncrementKey)
+                    ? int.Parse(formAnswers.FormData.GetValueOrDefault(formDataIncrementKey).ToString()) : 0;
+            }
+
+            return 0;
         }
 
         public async Task<Dictionary<string, string>> GenerateSummaryAnswers(List<IElement> formSchemaQuestions, Page page, FormAnswers formAnswers, bool ignoreDynamicallyGeneratedElements)

--- a/src/Services/MappingService/MappingService.cs
+++ b/src/Services/MappingService/MappingService.cs
@@ -228,9 +228,10 @@ namespace form_builder.Services.MappingService
 
         private async Task<IDictionary<string, dynamic>> CheckAndCreateForAddAnother(string target, IElement element, FormAnswers formAnswers, IDictionary<string, dynamic> obj)
         {
+            if (!formAnswers.FormData.Any() || !formAnswers.FormData.ContainsKey($"{AddAnotherConstants.IncrementKeyPrefix}{element.Properties.QuestionId}"))
+                return obj;
+            
             var savedIncrementValue = formAnswers.FormData[$"{AddAnotherConstants.IncrementKeyPrefix}{element.Properties.QuestionId}"].ToString();
-            if (string.IsNullOrEmpty(savedIncrementValue))
-                throw new ApplicationException($"MappingService::CheckAndCreateForAddAnother, Fieldset increment value not found in FormData in saved answers for questionId {element.Properties.QuestionId}");
 
             var numberOfIncrements = int.Parse(savedIncrementValue);
             var answers = new List<IDictionary<string, dynamic>>();

--- a/tests/unit-tests/UnitTests/Helpers/ElementHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/ElementHelperTests.cs
@@ -917,7 +917,7 @@ namespace form_builder_tests.UnitTests.Helpers
         }
 
         [Fact]
-        public void GetAddAnotherNumberOfFieldsets_ShouldThrowApplicationException_WhenFormDataDoesnotContainKey()
+        public void GetAddAnotherNumberOfFieldsets_ShouldReturnZero_WhenFormDataDoesnotContainKey()
         {
             // Arrange
             var element = new ElementBuilder()
@@ -942,8 +942,8 @@ namespace form_builder_tests.UnitTests.Helpers
                 },
             };
 
-            var result = Assert.Throws<ApplicationException>(() => _elementHelper.GetAddAnotherNumberOfFieldsets(element, formAnswers));
-            Assert.Equal($"ElementHelper::GetCurrentAddAnotherIncrement, FormData key not found for {AddAnotherConstants.IncrementKeyPrefix}test-id", result.Message);
+            var result = _elementHelper.GetAddAnotherNumberOfFieldsets(element, formAnswers);
+            Assert.Equal(0, result);
         }
     }
 }


### PR DESCRIPTION
### Description
Fix for the issue that causes forms with an AddAnother element to throw an exception if the AddAnother element has been skipped entirely.

 - Add functionality inside 'GetNumberOfFieldSets' that will return 0 instead of throw an error in the case that the AddAnother element doesn't exist within FormData.
 - Add early exit condition inside 'CreateAndCheckAddAnother' if element doesn't exsist within FormData.
 - Clean up existing test.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary