### PR TITLE
Manual address override

### DIFF
--- a/src/Validators/ManualAddressValidator.cs
+++ b/src/Validators/ManualAddressValidator.cs
@@ -48,12 +48,15 @@ namespace form_builder.Validators
                     addressPostcodeMessage = ValidationConstants.POSTCODE_INCORRECT_FORMAT;
                     addressPostcodeValid = false;
                 }
-                else 
+                else if(!AddressConstants.POSTCODE_REGEX.IsMatch(valueAddressPostcode))
                 {
                     addressPostcodeMessage = ValidationConstants.POSTCODE_INCORRECT_FORMAT;
                     addressPostcodeValid = false;
                 }
             }
+                
+
+            
 
             var isValid = addressLine1Valid && addressTownValid && addressPostcodeValid;
 

--- a/src/Validators/ManualAddressValidator.cs
+++ b/src/Validators/ManualAddressValidator.cs
@@ -33,22 +33,26 @@ namespace form_builder.Validators
                 : null;
 
             var addressPostcodeMessage = string.Empty;
-            var addressPostcodeValid = true;
+            var addressPostcodeValid = true;    
 
             if (string.IsNullOrEmpty(valueAddressPostcode))
             {
                 addressPostcodeMessage = ValidationConstants.POSTCODE_EMPTY;
                 addressPostcodeValid = false;
             }
-            else if (!AddressConstants.STOCKPORT_POSTCODE_REGEX.IsMatch(valueAddressPostcode) && element.Properties.StockportPostcode)
+
+            if (element.Properties.ValidatePostcode)
             {
-                addressPostcodeMessage = ValidationConstants.POSTCODE_INCORRECT_FORMAT;
-                addressPostcodeValid = false;
-            }
-            else if (!AddressConstants.POSTCODE_REGEX.IsMatch(valueAddressPostcode))
-            {
-                addressPostcodeMessage = ValidationConstants.POSTCODE_INCORRECT_FORMAT;
-                addressPostcodeValid = false;
+                if (!AddressConstants.STOCKPORT_POSTCODE_REGEX.IsMatch(valueAddressPostcode) && element.Properties.StockportPostcode)
+                {
+                    addressPostcodeMessage = ValidationConstants.POSTCODE_INCORRECT_FORMAT;
+                    addressPostcodeValid = false;
+                }
+                else 
+                {
+                    addressPostcodeMessage = ValidationConstants.POSTCODE_INCORRECT_FORMAT;
+                    addressPostcodeValid = false;
+                }
             }
 
             var isValid = addressLine1Valid && addressTownValid && addressPostcodeValid;


### PR DESCRIPTION
### Description
Added a small tweak to allow the ValidaatePostcode glad, which potentially allows overseas postal/zip codes to work with manual address validation


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary