### PR TITLE
chore(ispastdateafterrelative): new validation etc

### DIFF
--- a/src/Builders/ElementBuilder.cs
+++ b/src/Builders/ElementBuilder.cs
@@ -602,6 +602,14 @@ namespace form_builder.Builders
             return this;
         }
 
+        public ElementBuilder WithIsPastDateAfterRelative(string value, string validMessage = "")
+        {
+            _property.IsPastDateAfterRelative = value;
+            _property.ValidationMessageIsPastDateAfterRelative = validMessage;
+
+            return this;
+        }
+
         public ElementBuilder WithDecimal(bool value)
         {
             _property.Decimal = value;

--- a/src/Models/Properties/ElementProperties/DateProperty.cs
+++ b/src/Models/Properties/ElementProperties/DateProperty.cs
@@ -40,5 +40,7 @@
         public string ValidationMessageIsFutureDateBeforeRelative { get; set; } = string.Empty;
 
         public string ValidationMessageIsPastDateBeforeRelative { get; set; } = string.Empty;
+
+        public string ValidationMessageIsPastDateAfterRelative { get; set; } = string.Empty;
     }
 }

--- a/src/Utils/Startup/ServiceCollectionExtensions.cs
+++ b/src/Utils/Startup/ServiceCollectionExtensions.cs
@@ -125,6 +125,7 @@ namespace form_builder.Utils.Startup
             services.AddTransient<IElementValidator, DateInputIsFutureDateAfterRelativeValidator>();
             services.AddTransient<IElementValidator, DateInputIsFutureDateBeforeRelativeValidator>();
             services.AddTransient<IElementValidator, DateInputIsPastDateBeforeRelativeValidator>();
+            services.AddTransient<IElementValidator, DateInputIsPastDateAfterRelativeValidator>();
             services.AddTransient<IElementValidator, EmailElementValidator>();
             services.AddTransient<IElementValidator, PostcodeElementValidator>();
             services.AddTransient<IElementValidator, StockportPostcodeElementValidator>();

--- a/src/Validators/DateInputIsPastDateAfterRelativeValidator.cs
+++ b/src/Validators/DateInputIsPastDateAfterRelativeValidator.cs
@@ -1,0 +1,54 @@
+﻿using form_builder.Constants;
+using form_builder.Enum;
+using form_builder.Helpers.RelativeDateHelper;
+using form_builder.Models;
+using form_builder.Models.Elements;
+
+namespace form_builder.Validators
+{
+    public class DateInputIsPastDateAfterRelativeValidator : IElementValidator
+    {
+        private IRelativeDateHelper _relativeDateHelper;
+
+        public DateInputIsPastDateAfterRelativeValidator(IRelativeDateHelper relativeDateHelper) => _relativeDateHelper = relativeDateHelper;
+
+        public ValidationResult Validate(Element element, Dictionary<string, dynamic> viewModel, FormSchema baseForm)
+        {
+            if (!element.Type.Equals(EElementType.DateInput) || string.IsNullOrEmpty(element.Properties.IsPastDateAfterRelative))
+                return new ValidationResult { IsValid = true };
+
+            if (_relativeDateHelper.HasValidDate(element, viewModel))
+            {
+                var relativeDate = _relativeDateHelper.GetRelativeDate(element.Properties.IsPastDateAfterRelative);
+                var maximumDate = DateTime.Today;
+
+                if (relativeDate.Unit.Equals(DateInputConstants.YEAR))
+                    maximumDate = DateTime.Today.AddYears(-relativeDate.Ammount);
+
+                if (relativeDate.Unit.Equals(DateInputConstants.MONTH))
+                    maximumDate = DateTime.Today.AddMonths(-relativeDate.Ammount);
+
+                if (relativeDate.Unit.Equals(DateInputConstants.DAY))
+                    maximumDate = DateTime.Today.AddDays(-relativeDate.Ammount);
+
+                var chosenDate = _relativeDateHelper.GetChosenDate(element, viewModel);
+
+                if (relativeDate.Type.Equals(DateInputConstants.INCLUSIVE) && maximumDate > _relativeDateHelper.GetChosenDate(element, viewModel) ||
+                    relativeDate.Type.Equals(DateInputConstants.EXCLUSIVE) && maximumDate >= _relativeDateHelper.GetChosenDate(element, viewModel))
+                {
+                    return new ValidationResult
+                    {
+                        IsValid = false,
+                        Message = !string.IsNullOrEmpty(element.Properties.ValidationMessageIsPastDateAfterRelative) ? element.Properties.ValidationMessageIsPastDateAfterRelative : "Check the date and try again"
+                    };
+                }
+            }
+
+            return new ValidationResult
+            {
+                IsValid = true,
+                Message = string.Empty
+            };
+        }
+    }
+}

--- a/src/Validators/IntegrityChecks/Elements/DateValidationsCheck.cs
+++ b/src/Validators/IntegrityChecks/Elements/DateValidationsCheck.cs
@@ -35,19 +35,25 @@ namespace form_builder.Validators.IntegrityChecks.Elements
             if (!string.IsNullOrEmpty(element.Properties.IsFutureDateAfterRelative) &&
                 !relativeDateStringRegex.Match(element.Properties.IsFutureDateAfterRelative).Success)
             {
-                result.AddFailureMessage("Property 'IsPastDateBeforeRelative' is invalid");
+                result.AddFailureMessage("Property 'IsFutureDateAfterRelative' is invalid");
             }
 
             if (!string.IsNullOrEmpty(element.Properties.IsFutureDateBeforeRelative) &&
                 !relativeDateStringRegex.Match(element.Properties.IsFutureDateBeforeRelative).Success)
             {
-                result.AddFailureMessage("Property 'IsPastDateBeforeRelative' is invalid");
+                result.AddFailureMessage("Property 'IsFutureDateBeforeRelative' is invalid");
             }
 
             if (!string.IsNullOrEmpty(element.Properties.IsPastDateBeforeRelative) &&
                 !relativeDateStringRegex.Match(element.Properties.IsPastDateBeforeRelative).Success)
             {
                 result.AddFailureMessage("Property 'IsPastDateBeforeRelative' is invalid");
+            }
+
+            if (!string.IsNullOrEmpty(element.Properties.IsPastDateAfterRelative) &&
+               !relativeDateStringRegex.Match(element.Properties.IsPastDateAfterRelative).Success)
+            {
+                result.AddFailureMessage("Property 'IsPastDateAfterRelative' is invalid");
             }
 
             return result;

--- a/tests/unit-tests/UnitTests/Validators/DateInputIsPastDateAfterRelativeValidator.cs
+++ b/tests/unit-tests/UnitTests/Validators/DateInputIsPastDateAfterRelativeValidator.cs
@@ -1,0 +1,644 @@
+﻿using form_builder.Builders;
+using form_builder.Enum;
+using form_builder.Validators;
+using form_builder.Models;
+using Xunit;
+using Moq;
+using form_builder.Helpers.RelativeDateHelper;
+using form_builder.Constants;
+using form_builder.Models.Elements;
+using StockportGovUK.NetStandard.Gateways.Models.RevsAndBens;
+
+namespace form_builder_tests.UnitTests.Validators
+{
+    public class DateInputIsPastDateAfterRelativeValidatorTests
+    {
+        private readonly Mock<IRelativeDateHelper> _mockRelativeDateHelper = new Mock<IRelativeDateHelper>();
+        private readonly DateInputIsPastDateAfterRelativeValidator _dateInputIsPastDateAfterRelativeValidator;
+
+        public DateInputIsPastDateAfterRelativeValidatorTests()
+        {
+            _dateInputIsPastDateAfterRelativeValidator = new(_mockRelativeDateHelper.Object);
+            _mockRelativeDateHelper.Setup(_ => _.HasValidDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(true);
+        }
+
+        [Fact]
+        public void Validate_ShouldCheck_TheElementTypePassedIsNotADateInputElement()
+        {
+            // Arrange
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .Build();
+
+            // Act
+            var result = _dateInputIsPastDateAfterRelativeValidator.Validate(element, null, new FormSchema());
+
+            // Assert
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void Validate_ShouldRun_WhenDateIsOptional()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddDays(4);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate(It.IsAny<string>())).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.DAY,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .Build();
+
+            element.Properties.IsPastDateAfterRelative = "3-d-ex";
+            element.Properties.Optional = true;
+
+            var viewModel = new Dictionary<string, dynamic>();
+
+            // Act
+            _dateInputIsPastDateAfterRelativeValidator.Validate(element, viewModel, new FormSchema());
+
+            // Assert
+            _mockRelativeDateHelper.Verify(_ => _.HasValidDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>()), Times.Once);
+            _mockRelativeDateHelper.Verify(_ => _.GetRelativeDate(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void Validate_ShouldNotShowValidationMessage_WhenDayIsAfterRelativeDate()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddDays(-2);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("3-d-ex")).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.DAY,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("3-d-in")).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.DAY,
+                Type = DateInputConstants.INCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var exclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-d-ex", "Date is too late")
+                .Build();
+
+            var inclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-d-in", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var exclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(exclusiveElement, viewModel, new FormSchema());
+            var inclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(inclusiveElement, viewModel, new FormSchema());
+
+            // Assert
+            Assert.True(exclusiveResult.IsValid);
+            Assert.Equal(string.Empty, exclusiveResult.Message);
+
+            Assert.True(inclusiveResult.IsValid);
+            Assert.Equal(string.Empty, inclusiveResult.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldShowValidationMessage_WhenDayIsEqualRelativeDate_Exclusive()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddDays(-3);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate(It.IsAny<string>())).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.DAY,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-d-ex", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var result = _dateInputIsPastDateAfterRelativeValidator.Validate(element, viewModel, new FormSchema());
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Equal("Date is too late", result.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldNotShowValidationMessage_WhenDayIsEqualRelativeDate_Inclusive()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddDays(-3);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate(It.IsAny<string>())).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.DAY,
+                Type = DateInputConstants.INCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-d-in", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var result = _dateInputIsPastDateAfterRelativeValidator.Validate(element, viewModel, new FormSchema());
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Equal(string.Empty, result.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldShowValidationMessage_WhenDayIsAfterRelativeDate()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddDays(-4);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("3-d-ex")).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.DAY,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("3-d-in")).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.DAY,
+                Type = DateInputConstants.INCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var exclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-d-ex", "Date is too late")
+                .Build();
+
+            var inclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-d-in", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var exclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(exclusiveElement, viewModel, new FormSchema());
+            var inclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(inclusiveElement, viewModel, new FormSchema());
+
+            // Assert
+            Assert.False(exclusiveResult.IsValid);
+            Assert.Equal("Date is too late", exclusiveResult.Message);
+
+            Assert.False(inclusiveResult.IsValid);
+            Assert.Equal("Date is too late", inclusiveResult.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldNotShowValidationMessage_WhenMonthIsAfterRelativeDate()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddDays(+0).AddMonths(-3);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("3-m-ex")).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.MONTH,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("3-m-in")).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.MONTH,
+                Type = DateInputConstants.INCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var exclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-m-ex", "Date is too late")
+                .Build();
+
+            var inclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-m-in", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var exclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(exclusiveElement, viewModel, new FormSchema());
+            var inclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(inclusiveElement, viewModel, new FormSchema());
+
+            // Assert
+            Assert.False(exclusiveResult.IsValid);
+            Assert.Equal("Date is too late", exclusiveResult.Message);
+
+            Assert.True(inclusiveResult.IsValid);
+            Assert.Equal(string.Empty, inclusiveResult.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldShowValidationMessage_WhenMonthIsEqualRelativeDate_Exclusive()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddMonths(-3);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate(It.IsAny<string>())).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.MONTH,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-m-ex", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var result = _dateInputIsPastDateAfterRelativeValidator.Validate(element, viewModel, new FormSchema());
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Equal("Date is too late", result.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldNotShowValidationMessage_WhenMonthIsEqualRelativeDate_Inclusive()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddMonths(-3);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate(It.IsAny<string>())).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.MONTH,
+                Type = DateInputConstants.INCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-m-in", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var result = _dateInputIsPastDateAfterRelativeValidator.Validate(element, viewModel, new FormSchema());
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Equal(string.Empty, result.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldShowValidationMessage_WhenMonthIsBeforeRelativeDate()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddMonths(-2);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("3-m-ex")).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.MONTH,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("3-m-in")).Returns(new RelativeDate()
+            {
+                Ammount = 3,
+                Unit = DateInputConstants.MONTH,
+                Type = DateInputConstants.INCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var exclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-m-ex", "Date is too late")
+                .Build();
+
+            var inclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("3-m-in", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var exclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(exclusiveElement, viewModel, new FormSchema());
+            var inclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(inclusiveElement, viewModel, new FormSchema());
+
+            // Assert
+            Assert.True(exclusiveResult.IsValid);
+            Assert.Equal(string.Empty, exclusiveResult.Message);
+
+            Assert.True(inclusiveResult.IsValid);
+            Assert.Equal(string.Empty, inclusiveResult.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldNotShowValidationMessage_WhenYearAfterRelativeDate()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddYears(-3);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("2-y-ex")).Returns(new RelativeDate()
+            {
+                Ammount = 2,
+                Unit = DateInputConstants.YEAR,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("2-y-in")).Returns(new RelativeDate()
+            {
+                Ammount = 2,
+                Unit = DateInputConstants.YEAR,
+                Type = DateInputConstants.INCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var inclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("2-y-ex", "Date is too late")
+                .Build();
+
+            var exclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("2-y-in", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var inclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(inclusiveElement, viewModel, new FormSchema());
+            var exclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(exclusiveElement, viewModel, new FormSchema());
+
+            // Assert
+            Assert.False(inclusiveResult.IsValid);
+            Assert.Equal("Date is too late", inclusiveResult.Message);
+
+            Assert.False(exclusiveResult.IsValid);
+            Assert.Equal("Date is too late", exclusiveResult.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldShowValidationMessage_WhenYearIsBeforeRelativeDate()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddYears(-1);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("2-y-ex")).Returns(new RelativeDate()
+            {
+                Ammount = 2,
+                Unit = DateInputConstants.YEAR,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("2-y-in")).Returns(new RelativeDate()
+            {
+                Ammount = 2,
+                Unit = DateInputConstants.YEAR,
+                Type = DateInputConstants.INCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var exclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("2-y-ex", "Date is too late")
+                .Build();
+
+            var inclusiveElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("2-y-in", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var inclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(inclusiveElement, viewModel, new FormSchema());
+            var exclusiveResult = _dateInputIsPastDateAfterRelativeValidator.Validate(exclusiveElement, viewModel, new FormSchema());
+
+            // Assert
+            Assert.True(exclusiveResult.IsValid);
+            Assert.Equal(string.Empty, exclusiveResult.Message);
+
+            Assert.True(inclusiveResult.IsValid);
+            Assert.Equal(string.Empty, inclusiveResult.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldShowValidationMessage_WhenYearIsEqualRelativeDate_Exclusive()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddYears(-2);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate(It.IsAny<string>())).Returns(new RelativeDate()
+            {
+                Ammount = 2,
+                Unit = DateInputConstants.YEAR,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("2-y-ex", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var result = _dateInputIsPastDateAfterRelativeValidator.Validate(element, viewModel, new FormSchema());
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Equal("Date is too late", result.Message);
+        }
+
+        [Fact]
+        public void Validate_ShouldNotShowValidationMessage_WhenYearIsEqualRelativeDate_Inclusive()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddYears(-2);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate(It.IsAny<string>())).Returns(new RelativeDate()
+            {
+                Ammount = 2,
+                Unit = DateInputConstants.YEAR,
+                Type = DateInputConstants.INCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("2-y-in", "Date is too late")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var result = _dateInputIsPastDateAfterRelativeValidator.Validate(element, viewModel, new FormSchema());
+
+            // Assert
+            Assert.True(result.IsValid);
+            Assert.Equal(string.Empty, result.Message);
+        }
+
+
+        [Fact]
+        public void Validate_ShouldShowDefaultValidationMessage_WhenValidationIsTriggeredAndNoValidationMessageIsSet()
+        {
+            // Arrange
+            var dateToCheck = DateTime.Today.AddDays(-4);
+
+            _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate(It.IsAny<string>())).Returns(new RelativeDate()
+            {
+                Ammount = 2,
+                Unit = DateInputConstants.DAY,
+                Type = DateInputConstants.EXCLUSIVE
+            });
+
+            _mockRelativeDateHelper.Setup(_ => _.GetChosenDate(It.IsAny<Element>(), It.IsAny<Dictionary<string, dynamic>>())).Returns(dateToCheck);
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("test-date")
+                .WithIsPastDateAfterRelative("2-d-ex", "")
+                .Build();
+
+            var viewModel = new Dictionary<string, dynamic>
+            {
+                {"test-date-day", dateToCheck.Day},
+                {"test-date-month", dateToCheck.Month},
+                {"test-date-year", dateToCheck.Year}
+            };
+
+            // Act
+            var result = _dateInputIsPastDateAfterRelativeValidator.Validate(element, viewModel, new FormSchema());
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Equal("Check the date and try again", result.Message);
+        }
+    }
+}

--- a/tests/unit-tests/UnitTests/Validators/DateInputIsPastDateAfterRelativeValidator.cs
+++ b/tests/unit-tests/UnitTests/Validators/DateInputIsPastDateAfterRelativeValidator.cs
@@ -252,7 +252,7 @@ namespace form_builder_tests.UnitTests.Validators
         public void Validate_ShouldNotShowValidationMessage_WhenMonthIsAfterRelativeDate()
         {
             // Arrange
-            var dateToCheck = DateTime.Today.AddDays(+0).AddMonths(-3);
+            var dateToCheck = DateTime.Today.AddMonths(-3);
 
             _mockRelativeDateHelper.Setup(_ => _.GetRelativeDate("3-m-ex")).Returns(new RelativeDate()
             {

--- a/tests/unit-tests/UnitTests/Validators/IntegrityChecks/DateValidationsCheckTests.cs
+++ b/tests/unit-tests/UnitTests/Validators/IntegrityChecks/DateValidationsCheckTests.cs
@@ -141,11 +141,18 @@ namespace form_builder_tests.UnitTests.Validators.IntegrityChecks
                 .WithIsPastDateBeforeRelative(relativeDateString, "message")
                 .Build();
 
+            var pastDateAfterRelativeElement = new ElementBuilder()
+                .WithType(EElementType.DateInput)
+                .WithQuestionId("dateInput")
+                .WithIsPastDateAfterRelative(relativeDateString, "message")
+                .Build();
+
             // Act
             DateValidationsCheck check = new();
             var futureDateAfterRelativeResult = check.Validate(futureDateAfterRelativeElement);
             var futureDateBeforeRelativeResult = check.Validate(futureDateBeforeRelativeElement);
             var pastDateBeforeRelativeRelativeResult = check.Validate(pastDateBeforeRelativeElement);
+            var pastDateAfterRelativeRelativeResult = check.Validate(pastDateAfterRelativeElement);
 
             // Assert
             Assert.False(futureDateAfterRelativeResult.IsValid);
@@ -156,6 +163,9 @@ namespace form_builder_tests.UnitTests.Validators.IntegrityChecks
 
             Assert.False(pastDateBeforeRelativeRelativeResult.IsValid);
             Assert.Collection<string>(pastDateBeforeRelativeRelativeResult.Messages, message => Assert.StartsWith(IntegrityChecksConstants.FAILURE, message));
+
+            Assert.False(pastDateAfterRelativeRelativeResult.IsValid);
+            Assert.Collection<string>(pastDateAfterRelativeRelativeResult.Messages, message => Assert.StartsWith(IntegrityChecksConstants.FAILURE, message));
         }
     }
 }


### PR DESCRIPTION
### Description
The last of the date relative checks. This one ensures that the date is inside the past range,
e.g.    bbbbbbggggg[todaysDate]bbbbbbbbbb

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary