### PR TITLE
feat(TagParser): add Hint to FormAnswer and FormData TagParsers

### DIFF
--- a/src/TagParsers/FormAnswerTagParser.cs
+++ b/src/TagParsers/FormAnswerTagParser.cs
@@ -22,6 +22,9 @@ namespace form_builder.TagParsers
                 if (!string.IsNullOrEmpty(element.Properties?.Text))
                     element.Properties.Text = Parse(element.Properties.Text, answersDictionary, Regex);
 
+                if (!string.IsNullOrEmpty(element.Properties?.Hint))
+                    element.Properties.Hint = Parse(element.Properties.Hint, answersDictionary, Regex);
+
                 return element;
             }).ToList();
 

--- a/src/TagParsers/FormDataTagParser.cs
+++ b/src/TagParsers/FormDataTagParser.cs
@@ -22,6 +22,9 @@ namespace form_builder.TagParsers
                 if (!string.IsNullOrEmpty(element.Properties?.Text))
                     element.Properties.Text = Parse(element.Properties.Text, answersDictionary, Regex);
 
+                if (!string.IsNullOrEmpty(element.Properties?.Hint))
+                    element.Properties.Hint = Parse(element.Properties.Hint, answersDictionary, Regex);
+
                 return element;
             }).ToList();
 

--- a/tests/unit-tests/UnitTests/TagParsers/FormAnswerTagParserTests.cs
+++ b/tests/unit-tests/UnitTests/TagParsers/FormAnswerTagParserTests.cs
@@ -129,6 +129,42 @@ namespace form_builder_tests.UnitTests.TagParsers
         }
 
         [Fact]
+        public async Task Parse_ShouldReturnUpdatedValueForHint_WhenReplacingSingleValue()
+        {
+            var expectedString = "this value testfirstname should be replaced with name question";
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithHint("this value {{QUESTION:firstname}} should be replaced with name question")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "testfirstname"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Hint);
+        }
+
+        [Fact]
         public async Task Parse_ShouldReturnUpdatedValue_WhenReplacingMultipleValues()
         {
             var expectedString = "this value testfirstname should be replaced with firstname and this testlastname with lastname";
@@ -169,6 +205,46 @@ namespace form_builder_tests.UnitTests.TagParsers
             Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
         }
 
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValueForHint_WhenReplacingMultipleValues()
+        {
+            var expectedString = "this value testfirstname should be replaced with firstname and this testlastname with lastname";
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithHint("this value {{QUESTION:firstname}} should be replaced with firstname and this {{QUESTION:lastname}} with lastname")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "testfirstname"
+                            },
+                            new()
+                            {
+                                QuestionId = "lastname",
+                                Response = "testlastname"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Hint);
+        }
 
         [Fact]
         public async Task Parse_ShouldCallFormatter_WhenProvided()

--- a/tests/unit-tests/UnitTests/TagParsers/FormDataTagParserTests.cs
+++ b/tests/unit-tests/UnitTests/TagParsers/FormDataTagParserTests.cs
@@ -140,6 +140,58 @@ namespace form_builder_tests.UnitTests.TagParsers
             Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
         }
 
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValueForHint_WhenReplacingSingleValue()
+        {
+            var expectedString = "this value testfirstname should be replaced with name question";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.Textbox)
+               .WithHint("this value {{FORMDATA:firstname}} should be replaced with name question")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                AdditionalFormData = new Dictionary<string, object>
+                {
+                    { "firstname", "testfirstname"}
+                }
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Hint);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValueForHint_WhenReplacingMultipleValues()
+        {
+            var expectedString = "this value testfirstname should be replaced with firstname and this testlastname with lastname";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.Textbox)
+               .WithHint("this value {{FORMDATA:firstname}} should be replaced with firstname and this {{FORMDATA:lastname}} with lastname")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                AdditionalFormData = new Dictionary<string, object>
+                {
+                    { "firstname", "testfirstname"},
+                    { "lastname", "testlastname"}
+                }
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Hint);
+        }
 
         [Fact]
         public async Task Parse_ShouldCallFormatter_WhenProvided()


### PR DESCRIPTION
### Description
Add the ability to use FormAnswer and FormData TagParsers in Element Hints


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary