### PR TITLE
fix(CivicaPayResponse): changes string to bool

### DIFF
--- a/src/Providers/PaymentProvider/CivicaPayProvider.cs
+++ b/src/Providers/PaymentProvider/CivicaPayProvider.cs
@@ -82,8 +82,10 @@ namespace form_builder.Providers.PaymentProvider
             if (!civicaResponse.IsSuccessStatusCode)
                 throw new Exception($"CivicaPayProvider::GeneratePaymentUrl, CivicaPay gateway response with a non ok status code {civicaResponse.StatusCode}, HttpResponse: {JsonConvert.SerializeObject(civicaResponse)}");
 
-            if (civicaResponse.ResponseContent.Success.Equals("false"))
+            if (!civicaResponse.ResponseContent.Success)
+            {
                 throw new Exception($"CivicaPayProvider::GeneratePaymentUrl, CivicaPay gateway responded with a non successful response from the provider, {civicaResponse.ResponseContent.ResponseCode}, Summary: {civicaResponse.ResponseContent.ErrorMessage} - {civicaResponse.ResponseContent.ErrorSummary}, HttpResponse: {JsonConvert.SerializeObject(civicaResponse)}");
+            }
 
             return _civicaPayGateway.GetPaymentUrl(civicaResponse.ResponseContent.BasketReference, civicaResponse.ResponseContent.BasketToken, reference);
         }

--- a/src/form-builder.csproj
+++ b/src/form-builder.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="StockportGovUK.AspNetCore.Attributes.TokenAuthentication" Version="1.0.0" />
     <PackageReference Include="StockportGovUK.AspNetCore.Logging.Elasticsearch.Aws" Version="1.0.0" />
     <PackageReference Include="StockportGovUK.AspNetCore.Middleware.ExceptionHandling" Version="2.0.2" />
-    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="10.4.2" />
+    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="11.0.0-prerelease-167" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/tests/unit-tests/UnitTests/Providers/PaymentProvider/CivicaPayProviderTests.cs
+++ b/tests/unit-tests/UnitTests/Providers/PaymentProvider/CivicaPayProviderTests.cs
@@ -34,7 +34,7 @@ namespace form_builder_tests.UnitTests.Providers.PaymentProvider
                 .Returns(new HostString("www.test.com"));
 
             _mockCivicaPayGateway.Setup(_ => _.CreateImmediateBasketAsync(It.IsAny<CreateImmediateBasketRequest>()))
-                .ReturnsAsync(new HttpResponse<CreateImmediateBasketResponse> { IsSuccessStatusCode = true, StatusCode = HttpStatusCode.OK, ResponseContent = new CreateImmediateBasketResponse { BasketReference = "testRef", BasketToken = "testBasketToken", Success = "true" } });
+                .ReturnsAsync(new HttpResponse<CreateImmediateBasketResponse> { IsSuccessStatusCode = true, StatusCode = HttpStatusCode.OK, ResponseContent = new CreateImmediateBasketResponse { BasketReference = "testRef", BasketToken = "testBasketToken", Success = true } });
 
             _civicaPayConfig.Setup(_ => _.Value).Returns(new CivicaPaymentConfiguration { CustomerId = "testId", ApiPassword = "test" });
 
@@ -72,7 +72,7 @@ namespace form_builder_tests.UnitTests.Providers.PaymentProvider
                 {
                     StatusCode = HttpStatusCode.OK,
                     IsSuccessStatusCode = true,
-                    ResponseContent = new CreateImmediateBasketResponse { Success = "false" }
+                    ResponseContent = new CreateImmediateBasketResponse { Success = false }
                 });
 
             var result = await Assert.ThrowsAsync<Exception>(() => _civicaPayProvider.GeneratePaymentUrl("form", "page", "ref12345", "0101010-1010101", new PaymentInformation { FormName = new[] { "form" }, Settings = new Settings() }));

--- a/tests/unit-tests/form-builder-tests-unit.csproj
+++ b/tests/unit-tests/form-builder-tests-unit.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="105.0.5195.5200" />
     <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.48" />
-    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="10.4.2" />
+    <PackageReference Include="StockportGovUK.NetStandard.Gateways" Version="11.0.0-prerelease-167" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Description
Update Gateways to a pre-release to test in "int", with the Civica Pay Response corrected to be a bool property and not a string.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary