### PR TITLE
fix(maxlengthvalidation): using generic message on over error messages

### DIFF
--- a/src/Validators/MaxLengthvalidator.cs
+++ b/src/Validators/MaxLengthvalidator.cs
@@ -20,7 +20,7 @@ namespace form_builder.Validators
             {
                 var validationMessage = element.Properties.Decimal || element.Properties.Numeric
                     ? $"{element.Properties.Label} must be {element.Properties.MaxLength} digits or less"
-                     : $"{element.Properties.Label} has a maximum length of {element.Properties.MaxLength}";
+                     : $"Shorten the text so it's no longer than {element.Properties.MaxLength} characters";
 
                 return new ValidationResult
                 {

--- a/tests/unit-tests/UnitTests/Validators/MaxLengthValidatorTests.cs
+++ b/tests/unit-tests/UnitTests/Validators/MaxLengthValidatorTests.cs
@@ -23,7 +23,7 @@ namespace form_builder_tests.UnitTests.Validators
 
             var result = _validator.Validate(element, viewModel, new form_builder.Models.FormSchema());
             Assert.False(result.IsValid);
-            Assert.Equal("Label has a maximum length of 20", result.Message);
+            Assert.Equal("Shorten the text so it's no longer than 20 characters", result.Message);
         }
 
         [Fact]


### PR DESCRIPTION
### Description
made a generic validation message appear when too many characters entered into a text area


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary