### PR TITLE
fix(Booking): add Limit Date to cache keys

### DIFF
--- a/src/Services/BookingService/BookingService.cs
+++ b/src/Services/BookingService/BookingService.cs
@@ -76,7 +76,10 @@ namespace form_builder.Services.BookingService
             var appointmentType = bookingElement.Properties.AppointmentTypes
                 .GetAppointmentTypeForEnvironment(_environment.EnvironmentName);
 
-            var bookingInformationCacheKey = $"{bookingElement.Properties.QuestionId}:{appointmentType.AppointmentId}:{appointmentType.OptionalResources.CreateKeyFromResources()}:{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var bookingInformationCacheKey = $"{bookingElement.Properties.QuestionId}:{appointmentType.AppointmentId}:" + 
+                                             $"{bookingElement.Properties.LimitNextAvailableFromDate}:" +
+                                             $"{appointmentType.OptionalResources.CreateKeyFromResources()}:" +
+                                             $"{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
 
             var cachedAnswers = _distributedCache.GetString(sessionGuid);
             FormAnswers convertedAnswers = new();
@@ -195,7 +198,10 @@ namespace form_builder.Services.BookingService
             if (appointmentType.NeedsAppointmentIdMapping)
                 _mappingService.MapAppointmentId(appointmentType, convertedAnswers);
 
-            var bookingInformationCacheKey = $"{bookingElement.Properties.QuestionId}:{appointmentType.AppointmentId}:{appointmentType.OptionalResources.CreateKeyFromResources()}:{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var bookingInformationCacheKey = $"{bookingElement.Properties.QuestionId}:{appointmentType.AppointmentId}:" +
+                                             $"{bookingElement.Properties.LimitNextAvailableFromDate}:" +
+                                             $"{appointmentType.OptionalResources.CreateKeyFromResources()}:" +
+                                             $"{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
 
             var appointmentTimes = await _bookingProviders.Get(bookingElement.Properties.BookingProvider)
                 .GetAvailability(new AvailabilityRequest
@@ -277,7 +283,10 @@ namespace form_builder.Services.BookingService
 
         private async Task<BookingNextAvailabilityEntity> RetrieveNextAvailability(IElement bookingElement, IBookingProvider bookingProvider, AppointmentType appointmentType)
         {
-            var bookingNextAvailabilityCachedKey = $"{bookingElement.Properties.BookingProvider}-{bookingElement.Properties.QuestionId}-{appointmentType.AppointmentId}{appointmentType.OptionalResources.CreateKeyFromResources()}";
+            var bookingNextAvailabilityCachedKey = $"{bookingElement.Properties.BookingProvider}-{bookingElement.Properties.QuestionId}-" +
+                                                   $"{bookingElement.Properties.LimitNextAvailableFromDate}-" +
+                                                   $"{appointmentType.AppointmentId}{appointmentType.OptionalResources.CreateKeyFromResources()}";
+
             var bookingNextAvailabilityCachedResponse = _distributedCache.GetString(bookingNextAvailabilityCachedKey);
             if (bookingNextAvailabilityCachedResponse is not null)
                 return JsonConvert.DeserializeObject<BookingNextAvailabilityEntity>(bookingNextAvailabilityCachedResponse);
@@ -327,7 +336,10 @@ namespace form_builder.Services.BookingService
                 var appointmentType = element.Properties.AppointmentTypes
                     .GetAppointmentTypeForEnvironment(_environment.EnvironmentName);
 
-                var bookingInformationCacheKey = $"{appointmentType.AppointmentId}:{appointmentType.OptionalResources.CreateKeyFromResources()}:{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+                var bookingInformationCacheKey = $"{element.Properties.QuestionId}:{appointmentType.AppointmentId}:" +
+                                                 $"{element.Properties.LimitNextAvailableFromDate}:" +
+                                                 $"{appointmentType.OptionalResources.CreateKeyFromResources()}:" +
+                                                 $"{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
 
                 var cachedBookingInformation = JsonConvert.DeserializeObject<BookingInformation>(convertedAnswers.FormData[$"{bookingInformationCacheKey}"].ToString());
                 var bookingInformation = new List<object> { cachedBookingInformation };

--- a/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
@@ -171,7 +171,7 @@ namespace form_builder_tests.UnitTests.Services
                     FormData = new Dictionary<string, object>
                     {
                         {
-                            $"bookingQuestion:{appointmentId}::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}", cachedBookingInfo
+                            $"bookingQuestion:{appointmentId}:::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}", cachedBookingInfo
                         }
                     }
                 }));
@@ -204,7 +204,7 @@ namespace form_builder_tests.UnitTests.Services
         {
             var guid = Guid.NewGuid();
             var date = DateTime.Today.AddDays(-2);
-            var bookingCacheKey = $"bookingQuestion:{guid}::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var bookingCacheKey = $"bookingQuestion:{guid}:::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
 
             _bookingProvider.Setup(_ => _.NextAvailability(It.IsAny<AvailabilityRequest>()))
                 .ReturnsAsync(new AvailabilityDayResponse { Date = date });
@@ -239,7 +239,7 @@ namespace form_builder_tests.UnitTests.Services
 
             _bookingProvider.Verify(_ => _.NextAvailability(It.Is<AvailabilityRequest>(_ => _.AppointmentId.Equals(guid))), Times.Once);
             _bookingProvider.Verify(_ => _.GetAvailability(It.Is<AvailabilityRequest>(_ => _.AppointmentId.Equals(guid))), Times.Once);
-            _mockDistributedCache.Verify(_ => _.SetStringAsync(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion-{guid}")), It.IsAny<string>(), It.Is<int>(_ => _.Equals(_cacheConfig.Booking)), It.IsAny<CancellationToken>()), Times.Once);
+            _mockDistributedCache.Verify(_ => _.SetStringAsync(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion--{guid}")), It.IsAny<string>(), It.Is<int>(_ => _.Equals(_cacheConfig.Booking)), It.IsAny<CancellationToken>()), Times.Once);
             _mockPageHelper.Verify(_ => _.SaveFormData(It.Is<string>(_ => _.Equals(bookingCacheKey)), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
@@ -277,13 +277,13 @@ namespace form_builder_tests.UnitTests.Services
         }
 
         [Fact]
-        public async Task Get_Should_Save_NextAvailability_InCache_Using_Valid_Key_With_OptionalResources_WhenSupplied()
+        public async Task Get_Should_Save_NextAvailability_InCache_Using_Valid_Key_With_OptionalResources_AndLimitDate_WhenSupplied()
         {
             var guid = Guid.NewGuid();
             var date = DateTime.Today.AddDays(-2);
             var bookingResourceId = Guid.NewGuid();
             var bookingResourceQuantity = 3;
-            var bookingCacheKey = $"bookingQuestion:{guid}:-3{bookingResourceId}:{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var bookingCacheKey = $"bookingQuestion:{guid}:01-01-2022:-3{bookingResourceId}:{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
 
             _bookingProvider.Setup(_ => _.NextAvailability(It.IsAny<AvailabilityRequest>()))
                 .ReturnsAsync(new AvailabilityDayResponse { Date = date });
@@ -304,6 +304,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithType(EElementType.Booking)
                 .WithBookingProvider("testBookingProvider")
                 .WithQuestionId("bookingQuestion")
+                .WithLimitNextAvailableFromDate("01-01-2022")
                 .WithAppointmentType(appointmentType)
                 .Build();
 
@@ -324,7 +325,7 @@ namespace form_builder_tests.UnitTests.Services
 
             _bookingProvider.Verify(_ => _.NextAvailability(It.Is<AvailabilityRequest>(_ => _.AppointmentId.Equals(guid))), Times.Once);
             _bookingProvider.Verify(_ => _.GetAvailability(It.Is<AvailabilityRequest>(_ => _.AppointmentId.Equals(guid))), Times.Once);
-            _mockDistributedCache.Verify(_ => _.SetStringAsync(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion-{guid}-{bookingResourceQuantity}{bookingResourceId}")), It.IsAny<string>(), It.Is<int>(_ => _.Equals(_cacheConfig.Booking)), It.IsAny<CancellationToken>()), Times.Once);
+            _mockDistributedCache.Verify(_ => _.SetStringAsync(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion-01-01-2022-{guid}-{bookingResourceQuantity}{bookingResourceId}")), It.IsAny<string>(), It.Is<int>(_ => _.Equals(_cacheConfig.Booking)), It.IsAny<CancellationToken>()), Times.Once);
             _mockPageHelper.Verify(_ => _.SaveFormData(It.Is<string>(_ => _.Equals(bookingCacheKey)), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
@@ -356,7 +357,7 @@ namespace form_builder_tests.UnitTests.Services
             Assert.True(result.BookingHasNoAvailableAppointments);
             _bookingProvider.Verify(_ => _.NextAvailability(It.Is<AvailabilityRequest>(_ => _.AppointmentId.Equals(guid))), Times.Once);
             _bookingProvider.Verify(_ => _.GetAvailability(It.Is<AvailabilityRequest>(_ => _.AppointmentId.Equals(guid))), Times.Never);
-            _mockDistributedCache.Verify(_ => _.SetStringAsync(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion-{guid}")), It.IsAny<string>(), It.Is<int>(_ => _.Equals(_cacheConfig.BookingNoAppointmentsAvailable)), It.IsAny<CancellationToken>()), Times.Once);
+            _mockDistributedCache.Verify(_ => _.SetStringAsync(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion--{guid}")), It.IsAny<string>(), It.Is<int>(_ => _.Equals(_cacheConfig.BookingNoAppointmentsAvailable)), It.IsAny<CancellationToken>()), Times.Once);
             _mockPageHelper.Verify(_ => _.SaveFormData(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
@@ -364,7 +365,7 @@ namespace form_builder_tests.UnitTests.Services
         public async Task Get_Should_NotCall_NextAvailability_OnBookingProvider_WhenBookingInformationIs_InCache()
         {
             var guid = Guid.NewGuid();
-            var bookingCacheKey = $"bookingQuestion:{guid}::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var bookingCacheKey = $"bookingQuestion:{guid}:::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
 
             _bookingProvider.Setup(_ => _.NextAvailability(It.IsAny<AvailabilityRequest>()))
                 .ReturnsAsync(new AvailabilityDayResponse());
@@ -375,7 +376,7 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals("guid"))))
                 .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new FormAnswers { FormData = new Dictionary<string, object>() }));
 
-            _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion-{guid}"))))
+            _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion--{guid}"))))
                 .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new BookingNextAvailabilityEntity { DayResponse = new AvailabilityDayResponse() }));
 
             var element = new ElementBuilder()
@@ -395,7 +396,7 @@ namespace form_builder_tests.UnitTests.Services
             Assert.False(result.BookingHasNoAvailableAppointments);
             _bookingProvider.Verify(_ => _.NextAvailability(It.Is<AvailabilityRequest>(_ => _.AppointmentId.Equals(guid))), Times.Never);
             _bookingProvider.Verify(_ => _.GetAvailability(It.Is<AvailabilityRequest>(_ => _.AppointmentId.Equals(guid))), Times.Once);
-            _mockDistributedCache.Verify(_ => _.SetStringAsync(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion-{guid}")), It.IsAny<string>(), It.Is<int>(_ => _.Equals(_cacheConfig.Booking)), It.IsAny<CancellationToken>()), Times.Never);
+            _mockDistributedCache.Verify(_ => _.SetStringAsync(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion--{guid}")), It.IsAny<string>(), It.Is<int>(_ => _.Equals(_cacheConfig.Booking)), It.IsAny<CancellationToken>()), Times.Never);
             _mockPageHelper.Verify(_ => _.SaveFormData(It.Is<string>(_ => _.Equals(bookingCacheKey)), It.IsAny<object>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
@@ -414,7 +415,7 @@ namespace form_builder_tests.UnitTests.Services
             _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals("guid"))))
                 .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new FormAnswers { FormData = new Dictionary<string, object>() }));
 
-            _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion-{guid}"))))
+            _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion--{guid}"))))
                 .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new BookingNextAvailabilityEntity { DayResponse = new AvailabilityDayResponse { AppointmentTimes = new List<AppointmentTime> { new() { StartTime = startTime, EndTime = endTime } } } }));
 
             var element = new ElementBuilder()
@@ -446,7 +447,7 @@ namespace form_builder_tests.UnitTests.Services
             var questionId = "bookingQuestion";
             var appointmentId = new Guid("022ebc92-1c51-4a68-a079-f6edefc63a07");
             string sessionGuid = "session";
-            var bookingCacheKey = $"{questionId}:{appointmentId}::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var bookingCacheKey = $"{questionId}:{appointmentId}:::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
 
             _sessionHelper.Setup(_ => _.GetSessionGuid()).Returns(sessionGuid);
 
@@ -509,7 +510,7 @@ namespace form_builder_tests.UnitTests.Services
             var questionId = "bookingQuestion";
             var appointmentId = new Guid("022ebc92-1c51-4a68-a079-f6edefc63a07");
             string sessionGuid = "session";
-            var bookingCacheKey = $"bookingQuestion:{Guid.Empty}::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var bookingCacheKey = $"bookingQuestion:{Guid.Empty}:::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
 
             _sessionHelper.Setup(_ => _.GetSessionGuid()).Returns(sessionGuid);
 
@@ -682,7 +683,7 @@ namespace form_builder_tests.UnitTests.Services
             var questionId = "bookingQuestion";
             var appointmentId = new Guid("022ebc92-1c51-4a68-a079-f6edefc63a07");
             string sessionGuid = "session";
-            var bookingCacheKey = $"{questionId}:{appointmentId}::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var bookingCacheKey = $"{questionId}:{appointmentId}:::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
 
             _sessionHelper.Setup(_ => _.GetSessionGuid()).Returns(sessionGuid);
 
@@ -904,7 +905,7 @@ namespace form_builder_tests.UnitTests.Services
                 .WithPage(page)
                 .Build();
 
-            var bookingInformationCacheKey = $"bookingQuestion:{guid}::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
+            var bookingInformationCacheKey = $"bookingQuestion:{guid}:::{BookingConstants.APPOINTMENT_TYPE_SEARCH_RESULTS}";
             _bookingProvider.Setup(_ => _.GetAvailability(It.IsAny<AvailabilityRequest>()))
                 .ReturnsAsync(new List<AvailabilityDayResponse> { new() });
 


### PR DESCRIPTION
### Description
Add Limit Date to the Booking cache keys for if the user goes back and changes their answer
Update unit tests


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary