### PR TITLE
fix(SubmitAndEmail): remove duplicate mapping and transforms

### DIFF
--- a/src/Helpers/EmailHelpers/EmailHelper.cs
+++ b/src/Helpers/EmailHelpers/EmailHelper.cs
@@ -24,11 +24,6 @@ namespace form_builder.Helpers.EmailHelpers
 
         public async Task<EmailConfiguration> GetEmailInformation(string form)
         {
-            var sessionGuid = _sessionHelper.GetSessionGuid();
-            var mappingEntity = await _mappingService.Map(sessionGuid, form);
-            if (mappingEntity is null)
-                throw new Exception($"{nameof(EmailHelper)}::{nameof(GetEmailInformation)}: No mapping entity found for {form}");
-
             var emailConfigList = await _emailConfigProvider.Get<List<EmailConfiguration>>();
             var formEmailConfig = emailConfigList.FirstOrDefault(_ => _.FormName.Any(_ => _.Equals(form)));
 

--- a/src/Helpers/EmailHelpers/EmailHelper.cs
+++ b/src/Helpers/EmailHelpers/EmailHelper.cs
@@ -1,7 +1,5 @@
 ﻿using form_builder.Configuration;
-using form_builder.Helpers.Session;
 using form_builder.Providers.Transforms.EmailConfiguration;
-using form_builder.Services.MappingService;
 
 namespace form_builder.Helpers.EmailHelpers
 {
@@ -9,18 +7,8 @@ namespace form_builder.Helpers.EmailHelpers
     {
 
         private readonly IEmailConfigurationTransformDataProvider _emailConfigProvider;
-        private readonly ISessionHelper _sessionHelper;
-        private readonly IMappingService _mappingService;
 
-        public EmailHelper(
-           ISessionHelper sessionHelper,
-           IMappingService mappingService,
-           IEmailConfigurationTransformDataProvider emailConfigProvider)
-        {
-            _sessionHelper = sessionHelper;
-            _mappingService = mappingService;
-            _emailConfigProvider = emailConfigProvider;
-        }
+        public EmailHelper(IEmailConfigurationTransformDataProvider emailConfigProvider) => _emailConfigProvider = emailConfigProvider;
 
         public async Task<EmailConfiguration> GetEmailInformation(string form)
         {

--- a/src/Services/DocumentService/DocumentSummaryService.cs
+++ b/src/Services/DocumentService/DocumentSummaryService.cs
@@ -25,22 +25,14 @@ namespace form_builder.Services.DocumentService
             _schemaFactory = schemaFactory;
         }
 
-        public async Task<byte[]> GenerateDocument(DocumentSummaryEntity entity)
-        {
-            var journeyPages = entity.FormSchema.GetReducedPages(entity.PreviousAnswers);
-            foreach (var page in journeyPages)
-            {
-                await _schemaFactory.TransformPage(page, entity.PreviousAnswers);
-            }
-
-            return entity.DocumentType switch
+        public async Task<byte[]> GenerateDocument(DocumentSummaryEntity entity) =>
+            entity.DocumentType switch
             {
                 EDocumentType.Txt => await GenerateTextFile(entity.PreviousAnswers, entity.FormSchema),
                 EDocumentType.Html => await GenerateHtmlFile(entity.PreviousAnswers, entity.FormSchema),
                 EDocumentType.Pdf => await GeneratePdfFile(entity.PreviousAnswers, entity.FormSchema),
                 _ => throw new Exception("DocumentSummaryService::GenerateDocument, Unknown Document type request for Summary"),
             };
-        }
 
         private async Task<byte[]> GenerateTextFile(FormAnswers formAnswers, FormSchema formSchema)
         {

--- a/src/Services/EmailSubmitService/EmailSubmitService.cs
+++ b/src/Services/EmailSubmitService/EmailSubmitService.cs
@@ -51,7 +51,6 @@ namespace form_builder.Services.EmailSubmitService
                 data.FormAnswers.CaseReference = _referenceNumberProvider.GetReference(data.BaseForm.ReferencePrefix);
                 reference = data.FormAnswers.CaseReference;
                 _pageHelper.SaveCaseReference(sessionGuid, reference);
-                data = await _mappingService.Map(sessionGuid, form);
             }
 
             var doc = _documentSummaryService.GenerateDocument(

--- a/tests/unit-tests/UnitTests/Services/DocumentSummaryServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/DocumentSummaryServiceTests.cs
@@ -72,16 +72,6 @@ namespace form_builder_tests.UnitTests.Services
         }
 
         [Fact]
-        public async Task GenerateDocument_ShouldCallSchemaFactory()
-        {
-            // Act
-            await _documentSummaryService.GenerateDocument(new DocumentSummaryEntity { FormSchema = _formSchema, DocumentType = EDocumentType.Txt, PreviousAnswers = _formAnswers });
-
-            // Assert
-            _mockSchemaFactory.Verify(_ => _.TransformPage(It.IsAny<Page>(), It.IsAny<FormAnswers>()), Times.AtLeastOnce);
-        }
-
-        [Fact]
         public async Task GenerateDocument_ShouldCallDocumentCreationHelper_WhenDocumentTypeIsTxt()
         {
             // Act


### PR DESCRIPTION
### Description
EmailSubmitService - remove the .Map as it's already been done once in the Worlfow
EmailHelper - remove the _sessionHelper and _mappingService + related calls as they weren't used or needed
DocumentSummaryService - remove the Transform on the ReducedPages as the Transform has already been done in the Workflow and it was causing duplication of AddAnother elements

Update unit tests accordingly


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary