### PR TITLE
chore(answerbuilder/doccreation): removing the words (optional) when …

### DIFF
--- a/src/Builders/SummaryAnswerBuilder.cs
+++ b/src/Builders/SummaryAnswerBuilder.cs
@@ -14,9 +14,9 @@ namespace form_builder.Builders.Document
                 return;
 
             if (type.Equals(EElementType.FileUpload) || type.Equals(EElementType.MultipleFileUpload))
-                _filesData.Add($"<b>{question}</b><br/>{answer}");
+                _filesData.Add($"<b>{question.Replace("(optional)", "")}</b><br/>{answer}");
             else
-                _data.Add($"<b>{question}</b><br/>{answer}");
+                _data.Add($"<b>{question.Replace("(optional)", "")}</b><br/>{answer}");
         }
 
         public void AddQuestion(string question)

--- a/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
+++ b/src/Helpers/DocumentCreation/DocumentCreationHelper.cs
@@ -75,7 +75,7 @@ namespace form_builder.Helpers.DocumentCreation
                     }
                     else
                     {
-                        summaryBuilder.AddQuestion(question.GetLabelText(page.Title));
+                        summaryBuilder.AddQuestion(question.GetLabelText(page.Title).Replace("(optional)", ""));
                         summaryBuilder.AddAnswer(answer);
                     }
 


### PR DESCRIPTION
### Description
<!-- Please explain the changes you made here. -->
Removing the unnecessary (optional) from Questions found in the SubmitAndEmail action. It leaves the (optional) in the summary element.
 

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary