### PR TITLE
refactor(BookingService): add filter on HasAvailableAppointments

### DIFF
--- a/src/Services/BookingService/BookingService.cs
+++ b/src/Services/BookingService/BookingService.cs
@@ -121,7 +121,7 @@ namespace form_builder.Services.BookingService
             BookingInformation bookingInformation = new()
             {
                 AppointmentTypeId = appointmentType.AppointmentId,
-                Appointments = appointmentTimes,
+                Appointments = appointmentTimes.Where(appointment => appointment.HasAvailableAppointment).ToList(),
                 CurrentSearchedMonth = new DateTime(nextAvailability.DayResponse.Date.Year, nextAvailability.DayResponse.Date.Month, 1),
                 FirstAvailableMonth = new DateTime(nextAvailability.DayResponse.Date.Year, nextAvailability.DayResponse.Date.Month, 1),
                 IsFullDayAppointment = nextAvailability.DayResponse.IsFullDayAppointment
@@ -226,7 +226,7 @@ namespace form_builder.Services.BookingService
             BookingInformation bookingInformation = new()
             {
                 AppointmentTypeId = appointmentType.AppointmentId,
-                Appointments = appointmentTimes,
+                Appointments = appointmentTimes.Where(appointment => appointment.HasAvailableAppointment).ToList(),
                 CurrentSearchedMonth = requestedMonth,
                 FirstAvailableMonth = cachedBookingInformation.FirstAvailableMonth,
                 IsFullDayAppointment = cachedBookingInformation.IsFullDayAppointment,

--- a/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
+++ b/tests/unit-tests/UnitTests/Services/BookingServiceTests.cs
@@ -217,7 +217,17 @@ namespace form_builder_tests.UnitTests.Services
                 .ReturnsAsync(new AvailabilityDayResponse { Date = date });
 
             _bookingProvider.Setup(_ => _.GetAvailability(It.IsAny<AvailabilityRequest>()))
-                .ReturnsAsync(new List<AvailabilityDayResponse> { new() });
+                .ReturnsAsync(new List<AvailabilityDayResponse> 
+                { 
+                    new()
+                    {
+                        Date = date,
+                        AppointmentTimes = new List<AppointmentTime>
+                        {
+                            new()
+                        }
+                    }
+                });
 
             _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals("guid"))))
                 .Returns(JsonConvert.SerializeObject(new FormAnswers { FormData = new Dictionary<string, object>() }));
@@ -296,10 +306,20 @@ namespace form_builder_tests.UnitTests.Services
                 .ReturnsAsync(new AvailabilityDayResponse { Date = date });
 
             _bookingProvider.Setup(_ => _.GetAvailability(It.IsAny<AvailabilityRequest>()))
-                .ReturnsAsync(new List<AvailabilityDayResponse> { new() });
+                .ReturnsAsync(new List<AvailabilityDayResponse>
+                {
+                    new()
+                    {
+                        Date = date,
+                        AppointmentTimes = new List<AppointmentTime>
+                        {
+                            new()
+                        }
+                    }
+                });
 
             _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals("guid"))))
-                .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new FormAnswers { FormData = new Dictionary<string, object>() }));
+                .Returns(JsonConvert.SerializeObject(new FormAnswers { FormData = new Dictionary<string, object>() }));
 
             var appointmentType = new AppointmentTypeBuilder()
                 .WithAppointmentId(guid)
@@ -417,13 +437,27 @@ namespace form_builder_tests.UnitTests.Services
                 .ReturnsAsync(new AvailabilityDayResponse());
 
             _bookingProvider.Setup(_ => _.GetAvailability(It.IsAny<AvailabilityRequest>()))
-                .ReturnsAsync(new List<AvailabilityDayResponse> { new() });
+                .ReturnsAsync(new List<AvailabilityDayResponse>
+                {
+                    new()
+                    {
+                        Date = DateTime.Today.AddDays(2),
+                        AppointmentTimes = new List<AppointmentTime>
+                        {
+                            new()
+                            {
+                                StartTime = startTime,
+                                EndTime = endTime
+                            }
+                        }
+                    }
+                });
 
             _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals("guid"))))
-                .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new FormAnswers { FormData = new Dictionary<string, object>() }));
+                .Returns(JsonConvert.SerializeObject(new FormAnswers { FormData = new Dictionary<string, object>() }));
 
             _mockDistributedCache.Setup(_ => _.GetString(It.Is<string>(_ => _.Equals($"testBookingProvider-bookingQuestion--{guid}"))))
-                .Returns(Newtonsoft.Json.JsonConvert.SerializeObject(new BookingNextAvailabilityEntity { DayResponse = new AvailabilityDayResponse { AppointmentTimes = new List<AppointmentTime> { new() { StartTime = startTime, EndTime = endTime } } } }));
+                .Returns(JsonConvert.SerializeObject(new BookingNextAvailabilityEntity { DayResponse = new AvailabilityDayResponse { AppointmentTimes = new List<AppointmentTime> { new() { StartTime = startTime, EndTime = endTime } } } }));
 
             var element = new ElementBuilder()
                 .WithType(EElementType.Booking)


### PR DESCRIPTION
### Description
As the new Bookings API has admin override options for the internal UI, we now need an extra filter on the availability response before the calendar renders : previously the call only returned dates with availability, now it returns all dates with a bool of available or not 


### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary