### PR TITLE
fix(DynamicLookupPageTransformFactory): add missing full stops to the…

### DIFF
--- a/src/Factories/Transform/UserSchema/DynamicLookupPageTransformFactory.cs
+++ b/src/Factories/Transform/UserSchema/DynamicLookupPageTransformFactory.cs
@@ -70,12 +70,12 @@ namespace form_builder.Factories.Transform.UserSchema
 
             if (lookupOptionsResult.SelectExactly > 1)
             {
-                element.Properties.Hint = $"Select <b>{lookupOptionsResult.SelectExactly}</b> options";
+                element.Properties.Hint = $"Select <b>{lookupOptionsResult.SelectExactly}</b> options.";
                 element.Properties.CustomValidationMessage = $"Select {lookupOptionsResult.SelectExactly} options";
             }
             else if (lookupOptionsResult.SelectExactly is 1)
             {
-                element.Properties.Hint = $"Select <b>{lookupOptionsResult.SelectExactly}</b> option";
+                element.Properties.Hint = $"Select <b>{lookupOptionsResult.SelectExactly}</b> option.";
                 element.Properties.CustomValidationMessage = $"Select {lookupOptionsResult.SelectExactly} option";
             }
         }

--- a/tests/unit-tests/UnitTests/Factories/Transform/DynamicLookupPageTransformFactoryTests.cs
+++ b/tests/unit-tests/UnitTests/Factories/Transform/DynamicLookupPageTransformFactoryTests.cs
@@ -246,7 +246,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
             var result = await _dynamicLookupPageTransformFactory.Transform(page, new FormAnswers());
 
             // Assert
-            Assert.Equal("Select <b>1</b> option", result.Elements.FirstOrDefault().Properties.Hint);
+            Assert.Equal("Select <b>1</b> option.", result.Elements.FirstOrDefault().Properties.Hint);
             Assert.Equal("Select 1 option", result.Elements.FirstOrDefault().Properties.CustomValidationMessage);
             Assert.Equal(1, result.Elements.FirstOrDefault().Properties.SelectExactly);
         }
@@ -287,7 +287,7 @@ namespace form_builder_tests.UnitTests.Factories.Transform
             var result = await _dynamicLookupPageTransformFactory.Transform(page, new FormAnswers());
 
             // Assert
-            Assert.Equal("Select <b>2</b> options", result.Elements.FirstOrDefault().Properties.Hint);
+            Assert.Equal("Select <b>2</b> options.", result.Elements.FirstOrDefault().Properties.Hint);
             Assert.Equal("Select 2 options", result.Elements.FirstOrDefault().Properties.CustomValidationMessage);
             Assert.Equal(2, result.Elements.FirstOrDefault().Properties.SelectExactly);
         }


### PR DESCRIPTION
… Hint for select exactly

### Description
Added full stops to the end of the Hint
Update unit tests


### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary