### PR TITLE
fix(PaymentWorkflow): add PreProcessSubmission to PaymentWorkflow

### DIFF
--- a/src/Workflows/PaymentWorkflow/PaymentWorkflow.cs
+++ b/src/Workflows/PaymentWorkflow/PaymentWorkflow.cs
@@ -27,6 +27,8 @@ namespace form_builder.Workflows.PaymentWorkflow
             if (string.IsNullOrEmpty(sessionGuid))
                 throw new ApplicationException("A Session GUID was not provided.");
 
+            await _submitService.PreProcessSubmission(form, sessionGuid);
+
             var data = await _mappingService.Map(sessionGuid, form);
             var paymentReference = await _submitService.PaymentSubmission(data, form, sessionGuid);
 

--- a/tests/unit-tests/UnitTests/Workflows/PaymentWorkflowtests.cs
+++ b/tests/unit-tests/UnitTests/Workflows/PaymentWorkflowtests.cs
@@ -46,6 +46,7 @@ namespace form_builder_tests.UnitTests.Workflows
 
             // Assert
             _mappingService.Verify(_ => _.Map(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _submitService.Verify(_ => _.PreProcessSubmission(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             _submitService.Verify(_ => _.PaymentSubmission(It.IsAny<MappingEntity>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             _payService.Verify(_ => _.ProcessPayment(It.IsAny<MappingEntity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }


### PR DESCRIPTION
### Description
Forms with payments but no CRM Case (ie we generate a reference) weren't having a reference generated. Added in a call to PreProcessSubmission to enable the reference generation


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary