### PR TITLE
patch: fix incorrect expiration in distributed cache helper

### DIFF
--- a/src/Config/appsettings.json
+++ b/src/Config/appsettings.json
@@ -78,7 +78,7 @@
     "PaymentConfiguration": 5,
     "FormJson": 5,
     "FileUpload": 60,
-    "Document": 30,
+    "Document": 60,
     "Index": 43200,
     "Booking": 5,
     "BookingNoAppointmentsAvailable": 15

--- a/src/Providers/StorageProvider/DistributedCacheWrapper.cs
+++ b/src/Providers/StorageProvider/DistributedCacheWrapper.cs
@@ -50,7 +50,7 @@ namespace form_builder.Providers.StorageProvider
         {
             var distributedCacheOptions = new DistributedCacheEntryOptions();
 
-            distributedCacheOptions.SlidingExpiration = TimeSpan.FromMinutes(_distributedCacheExpirationConfiguration.UserData);
+            distributedCacheOptions.SlidingExpiration = TimeSpan.FromMinutes(expiration);
 
             return _distributedCache.SetStringAsync(key, value, distributedCacheOptions, token);
         }


### PR DESCRIPTION
### Description
In a rush to fix issues with session timeouts the cache helper was updated in a way which effects the caching of some elements of the system (JSON, Bookings etc.) that it shouldn't.

### Checklist
- [x] Code compiles correctly
- [] Created tests for the new changes
- [x] All tests passing
- [] Extended the README / documentation, if necessary