### PR TITLE
Document summary issue

### DIFF
--- a/src/Controllers/Document/DocumentController.cs
+++ b/src/Controllers/Document/DocumentController.cs
@@ -6,41 +6,40 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace form_builder.Controllers.Document
 {
-    [Route("document")]
-    public class DocumentController : Controller
-    {
-        private IDocumentWorkflow _documentWorkflow;
-        private ILogger<DocumentController> _logger;
+	[Route("document")]
+	public class DocumentController : Controller
+	{
+		private IDocumentWorkflow _documentWorkflow;
+		private ILogger<DocumentController> _logger;
 
-        public DocumentController(IDocumentWorkflow documentWorkflow, ILogger<DocumentController> logger)
-        {
-            _documentWorkflow = documentWorkflow;
-            _logger = logger;
-        }
+		public DocumentController(IDocumentWorkflow documentWorkflow, ILogger<DocumentController> logger)
+		{
+			_documentWorkflow = documentWorkflow;
+			_logger = logger;
+		}
 
-        [HttpGet]
-        [Route("Summary/{documentType}/{id}")]
-        public async Task<IActionResult> Summary(EDocumentType documentType, Guid id)
-        {
-            if (id.Equals(Guid.Empty))
-                return RedirectToAction("Index", "Error");
+		[HttpGet]
+		[Route("Summary/{documentType}/{id}")]
+		public async Task<IActionResult> Summary(EDocumentType documentType, string id)
+		{
+			if (string.IsNullOrEmpty(id)) return RedirectToAction("Index", "Error");
 
-            try
-            {
-                var result = await _documentWorkflow.GenerateSummaryDocumentAsync(documentType, id);
+			try
+			{
+				var result = await _documentWorkflow.GenerateSummaryDocumentAsync(documentType, id);
 
-                return File(result, documentType.ToContentType(), "summary.txt");
-            }
-            catch (DocumentExpiredException ex)
-            {
-                _logger.LogWarning(ex, ex.Message);
+				return File(result, documentType.ToContentType(), "summary.txt");
+			}
+			catch (DocumentExpiredException ex)
+			{
+				_logger.LogWarning(ex, ex.Message);
 
-                return RedirectToAction("Expired");
-            }
-        }
+				return RedirectToAction("Expired");
+			}
+		}
 
-        [HttpGet]
-        [Route("expired")]
-        public IActionResult Expired() => View();
-    }
+		[HttpGet]
+		[Route("expired")]
+		public IActionResult Expired() => View();
+	}
 }

--- a/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
+++ b/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
@@ -25,7 +25,7 @@ namespace form_builder.Workflows.DocumentWorkflow
             _pageHelper = pageHelper;
         }
 
