### PR TITLE
chore(tagParser): add optional formAnswer

### DIFF
--- a/src/TagParsers/FormAnswerOptionalTagParser.cs
+++ b/src/TagParsers/FormAnswerOptionalTagParser.cs
@@ -1,0 +1,75 @@
+using System.Text.RegularExpressions;
+using form_builder.Models;
+using form_builder.TagParsers.Formatters;
+
+namespace form_builder.TagParsers
+{
+    public class FormAnswerOptionalTagParser : TagParser, ITagParser
+    {
+        private readonly bool allowOptional = true;
+
+        public FormAnswerOptionalTagParser(IEnumerable<IFormatter> formatters) : base(formatters) { }
+
+        public Regex Regex => new Regex("(?<={{)QUESTIONOPT:.*?(?=}})", RegexOptions.Compiled);
+
+        public async Task<Page> Parse(Page page, FormAnswers formAnswers, FormSchema baseForm = null)
+        {
+            var answersDictionary = formAnswers.Pages?.SelectMany(x => x.Answers).ToDictionary(x => x.QuestionId, x => x.Response);
+
+            var leadingParagraphRegexIsMatch = !string.IsNullOrEmpty(page.LeadingParagraph) && Regex.IsMatch(page.LeadingParagraph);
+
+            if (leadingParagraphRegexIsMatch)
+            {
+                page.LeadingParagraph = Parse(page.LeadingParagraph, answersDictionary, Regex, allowOptional);
+            }   
+
+            page.Elements.Select((element) =>
+            {
+                if (!string.IsNullOrEmpty(element.Properties?.Text))
+                    element.Properties.Text = Parse(element.Properties.Text, answersDictionary, Regex, allowOptional);
+
+                if (!string.IsNullOrEmpty(element.Properties?.Hint))
+                    element.Properties.Hint = Parse(element.Properties.Hint, answersDictionary, Regex, allowOptional);
+
+                if (!string.IsNullOrEmpty(element.Properties?.LimitNextAvailableFromDate))
+                    element.Properties.LimitNextAvailableFromDate = Parse(element.Properties.LimitNextAvailableFromDate, answersDictionary, Regex, allowOptional);
+
+                if (element.Properties.ListItems.Any())
+                {
+                    for (int item = 0; item < element.Properties.ListItems.Count; item++)
+                    {
+                        element.Properties.ListItems[item] = Parse(element.Properties.ListItems[item], answersDictionary, Regex, allowOptional);
+                    }
+                }
+
+                return element;
+            }).ToList();
+
+            return await Task.FromResult(page);
+        }
+
+        public string ParseString(string content, FormAnswers formAnswers)
+        {
+            var answersDictionary = formAnswers.Pages?.SelectMany(x => x.Answers).ToDictionary(x => x.QuestionId, x => x.Response);
+            var updatedContent = content;
+            var matches = Regex.Matches(content);
+
+            foreach (Match match in matches)
+            {
+                var questionId = $"{{{{{match.Value}}}}}";
+
+                try
+                {
+                    var replacedContent = Parse(questionId, answersDictionary, Regex, allowOptional);
+                    updatedContent = updatedContent.Replace(questionId, replacedContent);
+                }
+                catch (Exception)
+                {
+                    updatedContent = updatedContent.Replace(questionId, string.Empty);
+                }
+            }
+
+            return updatedContent;
+        }
+    }
+}

--- a/src/TagParsers/TagParser.cs
+++ b/src/TagParsers/TagParser.cs
@@ -3,196 +3,198 @@ using System.Text.RegularExpressions;
 using form_builder.Extensions;
 using form_builder.TagParsers.Formatters;
 
-namespace form_builder.TagParsers
+namespace form_builder.TagParsers;
+
+public class TagParser
 {
-    public class TagParser
+    private readonly IEnumerable<IFormatter> _formatters;
+    public TagParser(IEnumerable<IFormatter> formatters)
     {
-        private readonly IEnumerable<IFormatter> _formatters;
-        public TagParser(IEnumerable<IFormatter> formatters) => _formatters = formatters;
+        _formatters = formatters;
+    }
 
-        public string Parse(string value, Dictionary<string, object> answersDictionary, Regex regex, bool allowOptional = false)
+    public string Parse(string value, Dictionary<string, object> answersDictionary, Regex regex, bool allowOptional = false)
+    {
+        Match match = regex.Match(value);
+
+        if (match.Success)
         {
-            var match = regex.Match(value);
-            if (match.Success)
+            StringBuilder replacementText = new(value);
+            string[] splitMatch = match.Value.Split(":");
+            string questionId = splitMatch[1];
+
+            string format = string.Empty;
+            if (splitMatch.Length > 2)
+                format = splitMatch[2];
+
+            if (!answersDictionary.ContainsKey(questionId) || string.IsNullOrEmpty((string)answersDictionary[questionId]))
             {
-                var splitMatch = match.Value.Split(":");
-                var questionId = splitMatch[1];
-
-                var format = string.Empty;
-                if (splitMatch.Length > 2)
-                    format = splitMatch[2];
-
-                if (!answersDictionary.ContainsKey(questionId) || string.IsNullOrEmpty((string)answersDictionary[questionId]))
+                if (allowOptional)
                 {
-                    if (allowOptional)
+                    replacementText.Remove(match.Index - 2, match.Length + 4);
+                    replacementText.Insert(match.Index - 2, string.Empty);
+                    return Parse(replacementText.ToString(), answersDictionary, regex, allowOptional);
+                }
+
+                if (!answersDictionary.ContainsKey(questionId))
+                    throw new ApplicationException($"FormAnswerTagParser::Parse, replacement value for questionId {questionId} is not stored within answers, Match value: {match.Value}");
+
+                throw new ApplicationException($"FormAnswerTagParser::Parse, replacement value for questionId {questionId} is null or empty, Match value: {match.Value}");
+            }
+
+            string questionValue = (string)answersDictionary[questionId];
+
+            if (!string.IsNullOrEmpty(format))
+                questionValue = _formatters.Get(format).Parse(questionValue);
+
+            replacementText.Remove(match.Index - 2, match.Length + 4);
+            replacementText.Insert(match.Index - 2, questionValue);
+            return Parse(replacementText.ToString(), answersDictionary, regex, allowOptional);
+        }
+
+        return value;
+    }
+
+
+    public string Parse(string value, Regex regex, string data, Func<string[], string> formatContent, string split = ":")
+    {
+        Match match = regex.Match(value);
+        if (match.Success)
+        {
+            string[] splitMatch = match.Value.Split(split);
+            string[] content = splitMatch.Skip(1).Take(splitMatch.Length - 1).ToArray();
+
+            StringBuilder replacementText = new(value);
+            replacementText.Remove(match.Index - 2, match.Length + 4);
+            replacementText.Insert(match.Index - 2, formatContent(content));
+            return Parse(replacementText.ToString(), regex, data, formatContent);
+        }
+
+        return value;
+    }
+
+    public string Parse(string value, string parseValue, Regex regex)
+    {
+        Match match = regex.Match(value);
+        if (match.Success)
+        {
+            StringBuilder replacementText = new(value);
+            replacementText.Remove(match.Index - 2, match.Length + 4);
+            replacementText.Insert(match.Index - 2, parseValue);
+            return replacementText.ToString();
+        }
+
+        return value;
+    }
+
+    public string Parse(string value, Regex regex)
+    {
+        Match match = regex.Match(value);
+        if (match.Success)
+        {
+            string[] parser = match.Value.Split("::");
+            string parserType = parser[0];
+            string parserValue = string.Empty;
+            if (parser.Length > 1)
+                parserValue = parser[1];
+
+            StringBuilder replacementText = new(value);
+            replacementText.Remove(match.Index - 2, match.Length + 4);
+            switch (parserType)
+            {
+                case "STRONG":
+                    replacementText.Insert(match.Index - 2, $"<strong>{parserValue}</strong>");
+                    break;
+                case "BOLD":
+                    replacementText.Insert(match.Index - 2, $"<b>{parserValue}</b>");
+                    break;
+                case "EMPHASIS":
+                    replacementText.Insert(match.Index - 2, $"<em>{parserValue}</em>");
+                    break;
+                case "ITALIC":
+                    replacementText.Insert(match.Index - 2, $"<i>{parserValue}</i>");
+                    break;
+                case "BREAK":
+                    replacementText.Insert(match.Index - 2, "<br>");
+                    break;
+            }
+
+            return Parse(replacementText.ToString(), regex);
+        }
+
+        return value;
+    }
+
+    public string ParseList(string value, Regex regex, bool noClasses)
+    {
+        Match match = regex.Match(value);
+        if (match.Success)
+        {
+            string[] parser = match.Value.Split("::");
+            string parserType = parser[0];
+            string[] parserValue = parser[1].Split("|");
+            StringBuilder replacementText = new(value);
+            replacementText.Remove(match.Index - 2, match.Length + 4);
+            StringBuilder listHtml = new();
+
+            if (noClasses)
+                listHtml.Append(parserType.Equals("ULIST") ? "<ul>" : "<ol>");
+            else
+                listHtml.Append(parserType.Equals("ULIST") ? "<ul class='govuk-list govuk-list--bullet'>" : "<ol class='govuk-list govuk-list--number'>");
+
+            foreach (string item in parserValue)
+            {
+                listHtml.Append($"<li>{item}</li>");
+            }
+
+            listHtml.Append(parserType.Equals("ULIST") ? "</ul>" : "</ol>");
+            replacementText.Insert(match.Index - 2, listHtml);
+
+            return ParseList(replacementText.ToString(), regex, noClasses);
+        }
+
+        return value;
+    }
+
+    public string ParseDate(string value, Regex regex)
+    {
+        return regex.Replace(value, match =>
+        {
+            string parserValue = match.Value[8..^2];
+            DateTime dateNow = DateTime.Now;
+
+            if (parserValue.StartsWith('+') || parserValue.StartsWith('-'))
+            {
+                if (int.TryParse(parserValue[..^1], out int offset))
+                {
+                    DateTime date = parserValue[^1] switch
                     {
-                        var replacementText = new StringBuilder(value);
-                        replacementText.Remove(match.Index - 2, match.Length + 4);
-                        replacementText.Insert(match.Index - 2, string.Empty);
-                        return Parse(replacementText.ToString(), answersDictionary, regex, allowOptional);
-                    }
+                        'y' => dateNow.AddYears(offset),
+                        'm' => dateNow.AddMonths(offset),
+                        'w' => dateNow.AddDays(offset * 7),
+                        'd' => dateNow.AddDays(offset),
+                        _ => dateNow
+                    };
 
-                    if (!answersDictionary.ContainsKey(questionId))
-                        throw new ApplicationException($"FormAnswerTagParser::Parse, replacement value for questionId {questionId} is not stored within answers, Match value: {match.Value}");
-
-                    throw new ApplicationException($"FormAnswerTagParser::Parse, replacement value for questionId {questionId} is null or empty, Match value: {match.Value}");
+                    return date.ToString("dd MM yyyy");
                 }
-
-                var questionValue = (string)answersDictionary[questionId];
-
-                if (!string.IsNullOrEmpty(format))
-                    questionValue = _formatters.Get(format).Parse(questionValue);
-
-                var replacementText = new StringBuilder(value);
-                replacementText.Remove(match.Index - 2, match.Length + 4);
-                replacementText.Insert(match.Index - 2, questionValue);
-                return Parse(replacementText.ToString(), answersDictionary, regex, allowOptional);
             }
 
-            return value;
-        }
-
-
-        public string Parse(string value, Regex regex, string data, Func<string[], string> formatContent, string split = ":")
-        {
-            var match = regex.Match(value);
-            if (match.Success)
+            DateTime parsed = parserValue.ToLower() switch
             {
-                var splitMatch = match.Value.Split(split);
-                var content = splitMatch.Skip(1).Take(splitMatch.Length - 1).ToArray();
+                "childbirthyear" => dateNow.AddYears(-15),
+                "adultbirthyear" => dateNow.AddYears(-40),
+                "oapbirthyear" => dateNow.AddYears(-70),
+                "nextweek" => dateNow.AddDays(7),
+                "nextmonth" => dateNow.AddMonths(1),
+                "nextyear" => dateNow.AddYears(1),
+                "lastweek" => dateNow.AddDays(-7),
+                "lastmonth" => dateNow.AddMonths(-1),
+                "lastyear" => dateNow.AddYears(-1),
+                _ => dateNow
+            };
 
-                var replacementText = new StringBuilder(value);
-                replacementText.Remove(match.Index - 2, match.Length + 4);
-                replacementText.Insert(match.Index - 2, formatContent(content));
-                return Parse(replacementText.ToString(), regex, data, formatContent);
-            }
-
-            return value;
-        }
-
-        public string Parse(string value, string parseValue, Regex regex)
-        {
-            var match = regex.Match(value);
-            if (match.Success)
-            {
-                var replacementText = new StringBuilder(value);
-                replacementText.Remove(match.Index - 2, match.Length + 4);
-                replacementText.Insert(match.Index - 2, parseValue);
-                return replacementText.ToString();
-            }
-
-            return value;
-        }
-
-        public string Parse(string value, Regex regex)
-        {
-            var match = regex.Match(value);
-            if (match.Success)
-            {
-                var parser = match.Value.Split("::");
-                var parserType = parser[0];
-                var parserValue = string.Empty;
-                if (parser.Length > 1)
-                    parserValue = parser[1];
-
-                var replacementText = new StringBuilder(value);
-                replacementText.Remove(match.Index - 2, match.Length + 4);
-                switch (parserType)
-                {
-                    case "STRONG":
-                        replacementText.Insert(match.Index - 2, $"<strong>{parserValue}</strong>");
-                        break;
-                    case "BOLD":
-                        replacementText.Insert(match.Index - 2, $"<b>{parserValue}</b>");
-                        break;
-                    case "EMPHASIS":
-                        replacementText.Insert(match.Index - 2, $"<em>{parserValue}</em>");
-                        break;
-                    case "ITALIC":
-                        replacementText.Insert(match.Index - 2, $"<i>{parserValue}</i>");
-                        break;
-                    case "BREAK":
-                        replacementText.Insert(match.Index - 2, "<br>");
-                        break;
-                }
-
-                return Parse(replacementText.ToString(), regex);
-            }
-
-            return value;
-        }
-
-        public string ParseList(string value, Regex regex, bool noClasses)
-        {
-            var match = regex.Match(value);
-            if (match.Success)
-            {
-                var parser = match.Value.Split("::");
-                var parserType = parser[0];
-                var parserValue = parser[1].Split("|");
-                var replacementText = new StringBuilder(value);
-                replacementText.Remove(match.Index - 2, match.Length + 4);
-                var listHtml = new StringBuilder();
-
-                if (noClasses)
-                    listHtml.Append(parserType.Equals("ULIST") ? "<ul>" : "<ol>");
-                else
-                    listHtml.Append(parserType.Equals("ULIST") ? "<ul class='govuk-list govuk-list--bullet'>" : "<ol class='govuk-list govuk-list--number'>");
-
-                foreach (var item in parserValue)
-                {
-                    listHtml.Append($"<li>{item}</li>");
-                }
-
-                listHtml.Append(parserType.Equals("ULIST") ? "</ul>" : "</ol>");
-                replacementText.Insert(match.Index - 2, listHtml);
-
-                return ParseList(replacementText.ToString(), regex, noClasses);
-            }
-
-            return value;
-        }
-
-        public string ParseDate(string value, Regex regex)
-        {
-            return regex.Replace(value, match =>
-            {
-                var parserValue = match.Value[8..^2];
-                var dateNow = DateTime.Now;
-
-                if (parserValue.StartsWith('+') || parserValue.StartsWith('-'))
-                {
-                    if (int.TryParse(parserValue[..^1], out var offset))
-                    {
-                        var date = parserValue[^1] switch
-                        {
-                            'y' => dateNow.AddYears(offset),
-                            'm' => dateNow.AddMonths(offset),
-                            'w' => dateNow.AddDays(offset * 7),
-                            'd' => dateNow.AddDays(offset),
-                            _ => dateNow
-                        };
-
-                        return date.ToString("dd MM yyyy");
-                    }
-                }
-
-                var parsed = parserValue.ToLower() switch
-                {
-                    "childbirthyear" => dateNow.AddYears(-15),
-                    "adultbirthyear" => dateNow.AddYears(-40),
-                    "oapbirthyear" => dateNow.AddYears(-70),
-                    "nextweek" => dateNow.AddDays(7),
-                    "nextmonth" => dateNow.AddMonths(1),
-                    "nextyear" => dateNow.AddYears(1),
-                    "lastweek" => dateNow.AddDays(-7),
-                    "lastmonth" => dateNow.AddMonths(-1),
-                    "lastyear" => dateNow.AddYears(-1),
-                    _ => dateNow
-                };
-
-                return parsed.ToString("dd MM yyyy");
-            });
-        }
+            return parsed.ToString("dd MM yyyy");
+        });
     }
 }

--- a/src/TagParsers/TagParser.cs
+++ b/src/TagParsers/TagParser.cs
@@ -10,7 +10,7 @@ namespace form_builder.TagParsers
         private readonly IEnumerable<IFormatter> _formatters;
         public TagParser(IEnumerable<IFormatter> formatters) => _formatters = formatters;
 
-        public string Parse(string value, Dictionary<string, object> answersDictionary, Regex regex)
+        public string Parse(string value, Dictionary<string, object> answersDictionary, Regex regex, bool allowOptional = false)
         {
             var match = regex.Match(value);
             if (match.Success)
@@ -22,21 +22,31 @@ namespace form_builder.TagParsers
                 if (splitMatch.Length > 2)
                     format = splitMatch[2];
 
-                if (!answersDictionary.ContainsKey(questionId))
-                    throw new ApplicationException($"FormAnswerTagParser::Parse, replacement value for questionId {questionId} is not stored within answers, Match value: {match.Value}");
+                if (!answersDictionary.ContainsKey(questionId) || string.IsNullOrEmpty((string)answersDictionary[questionId]))
+                {
+                    if (allowOptional)
+                    {
+                        var replacementText = new StringBuilder(value);
+                        replacementText.Remove(match.Index - 2, match.Length + 4);
+                        replacementText.Insert(match.Index - 2, string.Empty);
+                        return Parse(replacementText.ToString(), answersDictionary, regex, allowOptional);
+                    }
+
+                    if (!answersDictionary.ContainsKey(questionId))
+                        throw new ApplicationException($"FormAnswerTagParser::Parse, replacement value for questionId {questionId} is not stored within answers, Match value: {match.Value}");
+
+                    throw new ApplicationException($"FormAnswerTagParser::Parse, replacement value for questionId {questionId} is null or empty, Match value: {match.Value}");
+                }
 
                 var questionValue = (string)answersDictionary[questionId];
-
-                if (string.IsNullOrEmpty(questionValue))
-                    throw new ApplicationException($"FormAnswerTagParser::Parse, replacement value for questionId {questionId} is null or empty, Match value: {match.Value}");
 
                 if (!string.IsNullOrEmpty(format))
                     questionValue = _formatters.Get(format).Parse(questionValue);
 
-                var replacementText = new StringBuilder(value);
-                replacementText.Remove(match.Index - 2, match.Length + 4);
-                replacementText.Insert(match.Index - 2, questionValue);
-                return Parse(replacementText.ToString(), answersDictionary, regex);
+                var replacementText2 = new StringBuilder(value);
+                replacementText2.Remove(match.Index - 2, match.Length + 4);
+                replacementText2.Insert(match.Index - 2, questionValue);
+                return Parse(replacementText2.ToString(), answersDictionary, regex, allowOptional);
             }
 
             return value;

--- a/src/TagParsers/TagParser.cs
+++ b/src/TagParsers/TagParser.cs
@@ -43,10 +43,10 @@ namespace form_builder.TagParsers
                 if (!string.IsNullOrEmpty(format))
                     questionValue = _formatters.Get(format).Parse(questionValue);
 
-                var replacementText2 = new StringBuilder(value);
-                replacementText2.Remove(match.Index - 2, match.Length + 4);
-                replacementText2.Insert(match.Index - 2, questionValue);
-                return Parse(replacementText2.ToString(), answersDictionary, regex, allowOptional);
+                var replacementText = new StringBuilder(value);
+                replacementText.Remove(match.Index - 2, match.Length + 4);
+                replacementText.Insert(match.Index - 2, questionValue);
+                return Parse(replacementText.ToString(), answersDictionary, regex, allowOptional);
             }
 
             return value;

--- a/src/Utils/Startup/ServiceCollectionExtensions.cs
+++ b/src/Utils/Startup/ServiceCollectionExtensions.cs
@@ -154,6 +154,7 @@ namespace form_builder.Utils.Startup
         public static IServiceCollection AddTagParsers(this IServiceCollection services)
         {
             services.AddTransient<ITagParser, FormAnswerTagParser>();
+            services.AddTransient<ITagParser, FormAnswerOptionalTagParser>();
             services.AddTransient<ITagParser, FormDataTagParser>();
             services.AddTransient<ITagParser, LinkTagParser>();
             services.AddTransient<ITagParser, MailToTagParser>();

--- a/tests/unit-tests/UnitTests/TagParsers/FormAnswerOptionalTagParserTests.cs
+++ b/tests/unit-tests/UnitTests/TagParsers/FormAnswerOptionalTagParserTests.cs
@@ -1,301 +1,858 @@
 using form_builder.Builders;
 using form_builder.Enum;
 using form_builder.Models;
-using form_builder.Models.Elements;
 using form_builder.TagParsers;
 using form_builder.TagParsers.Formatters;
 using Moq;
 using Xunit;
 
-namespace form_builder_tests.UnitTests.TagParsers;
-
-public class FormAnswerOptionalTagParserTests
+namespace form_builder_tests.UnitTests.TagParsers
 {
-    private readonly Mock<IFormatter> _mockFormatter = new();
-    private readonly Mock<IFormatter> _mockFormatterTwo = new();
-
-    private readonly FormAnswerOptionalTagParser _tagParser;
-
-    public FormAnswerOptionalTagParserTests()
+    public class FormAnswerOptionalTagParserTests
     {
-        _mockFormatter.Setup(x => x.FormatterName).Returns("testformatter");
-        _mockFormatter.Setup(x => x.Parse(It.IsAny<string>()))
-            .Returns("FAKE-FORMATTED-VALUE");
+        private readonly Mock<IFormatter> _mockFormatter = new();
+        private readonly Mock<IFormatter> _mockFormatterTwo = new();
 
-        _mockFormatterTwo.Setup(x => x.FormatterName).Returns("anothertestformatter");
-        _mockFormatterTwo.Setup(x => x.Parse(It.IsAny<string>()))
-            .Returns("ANOTHER-FORMATTER");
+        private readonly FormAnswerOptionalTagParser _tagParser;
 
-        IEnumerable<IFormatter> formatters = new List<IFormatter>
+        public FormAnswerOptionalTagParserTests()
         {
-            _mockFormatter.Object,
-            _mockFormatterTwo.Object
-        };
-
-        _tagParser = new FormAnswerOptionalTagParser(formatters);
-    }
-
-    [Theory]
-    [InlineData("{{QUESTIONOPT:firstname}}")]
-    [InlineData("{{QUESTIONOPT:ref}}")]
-    public void Regex_ShouldReturnTrue_Result(string value) => Assert.True(_tagParser.Regex.Match(value).Success);
-
-    [Theory]
-    [InlineData("{{QUESTION:firstname}}")]
-    [InlineData("{{QUESTIONOPT}}")]
-    [InlineData("{QUESTIONOPT:firstname}")]
-    [InlineData("{{QUESTIONOPT:firstname}")]
-    [InlineData("{{DIFFERENTTAG:firstname}}")]
-    public void Regex_ShouldReturnFalse_Result(string value) => Assert.False(_tagParser.Regex.Match(value).Success);
-
-    [Fact]
-    public async Task Parse_ShouldReturnInitialValue_WhenNoValues()
-    {
-        Element element = new ElementBuilder()
-            .WithType(EElementType.P)
-            .WithPropertyText("no values")
-            .Build();
-
-        Page page = new PageBuilder()
-            .WithElement(element)
-            .Build();
-
-        Page result = await _tagParser.Parse(page, new FormAnswers());
-
-        Assert.Equal("no values", result.Elements.First().Properties.Text);
-    }
-
-    [Fact]
-    public async Task Parse_ShouldReturnUpdatedValue_WhenReplacingSingleValue()
-    {
-        string expected = "value test";
-
-        Element element = new ElementBuilder()
-            .WithType(EElementType.P)
-            .WithPropertyText("value {{QUESTIONOPT:q1}}")
-            .Build();
-
-        Page page = new PageBuilder().WithElement(element).Build();
-
-        var formAnswers = new FormAnswers
-        {
-            Pages = new List<PageAnswers>
+            _mockFormatter.Setup(mock => mock.FormatterName).Returns("testformatter");
+            _mockFormatter.Setup(mock => mock.Parse(It.IsAny<string>())).Returns("FAKE-FORMATTED-VALUE");
+            _mockFormatterTwo.Setup(mock => mock.FormatterName).Returns("anothertestformatter");
+            _mockFormatterTwo.Setup(mock => mock.Parse(It.IsAny<string>())).Returns("ANOTHER-FORMATTER");
+            IEnumerable<IFormatter> formatters = new List<IFormatter>
             {
-                new()
+                _mockFormatter.Object,
+                _mockFormatterTwo.Object
+            };
+
+            _tagParser = new FormAnswerOptionalTagParser(formatters);
+        }
+
+        [Theory]
+        [InlineData("{{QUESTIONOPT:firstname}}")]
+        [InlineData("{{QUESTIONOPT:ref}}")]
+        public void Regex_ShouldReturnTrue_Result(string value)
+        {
+            Assert.True(_tagParser.Regex.Match(value).Success);
+        }
+
+        [Theory]
+        [InlineData("{{QUESTIONOPTT:firstname}}")]
+        [InlineData("{{UESTIONOPT:firstname}}")]
+        [InlineData("{QUESTIONOPT:firstname}")]
+        [InlineData("{{QUESTIONOPT:firstname}")]
+        [InlineData("{{TAG:firstname}")]
+        [InlineData("{{DIFFERENTTAG:firstname}}")]
+        public void Regex_ShouldReturnFalse_Result(string value)
+        {
+            Assert.False(_tagParser.Regex.Match(value).Success);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnInitialValue_WhenNoValuesAre_To_BeReplaced()
+        {
+            var element = new ElementBuilder()
+                .WithType(EElementType.P)
+                .WithPropertyText("this has no values to be replaced")
+                .Build();
+
+            var ulElement = new ElementBuilder()
+                .WithType(EElementType.UL)
+                .WithListItems(["this item has no values to be replaced"])
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithElement(ulElement)
+                .Build();
+
+            var formAnswers = new FormAnswers();
+
+            var result = await _tagParser.Parse(page, formAnswers);
+
+            Assert.Equal(element.Properties.Text, result.Elements.FirstOrDefault().Properties.Text);
+            Assert.Equal(ulElement.Properties.ListItems.First(), result.Elements.First(element => element.Type.Equals(EElementType.UL)).Properties.ListItems.First());
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnInitialValue_When_NoTag_MatchesRegex()
+        {
+            var element = new ElementBuilder()
+                .WithType(EElementType.P)
+                .WithPropertyText("this value {{TAG:firstname}} should be replaced with name question")
+                .Build();
+
+            var ulElement = new ElementBuilder()
+                .WithType(EElementType.UL)
+                .WithListItems(["this value {{TAG:firstname}} should be replaced with name question"])
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithElement(ulElement)
+                .Build();
+
+            var formAnswers = new FormAnswers();
+
+            var result = await _tagParser.Parse(page, formAnswers);
+
+            Assert.Equal(element.Properties.Text, result.Elements.FirstOrDefault().Properties.Text);
+            Assert.Equal(ulElement.Properties.ListItems.First(), result.Elements.First(element => element.Type.Equals(EElementType.UL)).Properties.ListItems.First());
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValue_WhenReplacingSingleValue()
+        {
+            var expectedString = "this value testfirstname should be replaced with name question";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value {{QUESTIONOPT:firstname}} should be replaced with name question")
+               .Build();
+
+            var ulElement = new ElementBuilder()
+                .WithType(EElementType.UL)
+                .WithListItems(["this value {{QUESTIONOPT:firstname}} should be replaced with name question"])
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithElement(ulElement)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
                 {
-                    Answers = new List<Answers>
+                    new()
                     {
-                        new()
+                        Answers = new List<Answers>
                         {
-                            QuestionId = "q1",
-                            Response = "test"
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "testfirstname"
+                            }
                         }
                     }
                 }
-            }
-        };
+            };
 
-        Page result = await _tagParser.Parse(page, formAnswers);
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+            Assert.Equal(expectedString, result.Elements.First(element => element.Type.Equals(EElementType.UL)).Properties.ListItems.First());
+        }
 
-        Assert.Equal(expected, result.Elements.First().Properties.Text);
-    }
-
-    [Fact]
-    public async Task Parse_ShouldRemoveTag_WhenValueMissing_Optional()
-    {
-        Element element = new ElementBuilder()
-            .WithType(EElementType.P)
-            .WithPropertyText("value {{QUESTIONOPT:q1}}")
-            .Build();
-
-        Page page = new PageBuilder().WithElement(element).Build();
-
-        var formAnswers = new FormAnswers
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValueForHint_WhenReplacingSingleValue()
         {
-            Pages = new List<PageAnswers>()
-        };
+            var expectedString = "this value testfirstname should be replaced with name question";
 
-        Page result = await _tagParser.Parse(page, formAnswers);
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithHint("this value {{QUESTIONOPT:firstname}} should be replaced with name question")
+                .Build();
 
-        Assert.Equal("value ", result.Elements.First().Properties.Text);
-    }
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
 
-    [Fact]
-    public async Task Parse_ShouldUpdate_All_PropertyTypes()
-    {
-        Element element = new ElementBuilder()
-            .WithType(EElementType.Booking)
-            .WithPropertyText("{{QUESTIONOPT:q1}}")
-            .WithHint("{{QUESTIONOPT:q1}}")
-            .WithLimitNextAvailableFromDate("{{QUESTIONOPT:q1}}")
-            .WithListItems(new List<string> { "{{QUESTIONOPT:q1}}" })
-            .Build();
-
-        Page page = new PageBuilder()
-            .WithLeadingParagraph("{{QUESTIONOPT:q1}}")
-            .WithElement(element)
-            .Build();
-
-        var formAnswers = new FormAnswers
-        {
-            Pages = new List<PageAnswers>
+            var formAnswers = new FormAnswers
             {
-                new()
+                Pages = new List<PageAnswers>
                 {
-                    Answers = new List<Answers>
+                    new()
                     {
-                        new()
+                        Answers = new List<Answers>
                         {
-                            QuestionId = "q1",
-                            Response = "value"
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "testfirstname"
+                            }
                         }
                     }
                 }
-            }
-        };
+            };
 
-        Page result = await _tagParser.Parse(page, formAnswers);
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Hint);
+        }
 
-        IElement resultElement = result.Elements.First();
-
-        Assert.Equal("value", result.LeadingParagraph);
-        Assert.Equal("value", resultElement.Properties.Text);
-        Assert.Equal("value", resultElement.Properties.Hint);
-        Assert.Equal("value", resultElement.Properties.LimitNextAvailableFromDate);
-        Assert.Equal("value", resultElement.Properties.ListItems.First());
-    }
-
-    [Fact]
-    public async Task Parse_ShouldCallFormatter_WhenProvided()
-    {
-        Element element = new ElementBuilder()
-            .WithType(EElementType.P)
-            .WithPropertyText("{{QUESTIONOPT:q1:testformatter}}")
-            .Build();
-
-        Page page = new PageBuilder().WithElement(element).Build();
-
-        var formAnswers = new FormAnswers
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValueForLimitNextAvailableFromDate_WhenReplacingSingleValue()
         {
-            Pages = new List<PageAnswers>
+            var expectedString = "01-01-2022";
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Booking)
+                .WithLimitNextAvailableFromDate("{{QUESTIONOPT:date}}")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
             {
-                new()
+                Pages = new List<PageAnswers>
                 {
-                    Answers = new List<Answers>
+                    new()
                     {
-                        new()
+                        Answers = new List<Answers>
                         {
-                            QuestionId = "q1",
-                            Response = "value"
+                            new()
+                            {
+                                QuestionId = "date",
+                                Response = "01-01-2022"
+                            }
                         }
                     }
                 }
-            }
-        };
+            };
 
-        Page result = await _tagParser.Parse(page, formAnswers);
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.LimitNextAvailableFromDate);
+        }
 
-        Assert.Equal("FAKE-FORMATTED-VALUE", result.Elements.First().Properties.Text);
-        _mockFormatter.Verify(x => x.Parse(It.IsAny<string>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task Parse_ShouldCall_Multiple_Formatters()
-    {
-        Element element = new ElementBuilder()
-            .WithType(EElementType.P)
-            .WithPropertyText("{{QUESTIONOPT:q1:testformatter}} {{QUESTIONOPT:q1:anothertestformatter}}")
-            .Build();
-
-        Page page = new PageBuilder().WithElement(element).Build();
-
-        var formAnswers = new FormAnswers
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValue_WhenReplacingMultipleValues()
         {
-            Pages = new List<PageAnswers>
+            var expectedString = "this value testfirstname should be replaced with firstname and this testlastname with lastname";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value {{QUESTIONOPT:firstname}} should be replaced with firstname and this {{QUESTIONOPT:lastname}} with lastname")
+               .Build();
+
+            var ulElement = new ElementBuilder()
+                .WithType(EElementType.UL)
+                .WithListItems(["this value {{QUESTIONOPT:firstname}} should be replaced with firstname and this {{QUESTIONOPT:lastname}} with lastname"])
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithElement(ulElement)
+                .Build();
+
+            var formAnswers = new FormAnswers
             {
-                new()
+                Pages = new List<PageAnswers>
                 {
-                    Answers = new List<Answers>
+                    new()
                     {
-                        new()
+                        Answers = new List<Answers>
                         {
-                            QuestionId = "q1",
-                            Response = "value"
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "testfirstname"
+                            },
+                            new()
+                            {
+                                QuestionId = "lastname",
+                                Response = "testlastname"
+                            }
                         }
                     }
                 }
-            }
-        };
+            };
 
-        Page result = await _tagParser.Parse(page, formAnswers);
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+            Assert.Equal(expectedString, result.Elements.First(element => element.Type.Equals(EElementType.UL)).Properties.ListItems.First());
+        }
 
-        Assert.Equal("FAKE-FORMATTED-VALUE ANOTHER-FORMATTER", result.Elements.First().Properties.Text);
-        _mockFormatter.Verify(x => x.Parse(It.IsAny<string>()), Times.Once);
-        _mockFormatterTwo.Verify(x => x.Parse(It.IsAny<string>()), Times.Once);
-    }
-
-    [Fact]
-    public void ParseString_ShouldReturnUpdatedValue()
-    {
-        string text = "value {{QUESTIONOPT:q1}}";
-
-        var formAnswers = new FormAnswers
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValueForHint_WhenReplacingMultipleValues()
         {
-            Pages = new List<PageAnswers>
+            var expectedString = "this value testfirstname should be replaced with firstname and this testlastname with lastname";
+
+            var element = new ElementBuilder()
+                .WithType(EElementType.Textbox)
+                .WithHint("this value {{QUESTIONOPT:firstname}} should be replaced with firstname and this {{QUESTIONOPT:lastname}} with lastname")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
             {
-                new()
+                Pages = new List<PageAnswers>
                 {
-                    Answers = new List<Answers>
+                    new()
                     {
-                        new()
+                        Answers = new List<Answers>
                         {
-                            QuestionId = "q1",
-                            Response = "test"
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "testfirstname"
+                            },
+                            new()
+                            {
+                                QuestionId = "lastname",
+                                Response = "testlastname"
+                            }
                         }
                     }
                 }
-            }
-        };
+            };
 
-        string result = _tagParser.ParseString(text, formAnswers);
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Hint);
+        }
 
-        Assert.Equal("value test", result);
-    }
-
-    [Fact]
-    public void ParseString_ShouldReturnEmpty_WhenMissing()
-    {
-        string result = _tagParser.ParseString("value {{QUESTIONOPT:q1}}", new FormAnswers());
-
-        Assert.Equal("value ", result);
-    }
-
-    [Fact]
-    public void ParseString_ShouldCallFormatter()
-    {
-        string text = "{{QUESTIONOPT:q1:testformatter}}";
-
-        var formAnswers = new FormAnswers
+        [Fact]
+        public async Task Parse_ShouldCallFormatter_WhenProvided()
         {
-            Pages = new List<PageAnswers>
+            var expectedString = "this value should be formatted: FAKE-FORMATTED-VALUE";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value should be formatted: {{QUESTIONOPT:firstname:testformatter}}")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
             {
-                new()
+                Pages = new List<PageAnswers>
                 {
-                    Answers = new List<Answers>
+                    new()
                     {
-                        new()
+                        Answers = new List<Answers>
                         {
-                            QuestionId = "q1",
-                            Response = "value"
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "value"
+                            }
                         }
                     }
                 }
-            }
-        };
+            };
 
-        string result = _tagParser.ParseString(text, formAnswers);
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+            _mockFormatter.Verify(mock => mock.Parse(It.IsAny<string>()), Times.Once);
+        }
 
-        Assert.Equal("FAKE-FORMATTED-VALUE", result);
-        _mockFormatter.Verify(x => x.Parse(It.IsAny<string>()), Times.Once);
+        [Fact]
+        public async Task Parse_ShouldCall_Multiple_Formatters_WhenProvided()
+        {
+            var expectedString = "this value should be formatted: FAKE-FORMATTED-VALUE ANOTHER-FORMATTER";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value should be formatted: {{QUESTIONOPT:firstname:testformatter}} {{QUESTIONOPT:firstname:anothertestformatter}}")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "value"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+            _mockFormatter.Verify(mock => mock.Parse(It.IsAny<string>()), Times.Once);
+            _mockFormatterTwo.Verify(mock => mock.Parse(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldCall_Same_Formatter_MultipleTimes()
+        {
+            var expectedString = "this value should be formatted: FAKE-FORMATTED-VALUE FAKE-FORMATTED-VALUE";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value should be formatted: {{QUESTIONOPT:firstname:testformatter}} {{QUESTIONOPT:firstname:testformatter}}")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "value"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+            _mockFormatter.Verify(mock => mock.Parse(It.IsAny<string>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnEmpty_WhenValueMissing()
+        {
+            var expectedString = "this value  should be replaced with name question";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value {{QUESTIONOPT:firstname}} should be replaced with name question")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>()
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnEmpty_WhenValueIsNull()
+        {
+            var expectedString = "this value  should be replaced with name question";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value {{QUESTIONOPT:firstname}} should be replaced with name question")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = null
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnEmpty_WhenValueIsEmptyString()
+        {
+            var expectedString = "this value  should be replaced with name question";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value {{QUESTIONOPT:firstname}} should be replaced with name question")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = ""
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnInitialValueForLeadingParagraph_When_NoTag_MatchesRegex()
+        {
+            var element = new ElementBuilder()
+                .WithType(EElementType.P)
+                .WithPropertyText("this value {{TAG}} should be replaced with value")
+                .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithLeadingParagraph("this value {{TAG}} should be replaced with value")
+                .Build();
+
+            var formAnswers = new FormAnswers();
+
+            var result = await _tagParser.Parse(page, formAnswers);
+
+            Assert.Equal(element.Properties.Text, result.Elements.FirstOrDefault().Properties.Text);
+            Assert.Equal(page.LeadingParagraph, result.LeadingParagraph);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValueForLeadingParagraph_WhenReplacingSingleValue()
+        {
+            var expectedString = "this value firstname should be replaced with firstname";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value {{QUESTIONOPT:firstname}} should be replaced with firstname")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithLeadingParagraph("this value {{QUESTIONOPT:firstname}} should be replaced with firstname")
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "firstname"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = await _tagParser.Parse(page, formAnswers);
+
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+            Assert.Equal(expectedString, result.LeadingParagraph);
+        }
+
+        [Fact]
+        public async Task Parse_ShouldReturnUpdatedValueForLeadingParagraph_WhenReplacingMultipleValues()
+        {
+            var expectedString = "this value firstname should be replaced with firstname and this lastname with lastname";
+
+            var element = new ElementBuilder()
+               .WithType(EElementType.P)
+               .WithPropertyText("this value {{QUESTIONOPT:firstname}} should be replaced with firstname and this {{QUESTIONOPT:lastname}} with lastname")
+               .Build();
+
+            var page = new PageBuilder()
+                .WithElement(element)
+                .WithLeadingParagraph("this value {{QUESTIONOPT:firstname}} should be replaced with firstname and this {{QUESTIONOPT:lastname}} with lastname")
+                .Build();
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "firstname"
+                            },
+                            new()
+                            {
+                                QuestionId = "lastname",
+                                Response = "lastname"
+                            }
+                        }
+                    }
+                }
+            };            
+            
+            var result = await _tagParser.Parse(page, formAnswers);
+
+            Assert.Equal(expectedString, result.Elements.FirstOrDefault().Properties.Text);
+            Assert.Equal(expectedString, result.LeadingParagraph);
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturnInitialValue_WhenNoValuesAre_To_BeReplaced()
+        {
+            var text = "this has no values to be replaced";
+            var formAnswers = new FormAnswers();
+
+            var result = _tagParser.ParseString(text, formAnswers);
+
+            Assert.Equal(text, result);
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturnInitialValue_When_NoTag_MatchesRegex()
+        {
+            var text = "this value {{TAG:firstname}} should be replaced with name question";
+            var formAnswers = new FormAnswers();
+
+            var result = _tagParser.ParseString(text, formAnswers);
+
+            Assert.Equal(text, result);
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturnUpdatedValue_WhenReplacingSingleValue()
+        {
+            var expectedString = "this value testfirstname should be replaced with name question";
+            var text = "this value {{QUESTIONOPT:firstname}} should be replaced with name question";
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "testfirstname"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = _tagParser.ParseString(text, formAnswers);
+            Assert.Equal(expectedString, result);
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturnUpdatedValue_WhenReplacingMultipleValues()
+        {
+            var expectedString = "this value testfirstname should be replaced with firstname and this testlastname with lastname";
+            var text = "this value {{QUESTIONOPT:firstname}} should be replaced with firstname and this {{QUESTIONOPT:lastname}} with lastname";
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "testfirstname"
+                            },
+                            new()
+                            {
+                                QuestionId = "lastname",
+                                Response = "testlastname"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = _tagParser.ParseString(text, formAnswers);
+            Assert.Equal(expectedString, result);
+        }
+
+        [Fact]
+        public void ParseString_ShouldCallFormatter_WhenProvided()
+        {
+            var expectedString = "this value should be formatted: FAKE-FORMATTED-VALUE";
+            var text = "this value should be formatted: {{QUESTIONOPT:firstname:testformatter}}";
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "value"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = _tagParser.ParseString(text, formAnswers);
+            Assert.Equal(expectedString, result);
+            _mockFormatter.Verify(mock => mock.Parse(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void ParseString_ShouldCall_Multiple_Formatters_WhenProvided()
+        {
+            var expectedString = "this value should be formatted: FAKE-FORMATTED-VALUE ANOTHER-FORMATTER";
+            var text = "this value should be formatted: {{QUESTIONOPT:firstname:testformatter}} {{QUESTIONOPT:firstname:anothertestformatter}}";
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "value"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = _tagParser.ParseString(text, formAnswers);
+            Assert.Equal(expectedString, result);
+            _mockFormatter.Verify(mock => mock.Parse(It.IsAny<string>()), Times.Once);
+            _mockFormatterTwo.Verify(mock => mock.Parse(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public void ParseString_ShouldCall_Same_Formatter_MultipleTimes()
+        {
+            var expectedString = "this value should be formatted: FAKE-FORMATTED-VALUE FAKE-FORMATTED-VALUE";
+            var text = "this value should be formatted: {{QUESTIONOPT:firstname:testformatter}} {{QUESTIONOPT:firstname:testformatter}}";
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = "value"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = _tagParser.ParseString(text, formAnswers);
+            Assert.Equal(expectedString, result);
+            _mockFormatter.Verify(mock => mock.Parse(It.IsAny<string>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturnEmpty_WhenValueMissing()
+        {
+            var expectedString = "this value  should be replaced with name question";
+            var text = "this value {{QUESTIONOPT:firstname}} should be replaced with name question";
+            var formAnswers = new FormAnswers();
+
+            var result = _tagParser.ParseString(text, formAnswers);
+            Assert.Equal(expectedString, result);
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturnEmpty_WhenValueIsNull()
+        {
+            var expectedString = "this value  should be replaced with name question";
+            var text = "this value {{QUESTIONOPT:firstname}} should be replaced with name question";
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = null
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = _tagParser.ParseString(text, formAnswers);
+            Assert.Equal(expectedString, result);
+        }
+
+        [Fact]
+        public void ParseString_ShouldReturnEmpty_WhenValueIsEmptyString()
+        {
+            var expectedString = "this value  should be replaced with name question";
+            var text = "this value {{QUESTIONOPT:firstname}} should be replaced with name question";
+
+            var formAnswers = new FormAnswers
+            {
+                Pages = new List<PageAnswers>
+                {
+                    new()
+                    {
+                        Answers = new List<Answers>
+                        {
+                            new()
+                            {
+                                QuestionId = "firstname",
+                                Response = ""
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = _tagParser.ParseString(text, formAnswers);
+            Assert.Equal(expectedString, result);
+        }
     }
 }

--- a/tests/unit-tests/UnitTests/TagParsers/FormAnswerOptionalTagParserTests.cs
+++ b/tests/unit-tests/UnitTests/TagParsers/FormAnswerOptionalTagParserTests.cs
@@ -1,0 +1,301 @@
+using form_builder.Builders;
+using form_builder.Enum;
+using form_builder.Models;
+using form_builder.Models.Elements;
+using form_builder.TagParsers;
+using form_builder.TagParsers.Formatters;
+using Moq;
+using Xunit;
+
+namespace form_builder_tests.UnitTests.TagParsers;
+
+public class FormAnswerOptionalTagParserTests
+{
+    private readonly Mock<IFormatter> _mockFormatter = new();
+    private readonly Mock<IFormatter> _mockFormatterTwo = new();
+
+    private readonly FormAnswerOptionalTagParser _tagParser;
+
+    public FormAnswerOptionalTagParserTests()
+    {
+        _mockFormatter.Setup(x => x.FormatterName).Returns("testformatter");
+        _mockFormatter.Setup(x => x.Parse(It.IsAny<string>()))
+            .Returns("FAKE-FORMATTED-VALUE");
+
+        _mockFormatterTwo.Setup(x => x.FormatterName).Returns("anothertestformatter");
+        _mockFormatterTwo.Setup(x => x.Parse(It.IsAny<string>()))
+            .Returns("ANOTHER-FORMATTER");
+
+        IEnumerable<IFormatter> formatters = new List<IFormatter>
+        {
+            _mockFormatter.Object,
+            _mockFormatterTwo.Object
+        };
+
+        _tagParser = new FormAnswerOptionalTagParser(formatters);
+    }
+
+    [Theory]
+    [InlineData("{{QUESTIONOPT:firstname}}")]
+    [InlineData("{{QUESTIONOPT:ref}}")]
+    public void Regex_ShouldReturnTrue_Result(string value) => Assert.True(_tagParser.Regex.Match(value).Success);
+
+    [Theory]
+    [InlineData("{{QUESTION:firstname}}")]
+    [InlineData("{{QUESTIONOPT}}")]
+    [InlineData("{QUESTIONOPT:firstname}")]
+    [InlineData("{{QUESTIONOPT:firstname}")]
+    [InlineData("{{DIFFERENTTAG:firstname}}")]
+    public void Regex_ShouldReturnFalse_Result(string value) => Assert.False(_tagParser.Regex.Match(value).Success);
+
+    [Fact]
+    public async Task Parse_ShouldReturnInitialValue_WhenNoValues()
+    {
+        Element element = new ElementBuilder()
+            .WithType(EElementType.P)
+            .WithPropertyText("no values")
+            .Build();
+
+        Page page = new PageBuilder()
+            .WithElement(element)
+            .Build();
+
+        Page result = await _tagParser.Parse(page, new FormAnswers());
+
+        Assert.Equal("no values", result.Elements.First().Properties.Text);
+    }
+
+    [Fact]
+    public async Task Parse_ShouldReturnUpdatedValue_WhenReplacingSingleValue()
+    {
+        string expected = "value test";
+
+        Element element = new ElementBuilder()
+            .WithType(EElementType.P)
+            .WithPropertyText("value {{QUESTIONOPT:q1}}")
+            .Build();
+
+        Page page = new PageBuilder().WithElement(element).Build();
+
+        var formAnswers = new FormAnswers
+        {
+            Pages = new List<PageAnswers>
+            {
+                new()
+                {
+                    Answers = new List<Answers>
+                    {
+                        new()
+                        {
+                            QuestionId = "q1",
+                            Response = "test"
+                        }
+                    }
+                }
+            }
+        };
+
+        Page result = await _tagParser.Parse(page, formAnswers);
+
+        Assert.Equal(expected, result.Elements.First().Properties.Text);
+    }
+
+    [Fact]
+    public async Task Parse_ShouldRemoveTag_WhenValueMissing_Optional()
+    {
+        Element element = new ElementBuilder()
+            .WithType(EElementType.P)
+            .WithPropertyText("value {{QUESTIONOPT:q1}}")
+            .Build();
+
+        Page page = new PageBuilder().WithElement(element).Build();
+
+        var formAnswers = new FormAnswers
+        {
+            Pages = new List<PageAnswers>() // ✅ prevents null
+        };
+
+        Page result = await _tagParser.Parse(page, formAnswers);
+
+        Assert.Equal("value ", result.Elements.First().Properties.Text);
+    }
+
+    [Fact]
+    public async Task Parse_ShouldUpdate_All_PropertyTypes()
+    {
+        Element element = new ElementBuilder()
+            .WithType(EElementType.Booking)
+            .WithPropertyText("{{QUESTIONOPT:q1}}")
+            .WithHint("{{QUESTIONOPT:q1}}")
+            .WithLimitNextAvailableFromDate("{{QUESTIONOPT:q1}}")
+            .WithListItems(new List<string> { "{{QUESTIONOPT:q1}}" })
+            .Build();
+
+        Page page = new PageBuilder()
+            .WithLeadingParagraph("{{QUESTIONOPT:q1}}")
+            .WithElement(element)
+            .Build();
+
+        var formAnswers = new FormAnswers
+        {
+            Pages = new List<PageAnswers>
+            {
+                new()
+                {
+                    Answers = new List<Answers>
+                    {
+                        new()
+                        {
+                            QuestionId = "q1",
+                            Response = "value"
+                        }
+                    }
+                }
+            }
+        };
+
+        Page result = await _tagParser.Parse(page, formAnswers);
+
+        IElement resultElement = result.Elements.First();
+
+        Assert.Equal("value", result.LeadingParagraph);
+        Assert.Equal("value", resultElement.Properties.Text);
+        Assert.Equal("value", resultElement.Properties.Hint);
+        Assert.Equal("value", resultElement.Properties.LimitNextAvailableFromDate);
+        Assert.Equal("value", resultElement.Properties.ListItems.First());
+    }
+
+    [Fact]
+    public async Task Parse_ShouldCallFormatter_WhenProvided()
+    {
+        Element element = new ElementBuilder()
+            .WithType(EElementType.P)
+            .WithPropertyText("{{QUESTIONOPT:q1:testformatter}}")
+            .Build();
+
+        Page page = new PageBuilder().WithElement(element).Build();
+
+        var formAnswers = new FormAnswers
+        {
+            Pages = new List<PageAnswers>
+            {
+                new()
+                {
+                    Answers = new List<Answers>
+                    {
+                        new()
+                        {
+                            QuestionId = "q1",
+                            Response = "value"
+                        }
+                    }
+                }
+            }
+        };
+
+        Page result = await _tagParser.Parse(page, formAnswers);
+
+        Assert.Equal("FAKE-FORMATTED-VALUE", result.Elements.First().Properties.Text);
+        _mockFormatter.Verify(x => x.Parse(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Parse_ShouldCall_Multiple_Formatters()
+    {
+        Element element = new ElementBuilder()
+            .WithType(EElementType.P)
+            .WithPropertyText("{{QUESTIONOPT:q1:testformatter}} {{QUESTIONOPT:q1:anothertestformatter}}")
+            .Build();
+
+        Page page = new PageBuilder().WithElement(element).Build();
+
+        var formAnswers = new FormAnswers
+        {
+            Pages = new List<PageAnswers>
+            {
+                new()
+                {
+                    Answers = new List<Answers>
+                    {
+                        new()
+                        {
+                            QuestionId = "q1",
+                            Response = "value"
+                        }
+                    }
+                }
+            }
+        };
+
+        Page result = await _tagParser.Parse(page, formAnswers);
+
+        Assert.Equal("FAKE-FORMATTED-VALUE ANOTHER-FORMATTER", result.Elements.First().Properties.Text);
+        _mockFormatter.Verify(x => x.Parse(It.IsAny<string>()), Times.Once);
+        _mockFormatterTwo.Verify(x => x.Parse(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void ParseString_ShouldReturnUpdatedValue()
+    {
+        string text = "value {{QUESTIONOPT:q1}}";
+
+        var formAnswers = new FormAnswers
+        {
+            Pages = new List<PageAnswers>
+            {
+                new()
+                {
+                    Answers = new List<Answers>
+                    {
+                        new()
+                        {
+                            QuestionId = "q1",
+                            Response = "test"
+                        }
+                    }
+                }
+            }
+        };
+
+        string result = _tagParser.ParseString(text, formAnswers);
+
+        Assert.Equal("value test", result);
+    }
+
+    [Fact]
+    public void ParseString_ShouldReturnEmpty_WhenMissing()
+    {
+        string result = _tagParser.ParseString("value {{QUESTIONOPT:q1}}", new FormAnswers());
+
+        Assert.Equal("value ", result);
+    }
+
+    [Fact]
+    public void ParseString_ShouldCallFormatter()
+    {
+        string text = "{{QUESTIONOPT:q1:testformatter}}";
+
+        var formAnswers = new FormAnswers
+        {
+            Pages = new List<PageAnswers>
+            {
+                new()
+                {
+                    Answers = new List<Answers>
+                    {
+                        new()
+                        {
+                            QuestionId = "q1",
+                            Response = "value"
+                        }
+                    }
+                }
+            }
+        };
+
+        string result = _tagParser.ParseString(text, formAnswers);
+
+        Assert.Equal("FAKE-FORMATTED-VALUE", result);
+        _mockFormatter.Verify(x => x.Parse(It.IsAny<string>()), Times.Once);
+    }
+}

--- a/tests/unit-tests/UnitTests/TagParsers/FormAnswerOptionalTagParserTests.cs
+++ b/tests/unit-tests/UnitTests/TagParsers/FormAnswerOptionalTagParserTests.cs
@@ -112,7 +112,7 @@ public class FormAnswerOptionalTagParserTests
 
         var formAnswers = new FormAnswers
         {
-            Pages = new List<PageAnswers>() // ✅ prevents null
+            Pages = new List<PageAnswers>()
         };
 
         Page result = await _tagParser.Parse(page, formAnswers);


### PR DESCRIPTION
### Description
Add new {{QUESTIONOPT:questionId}} tag parser, allows optional questions to be referenced elsewhere in the form if they have a value or not.

{{QUESTION}} tag parser still works as before with a value required to be used.


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary