### PR TITLE
chore(document-creator): add xtext formatter to pdf content

### DIFF
--- a/src/Providers/DocumentCreation/Generic/TextfileDocumentCreator.cs
+++ b/src/Providers/DocumentCreation/Generic/TextfileDocumentCreator.cs
@@ -1,5 +1,6 @@
 using form_builder.Enum;
 using PdfSharpCore.Drawing;
+using PdfSharpCore.Drawing.Layout;
 using PdfSharpCore.Pdf;
 
 namespace form_builder.Providers.DocumentCreation.Generic
@@ -52,14 +53,20 @@ namespace form_builder.Providers.DocumentCreation.Generic
             pdfPage.TrimMargins.Left = 50;
 			pdfPage.TrimMargins.Top = 50;
 
-			XGraphics gfx = XGraphics.FromPdfPage(pdfPage);
-            gfx.DrawString("Submitted answers for " + formName, new XFont("Verdana", 18, XFontStyle.Bold), XBrushes.Black, new XRect(0, 0, pdfPage.Width, pdfPage.Height), XStringFormats.TopCenter);
+            XGraphics graph = XGraphics.FromPdfPage(pdfPage);
+
+            var tf = new XTextFormatter(graph);
+            var format = new XStringFormat();
+            format.LineAlignment = XLineAlignment.Near;
+            format.Alignment = XStringAlignment.Near;
+
+            tf.DrawString($"Submitted answers for {formName}", new XFont("Verdana", 18, XFontStyle.Bold), XBrushes.Black, new XRect(0, 0, pdfPage.Width, pdfPage.Height), XStringFormats.TopCenter);
 
             int y = 40;
 
             fileContent.ForEach((line) =>
             {
-                gfx.DrawString(line, new XFont("Verdana", 16, XFontStyle.Regular), XBrushes.Black, new XRect(0, y, pdfPage.Width - 10, pdfPage.Height), XStringFormats.TopLeft);
+                tf.DrawString(line, new XFont("Verdana", 16, XFontStyle.Regular), XBrushes.Black, new XRect(0, y, pdfPage.Width - 10, pdfPage.Height), format);
                 y += 20;
             });
 

--- a/src/Providers/DocumentCreation/Generic/TextfileDocumentCreator.cs
+++ b/src/Providers/DocumentCreation/Generic/TextfileDocumentCreator.cs
@@ -55,18 +55,18 @@ namespace form_builder.Providers.DocumentCreation.Generic
 
             XGraphics graph = XGraphics.FromPdfPage(pdfPage);
 
-            var tf = new XTextFormatter(graph);
+            var textFormatter = new XTextFormatter(graph);
             var format = new XStringFormat();
             format.LineAlignment = XLineAlignment.Near;
             format.Alignment = XStringAlignment.Near;
 
-            tf.DrawString($"Submitted answers for {formName}", new XFont("Verdana", 18, XFontStyle.Bold), XBrushes.Black, new XRect(0, 0, pdfPage.Width, pdfPage.Height), XStringFormats.TopCenter);
+            textFormatter.DrawString($"Submitted answers for {formName}", new XFont("Verdana", 18, XFontStyle.Bold), XBrushes.Black, new XRect(0, 0, pdfPage.Width, pdfPage.Height), XStringFormats.TopCenter);
 
             int y = 40;
 
             fileContent.ForEach((line) =>
             {
-                tf.DrawString(line, new XFont("Verdana", 16, XFontStyle.Regular), XBrushes.Black, new XRect(0, y, pdfPage.Width - 10, pdfPage.Height), format);
+                textFormatter.DrawString(line, new XFont("Verdana", 16, XFontStyle.Regular), XBrushes.Black, new XRect(0, y, pdfPage.Width - 10, pdfPage.Height), format);
                 y += 20;
             });
 


### PR DESCRIPTION
### Description
The PDFs created by the SubmitAndEmail in form builder has text overflowing from the page. This should add a word wrap to stop that from happening.


### Checklist
- [x] Code compiles correctly
- [x] All tests passing