### PR TITLE
chore(views): remove bold tag from radio with hint text

### DIFF
--- a/src/Views/Shared/HtmlElements/Inputs/Radio/RadioOptions.cshtml
+++ b/src/Views/Shared/HtmlElements/Inputs/Radio/RadioOptions.cshtml
@@ -32,8 +32,6 @@
 <div class="govuk-radios@(Model.Properties.Options.Any(_ => _.HasConditionalElement) ? " govuk-radios--conditional" : "")" data-module="govuk-radios">
 	@for (var i = 0; i < Model.Properties.Options.Count; i++)
 	{
-		var strongLabel = Model.Properties.Options[i].HasHint ? "govuk-label--s" : null;
-
 		@if (Model.Properties.Options[i].HasDivider)
 		{
 			<div class="govuk-radios__divider">@Model.Properties.Options[i].Divider</div>
@@ -49,7 +47,7 @@
 				   @(Model.Properties.Checked || Model.Properties.Value.Contains(Model.Properties.Options[i].Value) ? "checked" : string.Empty)
 				   @(Model.Properties.Options.Any(_ => _.HasConditionalElement) ? $"data-aria-controls=conditional-{i}{fieldsetIncrement}-{questionID}" : string.Empty) />
 
-			<label class="govuk-label govuk-radios__label @strongLabel"
+			<label class="govuk-label govuk-radios__label"
 				   for="@Model.GetListItemId(i)">
 				@Html.Raw(Model.Properties.Options[i].Text)
 			</label>


### PR DESCRIPTION
### Description
Currently, if we have hint text on a radio button, the a bold tag is added to the html input.
![image](https://user-images.githubusercontent.com/58711354/190164533-81286d86-206c-45ce-bca3-5f6a7d992131.png)
This isn't in line with the exemplar from [gov.uk design system](https://design-system.service.gov.uk/components/radios/), which has it remaining at the same thickness.
![image](https://user-images.githubusercontent.com/58711354/190165650-9d665a20-27fb-4402-9319-6523d35332e1.png)



### Checklist
- [x] Code compiles correctly
- [x] All tests passing