-        public async Task<byte[]> GenerateSummaryDocumentAsync(EDocumentType documentType, Guid id)
+        public async Task<byte[]> GenerateSummaryDocumentAsync(EDocumentType documentType, string id)
         {
             var previousAnswers = _pageHelper.GetSavedAnswers(id.ToString());
 

--- a/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
+++ b/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
@@ -10,42 +10,42 @@ using Newtonsoft.Json;
 
 namespace form_builder.Workflows.DocumentWorkflow
 {
-    public class DocumentWorkflow : IDocumentWorkflow
-    {
-        private IDocumentSummaryService _documentSummaryService;
-        private readonly IDistributedCacheWrapper _distributedCache;
-        private readonly IPageHelper _pageHelper;
-        private readonly ISchemaFactory _schemaFactory;
+	public class DocumentWorkflow : IDocumentWorkflow
+	{
+		private IDocumentSummaryService _documentSummaryService;
+		private readonly IDistributedCacheWrapper _distributedCache;
+		private readonly IPageHelper _pageHelper;
+		private readonly ISchemaFactory _schemaFactory;
 
-        public DocumentWorkflow(IDocumentSummaryService documentSummaryService, IDistributedCacheWrapper distributedCache, ISchemaFactory schemaFactory, IPageHelper pageHelper)
-        {
-            _documentSummaryService = documentSummaryService;
-            _distributedCache = distributedCache;
-            _schemaFactory = schemaFactory;
-            _pageHelper = pageHelper;
-        }
+		public DocumentWorkflow(IDocumentSummaryService documentSummaryService, IDistributedCacheWrapper distributedCache, ISchemaFactory schemaFactory, IPageHelper pageHelper)
+		{
+			_documentSummaryService = documentSummaryService;
+			_distributedCache = distributedCache;
+			_schemaFactory = schemaFactory;
+			_pageHelper = pageHelper;
+		}
 
-        public async Task<byte[]> GenerateSummaryDocumentAsync(EDocumentType documentType, string id)
-        {
-            var previousAnswers = _pageHelper.GetSavedAnswers(id);
+		public async Task<byte[]> GenerateSummaryDocumentAsync(EDocumentType documentType, string id)
+		{
+			var previousAnswers = _pageHelper.GetSavedAnswers(id);
 
-            if (previousAnswers.FormName is null)
-            {
-                var formData = _distributedCache.GetString($"document-{id}");
+			if (previousAnswers.FormName is null)
+			{
+				var formData = _distributedCache.GetString($"document-{id}");
 
-                if (formData is null)
-                    throw new DocumentExpiredException($"DocumentWorkflow::GenerateSummaryDocument, Previous answers has expired, unable to generate {documentType.ToString()} document for summary");
+				if (formData is null)
+					throw new DocumentExpiredException($"DocumentWorkflow::GenerateSummaryDocument, Previous answers has expired, unable to generate {documentType.ToString()} document for summary");
 
-                previousAnswers = JsonConvert.DeserializeObject<FormAnswers>(formData);
-            }
-            var baseForm = await _schemaFactory.Build(previousAnswers.FormName);
+				previousAnswers = JsonConvert.DeserializeObject<FormAnswers>(formData);
+			}
+			var baseForm = await _schemaFactory.Build(previousAnswers.FormName);
 
-            return await _documentSummaryService.GenerateDocument(new DocumentSummaryEntity
-            {
-                DocumentType = documentType,
-                PreviousAnswers = previousAnswers,
-                FormSchema = baseForm
-            });
-        }
-    }
+			return await _documentSummaryService.GenerateDocument(new DocumentSummaryEntity
+			{
+				DocumentType = documentType,
+				PreviousAnswers = previousAnswers,
+				FormSchema = baseForm
+			});
+		}
+	}
 }

--- a/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
+++ b/src/Workflows/DocumentWorkflow/DocumentWorkflow.cs
@@ -27,11 +27,11 @@ namespace form_builder.Workflows.DocumentWorkflow
 
         public async Task<byte[]> GenerateSummaryDocumentAsync(EDocumentType documentType, string id)
         {
-            var previousAnswers = _pageHelper.GetSavedAnswers(id.ToString());
+            var previousAnswers = _pageHelper.GetSavedAnswers(id);
 
             if (previousAnswers.FormName is null)
             {
-                var formData = _distributedCache.GetString($"document-{id.ToString()}");
+                var formData = _distributedCache.GetString($"document-{id}");
 
                 if (formData is null)
                     throw new DocumentExpiredException($"DocumentWorkflow::GenerateSummaryDocument, Previous answers has expired, unable to generate {documentType.ToString()} document for summary");

--- a/src/Workflows/DocumentWorkflow/IDocumentWorkflow.cs
+++ b/src/Workflows/DocumentWorkflow/IDocumentWorkflow.cs
@@ -4,6 +4,6 @@ namespace form_builder.Workflows.DocumentWorkflow
 {
     public interface IDocumentWorkflow
     {
-        Task<byte[]> GenerateSummaryDocumentAsync(EDocumentType documentType, Guid id);
+        Task<byte[]> GenerateSummaryDocumentAsync(EDocumentType documentType, string id);
     }
 }

--- a/tests/unit-tests/UnitTests/Controllers/DocumentControllerTests.cs
+++ b/tests/unit-tests/UnitTests/Controllers/DocumentControllerTests.cs
@@ -21,39 +21,39 @@ namespace form_builder_tests.UnitTests.Controllers
         }
 
         [Fact]
-        public async Task Summary_ShouldRedirect_ToError_WhenInvalidIdProvider()
+        public async Task Summary_ShouldRedirect_ToError_WhenInvalidIdProviderXX()
         {
-            var result = await _controller.Summary(EDocumentType.Txt, Guid.Empty);
+            var result = await _controller.Summary(EDocumentType.Txt, null);
 
             Assert.IsType<RedirectToActionResult>(result);
-            _mockDocumentWorkflow.Verify(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<Guid>()), Times.Never);
+            _mockDocumentWorkflow.Verify(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<string>()), Times.Never);
         }
-
-        [Fact]
+        	
+		[Fact]
         public async Task Summary_ShouldRedirect_ToExpired_When_ServiceThrows_DocumentExpiredExceptionException()
         {
-            _mockDocumentWorkflow.Setup(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<Guid>()))
+            _mockDocumentWorkflow.Setup(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<string>()))
                 .ThrowsAsync(new DocumentExpiredException("an exception"));
 
-            var result = await _controller.Summary(EDocumentType.Txt, Guid.NewGuid());
+            var result = await _controller.Summary(EDocumentType.Txt, "This is some text");
 
             var redirectResult = Assert.IsType<RedirectToActionResult>(result);
             Assert.Equal("Expired", redirectResult.ActionName);
-            _mockDocumentWorkflow.Verify(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<Guid>()), Times.Once);
+            _mockDocumentWorkflow.Verify(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<string>()), Times.Once);
         }
 
         [Fact]
         public async Task Summary_ShouldReturnFile_OnSuccess()
         {
-            _mockDocumentWorkflow.Setup(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<Guid>()))
+            _mockDocumentWorkflow.Setup(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<string>()))
                 .ReturnsAsync(new byte[0]);
 
-            var result = await _controller.Summary(EDocumentType.Txt, Guid.NewGuid());
+            var result = await _controller.Summary(EDocumentType.Txt, "This is some text");
 
             var fileContentResult = Assert.IsType<FileContentResult>(result);
             Assert.Equal("summary.txt", fileContentResult.FileDownloadName);
             Assert.Equal("text/plain", fileContentResult.ContentType);
-            _mockDocumentWorkflow.Verify(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<Guid>()), Times.Once);
+            _mockDocumentWorkflow.Verify(_ => _.GenerateSummaryDocumentAsync(It.IsAny<EDocumentType>(), It.IsAny<string>()), Times.Once);
         }
     }
 }

--- a/tests/unit-tests/UnitTests/Controllers/DocumentControllerTests.cs
+++ b/tests/unit-tests/UnitTests/Controllers/DocumentControllerTests.cs
@@ -21,7 +21,7 @@ namespace form_builder_tests.UnitTests.Controllers
         }
 
         [Fact]
-        public async Task Summary_ShouldRedirect_ToError_WhenInvalidIdProviderXX()
+        public async Task Summary_ShouldRedirect_ToError_WhenInvalidIdProvider()
         {
             var result = await _controller.Summary(EDocumentType.Txt, null);
 


### PR DESCRIPTION
### Description
Change the doc creation service to use the string being used in the cache storage from the GUID it used to use.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary