### PR TITLE
fix(AddAnother): fix broken AddAnother, change FormData to be removed when all optional fields empty

### DIFF
--- a/src/Helpers/PageHelpers/IPageHelper.cs
+++ b/src/Helpers/PageHelpers/IPageHelper.cs
@@ -23,6 +23,8 @@ namespace form_builder.Helpers.PageHelpers
 
         void SaveFormData(string key, object value, string guid, string formName);
 
+        void RemoveFormData(string key, string guid, string formName);
+
         void SaveNonQuestionAnswers(Dictionary<string, object> values, string form, string path, string guid);
 
         List<Answers> SaveFormFileAnswers(List<Answers> answers, IEnumerable<CustomFormFile> files, bool isMultipleFileUploadElementType, PageAnswers currentAnswersForFileUpload);

--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -245,6 +245,17 @@ namespace form_builder.Helpers.PageHelpers
             _distributedCache.SetStringAsync(guid, JsonConvert.SerializeObject(convertedAnswers));
         }
 
+        public void RemoveFormData(string key, string guid, string formName)
+        {
+            var convertedAnswers = GetSavedAnswers(guid);
+
+            if (convertedAnswers.FormData.ContainsKey(key))
+                convertedAnswers.FormData.Remove(key);
+
+            convertedAnswers.FormName = formName;
+            _distributedCache.SetStringAsync(guid, JsonConvert.SerializeObject(convertedAnswers));
+        }
+
         public void SaveNonQuestionAnswers(Dictionary<string, object> values, string form, string path, string guid)
         {
             if (!values.Any())

--- a/src/Services/AddAnotherService/AddAnotherService.cs
+++ b/src/Services/AddAnotherService/AddAnotherService.cs
@@ -51,14 +51,29 @@ namespace form_builder.Services.AddAnotherService
                 if (!string.IsNullOrEmpty(removeKey))
                     currentIncrement--;
 
-                var isOptionalAndEmpty = addAnotherElement.Properties.Elements.All(
-                    subElement => subElement.Properties.Optional &&
-                                  string.IsNullOrEmpty(viewModel[$"{subElement.Properties.QuestionId}:{currentIncrement}:"]));
+                if (!addEmptyFieldset && 
+                    string.IsNullOrEmpty(removeKey) && 
+                    addAnotherElement.Properties.Elements.All(subElement => subElement.Properties.Optional))
+                {
+                    var allOptionalElementsEmpty = true;
+                    for (int i = 1; i <= currentIncrement; i++)
+                    {
+                        allOptionalElementsEmpty = addAnotherElement.Properties.Elements.All(
+                            subElement => string.IsNullOrEmpty(viewModel[$"{subElement.Properties.QuestionId}:{i}:"]));
 
-                if (currentIncrement.Equals(1) && isOptionalAndEmpty)
-                    currentIncrement = 0;
+                        if (!allOptionalElementsEmpty)
+                            break;
+                    }
 
-                _pageHelper.SaveFormData(formDataIncrementKey, currentIncrement, guid, baseForm.BaseURL);
+                    if (allOptionalElementsEmpty)
+                        _pageHelper.RemoveFormData(formDataIncrementKey, guid, baseForm.BaseURL);
+                    else
+                        _pageHelper.SaveFormData(formDataIncrementKey, currentIncrement, guid, baseForm.BaseURL);
+                }
+                else
+                {
+                    _pageHelper.SaveFormData(formDataIncrementKey, currentIncrement, guid, baseForm.BaseURL);
+                }
             }
 
             if (!string.IsNullOrEmpty(removeKey))

--- a/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
+++ b/tests/unit-tests/UnitTests/Helpers/PageHelperTests.cs
@@ -1350,5 +1350,32 @@ namespace form_builder_tests.UnitTests.Helpers
             _mockDistributedCache.Verify(_ => _.GetString(sessionGuid), Times.Once);
             _mockDistributedCache.Verify(_ => _.SetStringAsync(sessionGuid, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
+
+        [Fact]
+        public void RemoveFormData_ShouldRemoveFormDataForKey()
+        {
+            // Arrange
+            var callbackCacheProvider = string.Empty;
+            var mockData = JsonConvert.SerializeObject(new FormAnswers
+            {
+                Path = "page-one",
+                Pages = new List<PageAnswers>(),
+                FormData = new Dictionary<string, object> { {"key", 1} }
+            });
+
+            _mockDistributedCache.Setup(_ => _.GetString(It.IsAny<string>()))
+                .Returns(mockData);
+
+            _mockDistributedCache
+                .Setup(_ => _.SetStringAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Callback<string, string, CancellationToken>((x, y, z) => callbackCacheProvider = y);
+
+            // Act
+            _pageHelper.RemoveFormData("key", "guid", "form-name");
+            var callbackModel = JsonConvert.DeserializeObject<FormAnswers>(callbackCacheProvider);
+
+            // Assert
+            Assert.False(callbackModel.FormData.ContainsKey("key"));
+        }
     }
 }

--- a/tests/unit-tests/UnitTests/Services/AddAnotherServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/AddAnotherServiceTests.cs
@@ -169,14 +169,14 @@ namespace form_builder_tests.UnitTests.Services
         }
 
         [Fact]
-        public async Task ProcessAddAnother_ShouldSetIncrementToZero_And_SaveFormDataIncrement_WhenOptionalAddAnotherLeftEmpty()
+        public async Task ProcessAddAnother_ShouldRemoveFormData_WhenOptionalAddAnotherLeftEmpty()
         {
             // Arrange
             var formAnswers = new FormAnswers
             {
                 FormData = new Dictionary<string, object>
                 {
-                    { $"{AddAnotherConstants.IncrementKeyPrefix}person", 0 }
+                    { $"{AddAnotherConstants.IncrementKeyPrefix}person", 3 }
                 }
             };
 
@@ -187,7 +187,13 @@ namespace form_builder_tests.UnitTests.Services
             var viewModel = new Dictionary<string, dynamic>
             {
                 {
-                    "question:0:", null
+                    "question:1:", null
+                },
+                {
+                    "question:2:", null
+                },
+                {
+                    "question:3:", null
                 }
             };
 
@@ -201,6 +207,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Textbox)
                 .WithLabel("Name")
                 .WithQuestionId("question")
+                .WithOptional(true)
                 .Build();
 
             addAnotherElement.Properties.Elements = new List<IElement> { textboxElement };
@@ -220,7 +227,7 @@ namespace form_builder_tests.UnitTests.Services
             await _addAnotherService.ProcessAddAnother(viewModel, page, baseSchema, Guid.NewGuid().ToString(), "page-one");
 
             // Assert
-            _mockPageHelper.Verify(_ => _.SaveFormData($"{AddAnotherConstants.IncrementKeyPrefix}person", 0, It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _mockPageHelper.Verify(_ => _.RemoveFormData($"{AddAnotherConstants.IncrementKeyPrefix}person",It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
### Description
* add PageHelper method to remove FormData
* amend logic to do the optional and empty check inside the if
* instead of setting the FormData to 0, it now gets removed if all elements are optional and empty
* update unit tests


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary