### PR TITLE
fix(PageHelper): remove generated reference from cached data if it al…

### DIFF
--- a/src/Helpers/PageHelpers/PageHelper.cs
+++ b/src/Helpers/PageHelpers/PageHelper.cs
@@ -204,8 +204,13 @@ namespace form_builder.Helpers.PageHelpers
                 convertedAnswers = JsonConvert.DeserializeObject<FormAnswers>(formData);
 
             if (isGenerated)
-                convertedAnswers.AdditionalFormData.Add(generatedReferenceMappingId, caseReference);
+            {
+                if (convertedAnswers.AdditionalFormData.ContainsKey(generatedReferenceMappingId))
+                    convertedAnswers.AdditionalFormData.Remove(generatedReferenceMappingId);
 
+                convertedAnswers.AdditionalFormData.Add(generatedReferenceMappingId, caseReference);
+            }
+            
             convertedAnswers.CaseReference = caseReference;
             _distributedCache.SetStringAsync(guid, JsonConvert.SerializeObject(convertedAnswers));
         }


### PR DESCRIPTION
…ready exists so new one can be saved

### Description
For forms that have payments and use formbuilder to generate a reference, there was an error when going back in the form after going to the Civica Pay pages because a new reference was generated but the key already existed. This fix checks if the key exists and if it does it removes the old reference before trying to save the new one.

I know there are no unit tests, there aren't any for any of this method. I will do these in my next First Responder duty


### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary