### PR TITLE
feat(ExternalData): add condition for Pages.Any()

### DIFF
--- a/src/Services/RetrieveExternalDataService/RetrieveExternalDataService.cs
+++ b/src/Services/RetrieveExternalDataService/RetrieveExternalDataService.cs
@@ -99,9 +99,12 @@ namespace form_builder.Services.RetrieveExternalDataService
                 }
             }
 
-            mappingData.FormAnswers.Pages
-                .FirstOrDefault(_ => _.PageSlug.Equals(mappingData.FormAnswers.Path, StringComparison.OrdinalIgnoreCase))
-                .Answers.AddRange(answers);
+            if (mappingData.FormAnswers.Pages.Any())
+            {
+                mappingData.FormAnswers.Pages
+                    .First(_ => _.PageSlug.Equals(mappingData.FormAnswers.Path, StringComparison.OrdinalIgnoreCase))
+                    .Answers.AddRange(answers);
+            }
 
             await _distributedCache.SetStringAsync(sessionGuid, JsonConvert.SerializeObject(mappingData.FormAnswers), CancellationToken.None);
         }


### PR DESCRIPTION
### Description
We were hitting errors on using Retrieve External Data on the first page as a Get action type... as there were no pages available to add these answers to.

It shouldn't brake any existing forms as it's just checking if something exists before acting on it, which would throw an error if it didn't exist. Safe enough and helps us out with the way we need to use Retrieve External Data.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary